### PR TITLE
Notification service v1

### DIFF
--- a/PoC-differ/config.toml
+++ b/PoC-differ/config.toml
@@ -22,5 +22,5 @@ content_server = "" #provide in deployment env or as secret
 content_endpoint = "" #provide in deployment env or as secret
 
 [notification]
-cluster_url = "" #provide in deployment env or as secret
-cluster_insights_tab = "#insights"
+cluster_details_uri = "" #provide in deployment env or as secret
+rule_details_uri = "" #provide in deployment env or as secret

--- a/PoC-differ/config_ci.toml
+++ b/PoC-differ/config_ci.toml
@@ -3,6 +3,16 @@ debug = true
 log_level = ""
 
 [kafka_broker]
-address = "platform-mq-ci-kafka-bootstrap.platform-mq-ci.svc:9092"
-topic = "platform.notifications.ingress"
+address = ""
+topic = ""
 timeout = "20s"
+
+[storage]
+db_driver = "postgres"
+pg_username = ""
+pg_password = ""
+pg_host = ""
+pg_port =
+pg_db_name = ""
+pg_params = ""
+log_sql_queries = true

--- a/PoC-differ/config_ci.toml
+++ b/PoC-differ/config_ci.toml
@@ -16,3 +16,7 @@ pg_port =
 pg_db_name = ""
 pg_params = ""
 log_sql_queries = true
+
+[notification]
+cluster_url = ""
+cluster_insights_tab = "#insights"

--- a/PoC-differ/config_prod.toml
+++ b/PoC-differ/config_prod.toml
@@ -3,6 +3,16 @@ debug = true
 log_level = ""
 
 [kafka_broker]
-address = "platform-mq-kafka-bootstrap.platform-mq-prod.svc.cluster.local:9092"
-topic = "platform.notifications.ingress"
+address = ""
+topic = ""
 timeout = "20s"
+
+[storage]
+db_driver = "postgres"
+pg_username = ""
+pg_password = ""
+pg_host = ""
+pg_port =
+pg_db_name = ""
+pg_params = ""
+log_sql_queries = true

--- a/PoC-differ/config_prod.toml
+++ b/PoC-differ/config_prod.toml
@@ -16,3 +16,7 @@ pg_port =
 pg_db_name = ""
 pg_params = ""
 log_sql_queries = true
+
+[notification]
+cluster_url = ""
+cluster_insights_tab = "#insights"

--- a/PoC-differ/config_stage.toml
+++ b/PoC-differ/config_stage.toml
@@ -3,6 +3,16 @@ debug = true
 log_level = ""
 
 [kafka_broker]
-address = "platform-mq-kafka-bootstrap.platform-mq-stage.svc.cluster.local:9092"
-topic = "platform.notifications.ingress"
+address = ""
+topic = ""
 timeout = "20s"
+
+[storage]
+db_driver = "postgres"
+pg_username = ""
+pg_password = ""
+pg_host = ""
+pg_port =
+pg_db_name = ""
+pg_params = ""
+log_sql_queries = true

--- a/PoC-differ/config_stage.toml
+++ b/PoC-differ/config_stage.toml
@@ -16,3 +16,7 @@ pg_port =
 pg_db_name = ""
 pg_params = ""
 log_sql_queries = true
+
+[notification]
+cluster_url = ""
+cluster_insights_tab = "#insights"

--- a/PoC-differ/content.go
+++ b/PoC-differ/content.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -30,92 +29,6 @@ import (
 	"github.com/go-yaml/yaml"
 	"github.com/rs/zerolog/log"
 )
-
-// readFilesIntoByteArrayPointers reads the contents of the specified files
-// in the base directory and saves them via the specified byte slice pointers.
-func readFilesIntoFileContent(baseDir string, filelist []string) (map[string][]byte, error) {
-	var filesContent = map[string][]byte{}
-	for _, name := range filelist {
-		log.Info().Msgf("Parsing %s/%s", baseDir, name)
-		var err error
-		rawBytes, err := ioutil.ReadFile(filepath.Clean(path.Join(baseDir, name)))
-		if err != nil {
-			filesContent[name] = nil
-			log.Error().Err(err)
-		} else {
-			filesContent[name] = rawBytes
-		}
-	}
-
-	return filesContent, nil
-}
-
-// createErrorContents takes a mapping of files into contents and perform
-// some checks about it
-func createErrorContents(contentRead map[string][]byte) (*types.RuleErrorKeyContent, error) {
-	errorContent := types.RuleErrorKeyContent{}
-
-	if contentRead["generic.md"] == nil {
-		return nil, &types.MissingMandatoryFile{FileName: "generic.md"}
-	}
-
-	errorContent.Generic = string(contentRead["generic.md"])
-
-	if contentRead["reason.md"] == nil {
-		errorContent.Reason = ""
-		errorContent.HasReason = false
-	} else {
-		errorContent.Reason = string(contentRead["reason.md"])
-		errorContent.HasReason = true
-	}
-
-	if contentRead["metadata.yaml"] == nil {
-		return nil, &types.MissingMandatoryFile{FileName: "metadata.yaml"}
-	}
-
-	if err := yaml.Unmarshal(contentRead["metadata.yaml"], &errorContent.Metadata); err != nil {
-		return nil, err
-	}
-
-	return &errorContent, nil
-}
-
-// parseErrorContents function reads the contents of the specified directory
-// and parses all subdirectories as error key contents.  This implicitly checks
-// that the directory exists, so it is not necessary to ever check that
-// elsewhere.
-func parseErrorContents(ruleDirPath string) (map[string]types.RuleErrorKeyContent, error) {
-	entries, err := ioutil.ReadDir(ruleDirPath)
-	if err != nil {
-		return nil, err
-	}
-
-	errorContents := map[string]types.RuleErrorKeyContent{}
-
-	for _, e := range entries {
-		if e.IsDir() {
-			name := e.Name()
-			contentFiles := []string{
-				"generic.md",
-				"reason.md",
-				"metadata.yaml",
-			}
-
-			readContents, err := readFilesIntoFileContent(path.Join(ruleDirPath, name), contentFiles)
-			if err != nil {
-				return errorContents, err
-			}
-
-			errContents, err := createErrorContents(readContents)
-			if err != nil {
-				return errorContents, err
-			}
-			errorContents[name] = *errContents
-		}
-	}
-
-	return errorContents, nil
-}
 
 // parseGlobalContentConfig reads the configuration file used to store
 // metadata used by all rule content, such as impact dictionary.
@@ -128,23 +41,6 @@ func parseGlobalContentConfig(configPath string) (types.GlobalRuleConfig, error)
 	conf := types.GlobalRuleConfig{}
 	err = yaml.Unmarshal(configBytes, &conf)
 	return conf, err
-}
-
-// checkRequiredFields function checks if all the required fields in the
-// RuleContent are ok and valid. At the moment only checks for Reason field is
-// being performed.
-func checkRequiredFields(rule types.RuleContent) error {
-	if rule.HasReason {
-		return nil
-	}
-
-	for _, errorKeyContent := range rule.ErrorKeys {
-		if !errorKeyContent.HasReason {
-			return &types.MissingMandatoryFile{FileName: "reason.md"}
-		}
-	}
-
-	return nil
 }
 
 // fetchAllRulesContent fetches the parsed rules provided by the content-service

--- a/PoC-differ/differ.go
+++ b/PoC-differ/differ.go
@@ -183,7 +183,7 @@ func processReportsByCluster(ruleContent map[string]types.RuleContent, impacts t
 			continue
 		}
 
-		notificationMsg := generateNotificationMessage(notificationConfig.ClusterDetailsUri, defaultNotificationAccountID, notificationType, string(cluster.ClusterName))
+		notificationMsg := generateNotificationMessage(notificationConfig.ClusterDetailsURI, defaultNotificationAccountID, notificationType, string(cluster.ClusterName))
 
 		for i, r := range deserialized.Reports {
 			ruleName := moduleToRuleName(string(r.Module))
@@ -201,7 +201,7 @@ func processReportsByCluster(ruleContent map[string]types.RuleContent, impacts t
 				Msg("Report")
 			if totalRisk >= 3 {
 				log.Warn().Int(totalRiskAttribute, totalRisk).Msg("Report with high impact detected")
-				appendEventToNotificationMessage(notificationConfig.RuleDetailsUri, &notificationMsg, ruleName, totalRisk, time.Time(reportedAt).UTC().Format(time.RFC3339Nano))
+				appendEventToNotificationMessage(notificationConfig.RuleDetailsURI, &notificationMsg, ruleName, totalRisk, time.Time(reportedAt).UTC().Format(time.RFC3339Nano))
 			}
 		}
 
@@ -265,7 +265,7 @@ func processAllReportsFromCurrentWeek(ruleContent map[string]types.RuleContent, 
 				Msg("Report")
 			if totalRisk >= 3 {
 				log.Warn().Int(totalRiskAttribute, totalRisk).Msg("Report with high impact detected")
-				appendEventToNotificationMessage(notificationConfig.RuleDetailsUri, &notificationMsg, ruleName, totalRisk, time.Time(reportedAt).UTC().Format(time.RFC3339Nano))
+				appendEventToNotificationMessage(notificationConfig.RuleDetailsURI, &notificationMsg, ruleName, totalRisk, time.Time(reportedAt).UTC().Format(time.RFC3339Nano))
 			}
 		}
 
@@ -452,6 +452,9 @@ func main() {
 	log.Info().Msg("Getting rule content from content service")
 
 	ruleContent, err := fetchAllRulesContent(conf.GetDependenciesConfiguration(config))
+	if err != nil {
+		os.Exit(ExitStatusFetchContentError)
+	}
 
 	waitForEnter()
 

--- a/PoC-differ/differ.go
+++ b/PoC-differ/differ.go
@@ -76,8 +76,9 @@ const (
 const (
 	notificationBundleName        = "openshift"
 	notificationApplicationName   = "advisor"
-	defaultNotificationAccountID  = "6089719"              //TODO: Replace this with getting acount ID for given customer
-	defaultNotificationClusterURL = "ci.cloud.redhat.com/" //TODO: Get correct URL from a working OCM UI and set it in config file (or env, better)
+	defaultNotificationAccountID  = "6089719"          //TODO: Replace this with getting account ID for affected cluster
+	defaultNotificationClusterURL = "localhost:12345/" //TODO: Get correct URL from a working OCM UI and set it in config file (or env, better)
+	defaultInsightsTab            = "#insights"        //TODO: Use value from configq
 )
 
 // Constants for notification event expected fields
@@ -206,12 +207,14 @@ func processClusters(ruleContent map[string]types.RuleContent, impacts types.Glo
 				}
 			}
 
-			_, _, err = notifier.ProduceMessage(notificationMsg)
-			if err != nil {
-				log.Error().
-					Str(errorStr, err.Error()).
-					Msg("Couldn't produce kafka event.")
-				os.Exit(ExitStatusKafkaProducerError)
+			if len(notificationMsg.Events) > 0 {
+				_, _, err = notifier.ProduceMessage(notificationMsg)
+				if err != nil {
+					log.Error().
+						Str(errorStr, err.Error()).
+						Msg("Couldn't produce kafka event.")
+					os.Exit(ExitStatusKafkaProducerError)
+				}
 			}
 		}
 	}
@@ -278,7 +281,7 @@ func appendEventToNotificationMessage(notification *types.NotificationMessage, r
 	//TODO: Discuss actual payload content
 	payload := types.EventPayload{
 		notificationPayloadRuleDescription: ruleName,
-		notificationPayloadRuleURL:         defaultNotificationClusterURL + ruleName,
+		notificationPayloadRuleURL:         defaultNotificationClusterURL + ruleName + defaultInsightsTab,
 		notificationPayloadTotalRisk:       string(totalRisk),
 		notificationPayloadPublishDate:     publishDate,
 	}

--- a/PoC-differ/differ.go
+++ b/PoC-differ/differ.go
@@ -180,7 +180,7 @@ func processClusters(ruleContent map[string]types.RuleContent, impacts types.Glo
 				Int("impact", impact).
 				Int(totalRiskAttribute, totalRisk).
 				Msg("Report")
-			if totalRisk >= 2 {
+			if totalRisk >= 3 {
 				log.Warn().Int(totalRiskAttribute, totalRisk).Msg("Report with high impact detected")
 				// TODO: Decide actual content of notification message's payload.
 				notification := generateNotificationMessage(ruleName, totalRisk, string(cluster.OrgID), types.InstantNotif)

--- a/PoC-differ/differ.go
+++ b/PoC-differ/differ.go
@@ -76,7 +76,7 @@ const (
 const (
 	notificationBundleName        = "openshift"
 	notificationApplicationName   = "advisor"
-	defaultNotificationAccountID  = "6089719" //TODO: Remove this
+	defaultNotificationAccountID  = "6089719"              //TODO: Replace this with getting acount ID for given customer
 	defaultNotificationClusterURL = "ci.cloud.redhat.com/" //TODO: Get correct URL from a working OCM UI and set it in config file (or env, better)
 )
 
@@ -88,11 +88,13 @@ const (
 	notificationPayloadTotalRisk       = "total_risk"
 	notificationPayloadPublishDate     = "publish_date"
 )
+
 // Constants for notification context expected fields
 const (
 	notificationContextDisplayName = "display_name"
 	notificationContextHostURL     = "host_url"
 )
+
 // showVersion function displays version information.
 func showVersion() {
 	fmt.Println(versionMessage)
@@ -202,8 +204,8 @@ func processClusters(ruleContent map[string]types.RuleContent, impacts types.Glo
 					Msg("Report")
 				if totalRisk >= 3 {
 					log.Warn().Int(totalRiskAttribute, totalRisk).Msg("Report with high impact detected")
-					//TODO: Time must be in the report
-					reportedAt := time.Now().Add(-2*time.Hour).UTC().Format(time.RFC3339Nano)
+					//TODO: Actual time must be in the report
+					reportedAt := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano)
 					appendEventToNotificationMessage(&notificationMsg, ruleName, totalRisk, reportedAt)
 				}
 			}
@@ -219,7 +221,6 @@ func processClusters(ruleContent map[string]types.RuleContent, impacts types.Glo
 	}
 	err := notifier.Close()
 	if err != nil {
-		// TODO: Can this be handled somehow?
 		log.Error().
 			Str(errorStr, err.Error()).
 			Msg("Couldn't close Kafka connection.")
@@ -252,8 +253,8 @@ func generateNotificationMessage(accountID string, eventType types.EventType, cl
 	//TODO: Discuss actual payload content
 	events := []types.Event{}
 	context := types.NotificationContext{
-		notificationContextDisplayName : clusterID,
-		notificationContextHostURL     : defaultNotificationClusterURL + clusterID,
+		notificationContextDisplayName: clusterID,
+		notificationContextHostURL:     defaultNotificationClusterURL + clusterID,
 	}
 
 	notification = types.NotificationMessage{
@@ -277,19 +278,19 @@ func toJsonEscapedString(i interface{}) string {
 	return s
 }
 
-func appendEventToNotificationMessage(notification *types.NotificationMessage, ruleName string, totalRisk int, publishDate string) () {
+func appendEventToNotificationMessage(notification *types.NotificationMessage, ruleName string, totalRisk int, publishDate string) {
 	//TODO: Discuss actual payload content
 	payload := types.EventPayload{
-		notificationPayloadRuleDescription : ruleName,
-		notificationPayloadRuleURL         : defaultNotificationClusterURL + ruleName,
-		notificationPayloadTotalRisk       : string(totalRisk),
-		notificationPayloadPublishDate     : publishDate,
+		notificationPayloadRuleDescription: ruleName,
+		notificationPayloadRuleURL:         defaultNotificationClusterURL + ruleName,
+		notificationPayloadTotalRisk:       string(totalRisk),
+		notificationPayloadPublishDate:     publishDate,
 	}
 	event := types.Event{
-			//The insights Notifications backend expects this field to be an empty object in the received JSON
-			Metadata: types.EventMetadata{},
-			//The insights Notifications backend expects to receive the payload as a string with all its fields as escaped strings
-			Payload: toJsonEscapedString(payload),
+		//The insights Notifications backend expects this field to be an empty object in the received JSON
+		Metadata: types.EventMetadata{},
+		//The insights Notifications backend expects to receive the payload as a string with all its fields as escaped strings
+		Payload: toJsonEscapedString(payload),
 	}
 	notification.Events = append(notification.Events, event)
 }

--- a/PoC-differ/differ.go
+++ b/PoC-differ/differ.go
@@ -73,8 +73,8 @@ const (
 
 // Notification-related constants
 const (
-	defaultNotificationBundleName      = "Openshift"
-	defaultNotificationApplicationName = "Advisor"
+	defaultNotificationBundleName      = "openshift"
+	defaultNotificationApplicationName = "advisor"
 )
 
 // showVersion function displays version information.

--- a/conf/config.go
+++ b/conf/config.go
@@ -61,10 +61,11 @@ import (
 // ConfigStruct is a structure holding the whole notification service
 // configuration
 type ConfigStruct struct {
-	Logging      LoggingConfiguration      `mapstructure:"logging" toml:"logging"`
-	Storage      StorageConfiguration      `mapstructure:"storage" toml:"storage"`
-	Kafka        KafkaConfiguration        `mapstructure:"kafka_broker" toml:"kafka_broker"`
-	Dependencies DependenciesConfiguration `mapstructure:"dependencies" toml:"dependencies"`
+	Logging       LoggingConfiguration       `mapstructure:"logging" toml:"logging"`
+	Storage       StorageConfiguration       `mapstructure:"storage" toml:"storage"`
+	Kafka         KafkaConfiguration         `mapstructure:"kafka_broker" toml:"kafka_broker"`
+	Dependencies  DependenciesConfiguration  `mapstructure:"dependencies" toml:"dependencies"`
+	Notifications NotificationsConfiguration `mapstructure:"notifications" toml:"notifications"`
 }
 
 // LoggingConfiguration represents configuration for logging in general
@@ -104,8 +105,14 @@ type DependenciesConfiguration struct {
 // KafkaConfiguration represents configuration of Kafka brokers and topics
 type KafkaConfiguration struct {
 	Address string        `mapstructure:"address" toml:"address"`
-	Topic   string        `mapstructure:"topic" toml:"topic"`
+	Topic   string        `mapstructure:"topic"   toml:"topic"`
 	Timeout time.Duration `mapstructure:"timeout" toml:"timeout"`
+}
+
+// NotificationsConfiguration represents the configuration specific to the content of notifications
+type NotificationsConfiguration struct {
+	ClusterDetailsURI string `mapstructure:"cluster_details_uri" toml:"cluster_details_uri"`
+	RuleDetailsURI    string `mapstructure:"rule_details_uri"    toml:"rule_details_uri"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in
@@ -168,4 +175,9 @@ func GetKafkaBrokerConfiguration(config ConfigStruct) KafkaConfiguration {
 // GetDependenciesConfiguration returns dependencies configuration
 func GetDependenciesConfiguration(config ConfigStruct) DependenciesConfiguration {
 	return config.Dependencies
+}
+
+// GetNotificationsConfiguration returns configuration related with notification content
+func GetNotificationsConfiguration(config ConfigStruct) NotificationsConfiguration {
+	return config.Notifications
 }

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -61,7 +61,9 @@ func New(brokerCfg conf.KafkaConfiguration) (*KafkaProducer, error) {
 // problem on broker side.
 func (producer *KafkaProducer) ProduceMessage(msg types.NotificationMessage) (partitionID int32, offset int64, err error) {
 	jsonBytes, err := json.Marshal(msg)
+
 	if err != nil {
+		log.Error().Err(err).Msg("Couldn't turn notification message into valid JSON")
 		return 0, 0, err
 	}
 

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -124,7 +124,7 @@ func TestProducerSendNotificationMessageNoEvents(t *testing.T) {
 		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   "000000",
 		Events:      nil,
-		Context:     nil,
+		Context:     "{}",
 	}
 
 	_, _, err := kafkaProducer.ProduceMessage(msg)
@@ -143,12 +143,8 @@ func TestProducerSendNotificationMessageSingleEvent(t *testing.T) {
 
 	events := []types.Event{
 		{
-			Metadata: nil,
-			Payload: map[string]interface{}{
-				"rule_id":       "a unique ID",
-				"what happened": "something baaad happened",
-				"error_code":    3,
-			},
+			Metadata: types.EventMetadata{},
+			Payload:  "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\"}",
 		},
 	}
 
@@ -159,7 +155,7 @@ func TestProducerSendNotificationMessageSingleEvent(t *testing.T) {
 		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   "000001",
 		Events:      events,
-		Context:     nil,
+		Context:     "{}",
 	}
 
 	_, _, err := kafkaProducer.ProduceMessage(msg)
@@ -178,21 +174,12 @@ func TestProducerSendNotificationMessageMultipleEvents(t *testing.T) {
 
 	events := []types.Event{
 		{
-			Metadata: nil,
-			Payload: map[string]interface{}{
-				"rule_id":       "a unique ID",
-				"what happened": "something baaad happened",
-				"error_code":    3,
-			},
+			Metadata: types.EventMetadata{},
+			Payload:  "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\"}",
 		},
 		{
-			Metadata: nil,
-			Payload: map[string]interface{}{
-				"rule_id":          "another unique ID",
-				"what happened":    "something less terrible happened",
-				"error_code":       4,
-				"more_random_data": "why not...",
-			},
+			Metadata: types.EventMetadata{},
+			Payload:  "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\", \"more_random_data\": \"why not...\"}",
 		},
 	}
 
@@ -203,7 +190,7 @@ func TestProducerSendNotificationMessageMultipleEvents(t *testing.T) {
 		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   "000001",
 		Events:      events,
-		Context:     nil,
+		Context:     "{}",
 	}
 
 	_, _, err := kafkaProducer.ProduceMessage(msg)
@@ -224,22 +211,14 @@ func TestProducerSendNotificationMessageEventContentNotValidJson(t *testing.T) {
 
 	events := []types.Event{
 		{
-			Metadata: nil,
-			Payload: map[string]interface{}{
-				"rule_id":       "a unique ID",
-				"what happened": "something baaad happened",
-				"error_code":    3,
-			},
+			Metadata: types.EventMetadata{},
+			Payload:  "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\"}",
 		},
 		{
 			Metadata: map[string]interface{}{
 				"foo": make(chan int), //A value that cannot be represented in JSON
 			},
-			Payload: map[string]interface{}{
-				"rule_id":       "a unique ID",
-				"what happened": "something baaad happened",
-				"error_code":    3,
-			},
+			Payload: "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\", \"more_random_data\": \"why not...\"}",
 		},
 	}
 
@@ -250,7 +229,7 @@ func TestProducerSendNotificationMessageEventContentNotValidJson(t *testing.T) {
 		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   "000001",
 		Events:      events,
-		Context:     nil,
+		Context:     "{}",
 	}
 
 	_, _, err := kafkaProducer.ProduceMessage(msg)

--- a/types/types.go
+++ b/types/types.go
@@ -139,8 +139,8 @@ const (
 
 // Event types string representation
 const (
-	eventTypeInstant = "Instant notification"
-	eventTypeWeekly  = "Weekly digest"
+	eventTypeInstant = "new-recommendation"
+	eventTypeWeekly  = "weekly-digest"
 )
 
 // String function returns string representation of given event type

--- a/types/types.go
+++ b/types/types.go
@@ -122,10 +122,13 @@ type ReportItem struct {
 	ErrorKey ErrorKey `json:"key"`
 }
 
+// Impacts represents the impacts parsed from the global config file
+type Impacts map[string]int
+
 // GlobalRuleConfig represents the file that contains
 // metadata globally applicable to any/all rule content.
 type GlobalRuleConfig struct {
-	Impact map[string]int `yaml:"impact" json:"impact"`
+	Impact Impacts `yaml:"impact" json:"impact"`
 }
 
 // EventType represents the allowed event types in notification messages

--- a/types/types.go
+++ b/types/types.go
@@ -148,25 +148,18 @@ func (e EventType) String() string {
 	return [...]string{eventTypeInstant, eventTypeWeekly}[e]
 }
 
-// Constants for notification context's expected fields
-const (
-	DisplayName = "display_name"
-	HostURL     = "host_url"
-)
-
-
 // EventMetadata represents the metadata of the sent payload.
 // It is expected to be an empty struct as of today
 type EventMetadata map[string]interface{}
 
 // EventPayload is a JSON string containing all the data required
 // by the app to compose the various messages (Email, webhook, ...).
-type EventPayload map[string]interface{}
+type EventPayload map[string]string
 
 // Event is a structure containing the payload and its metadata.
 type Event struct {
 	Metadata EventMetadata `json:"metadata"`
-	Payload  EventPayload  `json:"payload"`
+	Payload  string        `json:"payload"`
 }
 
 // NotificationContext represents the extra information
@@ -177,12 +170,11 @@ type NotificationContext map[string]interface{}
 // NotificationMessage represents content of messages
 // sent to the notification platform topic in Kafka.
 type NotificationMessage struct {
-	Bundle      string              `json:"bundle"`
-	Application string              `json:"application"`
-	EventType   string              `json:"event_type"`
-	Timestamp   string              `json:"timestamp"`
-	AccountID   string              `json:"account_id"`
-	Events      []Event             `json:"events"`
-	Context     NotificationContext `json:"context"`
+	Bundle      string  `json:"bundle"`
+	Application string  `json:"application"`
+	EventType   string  `json:"event_type"`
+	Timestamp   string  `json:"timestamp"`
+	AccountID   string  `json:"account_id"`
+	Events      []Event `json:"events"`
+	Context     string  `json:"context"`
 }
-

--- a/types/types.go
+++ b/types/types.go
@@ -148,6 +148,13 @@ func (e EventType) String() string {
 	return [...]string{eventTypeInstant, eventTypeWeekly}[e]
 }
 
+// Constants for notification context's expected fields
+const (
+	DisplayName = "display_name"
+	HostURL     = "host_url"
+)
+
+
 // EventMetadata represents the metadata of the sent payload.
 // It is expected to be an empty struct as of today
 type EventMetadata map[string]interface{}
@@ -178,3 +185,4 @@ type NotificationMessage struct {
 	Events      []Event             `json:"events"`
 	Context     NotificationContext `json:"context"`
 }
+


### PR DESCRIPTION
# Description

Incomplete but working version of the notification service.

- Config files have been cleaned up. Removed values are expected to be set in deployment environment.
- Differ produces 1 notification per cluster with important and critical issues.
- Updated constants for notification message (fields expected by the email template and such)
- Use the timestamp of the selected reports as timestamp for the notified issues
- Notify issues with total risk higher or equal to 3 instead of 2
- Make the notification message comply with the expected format (JSON string with escaped strings inside) 
- Fix some errors in the code (e.g Kafka producer was set and closed for each cluster), added some error control and basic logging.
- Added TODOs for code that is part of other tasks

Fixes #28 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)

## Testing steps

Mostly manual testing while preparing the demo.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
