### PR TITLE
Fetch rules content from content-service

### DIFF
--- a/PoC-differ/config.toml
+++ b/PoC-differ/config.toml
@@ -1,19 +1,26 @@
-# Config file for local development.
-# Feel free to push changes as long as
-# they can be used by any developer
-# and are reviewed by at least one
-# codeowner.
+[logging]
+debug = true
+log_level = "info"
+
+[kafka_broker]
+address = "" #provide in deployment env or as secret
+topic = "" #provide in deployment env or as secret
+timeout = "60s"
 
 [storage]
 db_driver = "postgres"
-pg_username = "postgres"
-pg_password = "postgres"
-pg_host = "localhost"
-pg_port = 5432
-pg_db_name = "notification"
+pg_username = "" #provide in deployment env or as secret
+pg_password = "" #provide in deployment env or as secret
+pg_host = "" #provide in deployment env or as secret
+pg_port =  #provide in deployment env or as secret
+pg_db_name = "" #provide in deployment env or as secret
 pg_params = "sslmode=disable"
 log_sql_queries = true
 
-[logging]
-debug = true
-log_level = ""
+[dependencies]
+content_server = "" #provide in deployment env or as secret
+content_endpoint = "" #provide in deployment env or as secret
+
+[notification]
+cluster_url = "" #provide in deployment env or as secret
+cluster_insights_tab = "#insights"

--- a/conf/config.go
+++ b/conf/config.go
@@ -97,6 +97,7 @@ type StorageConfiguration struct {
 
 // DependenciesConfiguration represents configuration of external services and other dependencies
 type DependenciesConfiguration struct {
+	ContentServiceServer   string `mapstructure:"content_server" toml:"content_endpoint"`
 	ContentServiceEndpoint string `mapstructure:"content_endpoint" toml:"content_endpoint"`
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -68,6 +68,12 @@ type RuleErrorKeyContent struct {
 	HasReason bool
 }
 
+// RuleContentDirectory contains content for all available rules in a directory.
+type RuleContentDirectory struct {
+	Config GlobalRuleConfig
+	Rules  map[string]RuleContent
+}
+
 // ErrorKeyMetadata is a Go representation of the `metadata.yaml`
 // file inside of an error key content directory.
 type ErrorKeyMetadata struct {


### PR DESCRIPTION
# Description

Remove parsing from content directory and fetch rules content from content service API instead.

Fixes #31

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)

## Testing steps

Manual test of differ service.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
