### PR TITLE
Adding basic Kafka producer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/RedHatInsights/ccx-notification-service
 go 1.14
 
 require (
-	github.com/BurntSushi/toml v0.3.1
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/RedHatInsights/insights-operator-utils v1.8.1
-	github.com/deckarep/golang-set v1.7.1
+	github.com/Shopify/sarama v1.27.1
+	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/rs/zerolog v1.21.0
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package producer contains functions that can be used to produce (that is
+// send) messages to properly configured Kafka broker.
+package producer
+
+import (
+	"encoding/json"
+	"github.com/RedHatInsights/ccx-notification-service/conf"
+
+	"github.com/Shopify/sarama"
+	"github.com/rs/zerolog/log"
+)
+
+//TODO: MOVE ALL THESE DEFINITIONS TO TYPE PACKAGE
+//TODO: CONFIRM IF THESE TYPE NEED TO BE EXPORTED OR NOT
+
+// Producer represents any producer
+type Producer interface {
+	Close() error
+}
+
+// KafkaProducer is an implementation of Producer interface
+type KafkaProducer struct {
+	Configuration conf.KafkaConfiguration
+	Producer      sarama.SyncProducer
+}
+
+// EventMetadata represents the metadata of the sent payload.
+// It is expected to be an empty struct as of today
+type EventMetadata map[string]interface{}
+
+// EventPayload is a JSON string containing all the data required
+// by the app to compose the various messages (Email, webhook, ...).
+type EventPayload map[string]interface{}
+
+// Event is a structure containing the payload and its metadata.
+type Event struct {
+	Metadata EventMetadata `json:"metadata"`
+	Payload  EventPayload  `json:"payload"`
+}
+
+// NotificationContext represents the extra information
+// that is common to all the events that are sent in
+// this message as a JSON string (escaped)
+type NotificationContext map[string]interface{}
+
+// NotificationMessage represents content of messages
+// sent to the notification platform topic in Kafka.
+type NotificationMessage struct {
+	Bundle      string              `json:"bundle"`
+	Application string              `json:"application"`
+	EventType   string              `json:"event_type"`
+	Timestamp   string              `json:"timestamp"`
+	AccountID   string              `json:"account_id"`
+	Events      []Event             `json:"events"`
+	Context     NotificationContext `json:"context"`
+}
+
+// New constructs new implementation of Producer interface
+func New(brokerCfg conf.KafkaConfiguration) (*KafkaProducer, error) {
+	producer, err := sarama.NewSyncProducer([]string{brokerCfg.Address}, nil)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to create a new Kafka producer")
+		return nil, err
+	}
+
+	return &KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:      producer,
+	}, nil
+}
+
+// ProduceMessage produces message to selected topic. That function returns
+// partition ID and offset of new message or an error value in case of any
+// problem on broker side.
+func (producer *KafkaProducer) ProduceMessage(msg NotificationMessage) (int32, int64, error) {
+	jsonBytes, err := json.Marshal(msg)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	producerMsg := &sarama.ProducerMessage{
+		Topic: producer.Configuration.Topic,
+		Value: sarama.ByteEncoder(jsonBytes),
+	}
+
+	partition, offset, err := producer.Producer.SendMessage(producerMsg)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to produce message to Kafka")
+	} else {
+		log.Info().Msgf("message sent to partition %d at offset %d\n", partition, offset)
+	}
+	return partition, offset, err
+}
+
+// Close allow the Sarama producer to be gracefully closed
+func (producer *KafkaProducer) Close() error {
+	if err := producer.Producer.Close(); err != nil {
+		log.Error().Err(err).Msg("unable to close Kafka producer")
+		return err
+	}
+
+	return nil
+}

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -88,7 +88,7 @@ func New(brokerCfg conf.KafkaConfiguration) (*KafkaProducer, error) {
 // ProduceMessage produces message to selected topic. That function returns
 // partition ID and offset of new message or an error value in case of any
 // problem on broker side.
-func (producer *KafkaProducer) ProduceMessage(msg NotificationMessage) (int32, int64, error) {
+func (producer *KafkaProducer) ProduceMessage(msg NotificationMessage) (partitionID int32, offset int64, err error) {
 	jsonBytes, err := json.Marshal(msg)
 	if err != nil {
 		return 0, 0, err
@@ -99,13 +99,13 @@ func (producer *KafkaProducer) ProduceMessage(msg NotificationMessage) (int32, i
 		Value: sarama.ByteEncoder(jsonBytes),
 	}
 
-	partition, offset, err := producer.Producer.SendMessage(producerMsg)
+	partitionID, offset, err = producer.Producer.SendMessage(producerMsg)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to produce message to Kafka")
 	} else {
-		log.Info().Msgf("message sent to partition %d at offset %d\n", partition, offset)
+		log.Info().Msgf("message sent to partition %d at offset %d\n", partitionID, offset)
 	}
-	return partition, offset, err
+	return
 }
 
 // Close allow the Sarama producer to be gracefully closed

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package producer
+
+import (
+	"errors"
+	"github.com/RedHatInsights/ccx-notification-service/conf"
+	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
+	"github.com/Shopify/sarama"
+	"github.com/Shopify/sarama/mocks"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+var (
+	brokerCfg = conf.KafkaConfiguration{
+		Address: "localhost:9092",
+		Topic:   "test_haberdasher",
+		Timeout: time.Duration(30*10 ^ 9),
+	}
+	// Base UNIX time plus approximately 50 years (not long before year 2020).
+	testTimestamp = time.Unix(50*365*24*60*60, 0)
+)
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+}
+
+// Test Producer creation with a non accessible Kafka broker
+func TestNewProducerBadBroker(t *testing.T) {
+	const expectedErr = "kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"
+
+	_, err := New(brokerCfg)
+	assert.EqualError(t, err, expectedErr)
+}
+
+// TestProducerClose makes sure it's possible to close the connection
+func TestProducerClose(t *testing.T) {
+	mockProducer := mocks.NewSyncProducer(t, nil)
+	prod := KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:      mockProducer,
+	}
+
+	err := prod.Close()
+	assert.NoError(t, err, "failed to close Kafka producer")
+}
+
+func TestProducerNew(t *testing.T) {
+	mockBroker := sarama.NewMockBroker(t, 0)
+	defer mockBroker.Close()
+
+	handlerMap := map[string]sarama.MockResponse{
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(mockBroker.Addr(), mockBroker.BrokerID()).
+			SetLeader(brokerCfg.Topic, 0, mockBroker.BrokerID()),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(brokerCfg.Topic, 0, -1, 0).
+			SetOffset(brokerCfg.Topic, 0, -2, 0),
+		"FetchRequest": sarama.NewMockFetchResponse(t, 1),
+		"FindCoordinatorRequest": sarama.NewMockFindCoordinatorResponse(t).
+			SetCoordinator(sarama.CoordinatorGroup, "", mockBroker),
+		"OffsetFetchRequest": sarama.NewMockOffsetFetchResponse(t).
+			SetOffset("", brokerCfg.Topic, 0, 0, "", sarama.ErrNoError),
+	}
+	mockBroker.SetHandlerByMap(handlerMap)
+
+	prod, err := New(
+		conf.KafkaConfiguration{
+			Address: mockBroker.Addr(),
+			Topic:   brokerCfg.Topic,
+			Timeout: brokerCfg.Timeout,
+		})
+	helpers.FailOnError(t, err)
+
+	helpers.FailOnError(t, prod.Close())
+}
+
+func TestProducerSendEmptyNotificationMessage(t *testing.T) {
+	mockProducer := mocks.NewSyncProducer(t, nil)
+	mockProducer.ExpectSendMessageAndSucceed()
+
+	kafkaProducer := KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:      mockProducer,
+	}
+
+	_, _, err := kafkaProducer.ProduceMessage(NotificationMessage{})
+	assert.NoError(t, err, "Couldn't produce message with given broker configuration")
+	helpers.FailOnError(t, kafkaProducer.Close())
+}
+
+func TestProducerSendNotificationMessageNoEvents(t *testing.T) {
+	mockProducer := mocks.NewSyncProducer(t, nil)
+	mockProducer.ExpectSendMessageAndSucceed()
+
+	kafkaProducer := KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:      mockProducer,
+	}
+
+	msg := NotificationMessage{
+		Bundle:      "openshift",
+		Application: "advisor",
+		EventType:   "critical",
+		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
+		AccountID:   "000000",
+		Events:      nil,
+		Context:     nil,
+	}
+
+	_, _, err := kafkaProducer.ProduceMessage(msg)
+	assert.NoError(t, err, "Couldn't produce message with given broker configuration")
+	helpers.FailOnError(t, kafkaProducer.Close())
+}
+
+func TestProducerSendNotificationMessageSingleEvent(t *testing.T) {
+	mockProducer := mocks.NewSyncProducer(t, nil)
+	mockProducer.ExpectSendMessageAndSucceed()
+
+	kafkaProducer := KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:      mockProducer,
+	}
+
+	events := []Event{
+		{
+			Metadata: nil,
+			Payload: map[string]interface{}{
+				"rule_id":       "a unique ID",
+				"what happened": "something baaad happened",
+				"error_code":    3,
+			},
+		},
+	}
+
+	msg := NotificationMessage{
+		Bundle:      "openshift",
+		Application: "advisor",
+		EventType:   "critical",
+		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
+		AccountID:   "000001",
+		Events:      events,
+		Context:     nil,
+	}
+
+	_, _, err := kafkaProducer.ProduceMessage(msg)
+	assert.NoError(t, err, "Couldn't produce message with given broker configuration")
+	helpers.FailOnError(t, kafkaProducer.Close())
+}
+
+func TestProducerSendNotificationMessageMultipleEvents(t *testing.T) {
+	mockProducer := mocks.NewSyncProducer(t, nil)
+	mockProducer.ExpectSendMessageAndSucceed()
+
+	kafkaProducer := KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:      mockProducer,
+	}
+
+	events := []Event{
+		{
+			Metadata: nil,
+			Payload: map[string]interface{}{
+				"rule_id":       "a unique ID",
+				"what happened": "something baaad happened",
+				"error_code":    3,
+			},
+		},
+		{
+			Metadata: nil,
+			Payload: map[string]interface{}{
+				"rule_id":          "another unique ID",
+				"what happened":    "something less terrible happened",
+				"error_code":       4,
+				"more_random_data": "why not...",
+			},
+		},
+	}
+
+	msg := NotificationMessage{
+		Bundle:      "openshift",
+		Application: "advisor",
+		EventType:   "critical",
+		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
+		AccountID:   "000001",
+		Events:      events,
+		Context:     nil,
+	}
+
+	_, _, err := kafkaProducer.ProduceMessage(msg)
+	assert.NoError(t, err, "Couldn't produce message with given broker configuration")
+	helpers.FailOnError(t, kafkaProducer.Close())
+}
+
+func TestProducerSendNotificationMessageEventContentNotValidJson(t *testing.T) {
+	const jsonParseErrorMessage = "json: unsupported type: chan int" //TODO: Using a mocked function for json.Marshall that throws an error is cooler than this =)
+
+	mockProducer := mocks.NewSyncProducer(t, nil)
+	mockProducer.ExpectSendMessageAndFail(errors.New(jsonParseErrorMessage))
+
+	kafkaProducer := KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:      mockProducer,
+	}
+
+	events := []Event{
+		{
+			Metadata: nil,
+			Payload: map[string]interface{}{
+				"rule_id":       "a unique ID",
+				"what happened": "something baaad happened",
+				"error_code":    3,
+			},
+		},
+		{
+			Metadata: map[string]interface{}{
+				"foo": make(chan int), //A value that cannot be represented in JSON
+			},
+			Payload: map[string]interface{}{
+				"rule_id":       "a unique ID",
+				"what happened": "something baaad happened",
+				"error_code":    3,
+			},
+		},
+	}
+
+	msg := NotificationMessage{
+		Bundle:      "openshift",
+		Application: "advisor",
+		EventType:   "critical",
+		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
+		AccountID:   "000001",
+		Events:      events,
+		Context:     nil,
+	}
+
+	_, _, err := kafkaProducer.ProduceMessage(msg)
+
+	assert.EqualError(t, err, jsonParseErrorMessage)
+}
+
+/* This sends to real kafka broker, just to make sure =)
+func TestProducerSend(t *testing.T) {
+
+	producer, err := sarama.NewSyncProducer([]string{brokerCfg.Address}, nil)
+	kafkaProducer := KafkaProducer{
+		Configuration: brokerCfg,
+		Producer:  producer   ,
+	}
+
+	events := []Event{
+		{
+			Metadata: nil,
+			Payload: map[string]interface{}{
+				"rule_id":       "a unique ID",
+				"what happened": "something baaad happened",
+				"error_code":    3,
+			},
+		},
+		{
+			Metadata: nil,
+			Payload: map[string]interface{}{
+				"rule_id":       "another unique ID",
+				"what happened": "something less terrible happened",
+				"error_code":    4,
+				"more_random_data": "why not...",
+			},
+		},
+	}
+
+	msg := NotificationMessage{
+		Bundle:      "openshift",
+		Application: "advisor",
+		EventType:   "critical",
+		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
+		AccountID:   "000001",
+		Events:      events,
+		Context:     nil,
+	}
+
+	_, _, err = kafkaProducer.ProduceMessage(msg)
+	assert.NoError(t, err, "Couldn't produce message with given broker configuration")
+	helpers.FailOnError(t, kafkaProducer.Close())
+}
+*/


### PR DESCRIPTION
# Description

basic kafka producer whose broker and production topic can be configured using the tool file.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

UTs + local kafka instance test 

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
