### PR TITLE
Retrieve correct account number from DB

### DIFF
--- a/PoC-differ/storage.go
+++ b/PoC-differ/storage.go
@@ -140,7 +140,7 @@ func (storage DBStorage) Close() error {
 func (storage DBStorage) ReadClusterList() ([]types.ClusterEntry, error) {
 	var clusterList = make([]types.ClusterEntry, 0)
 
-	rows, err := storage.connection.Query("SELECT org_id, cluster FROM new_reports ORDER BY updated_at")
+	rows, err := storage.connection.Query("SELECT org_id, account_number, cluster FROM new_reports ORDER BY updated_at")
 	if err != nil {
 		return clusterList, err
 	}
@@ -154,17 +154,18 @@ func (storage DBStorage) ReadClusterList() ([]types.ClusterEntry, error) {
 
 	for rows.Next() {
 		var (
-			clusterName types.ClusterName
-			orgID       types.OrgID
+			clusterName   types.ClusterName
+			orgID         types.OrgID
+			accountNumber types.AccountNumber
 		)
 
-		if err := rows.Scan(&orgID, &clusterName); err != nil {
+		if err := rows.Scan(&orgID, &accountNumber, &clusterName); err != nil {
 			if closeErr := rows.Close(); closeErr != nil {
 				log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
 			}
 			return clusterList, err
 		}
-		clusterList = append(clusterList, types.ClusterEntry{orgID, clusterName})
+		clusterList = append(clusterList, types.ClusterEntry{orgID, accountNumber, clusterName})
 	}
 
 	return clusterList, nil

--- a/types/types.go
+++ b/types/types.go
@@ -26,6 +26,9 @@ type Timestamp time.Time
 // OrgID represents organization ID
 type OrgID uint32
 
+// AccountNumber represents account number for a given report
+type AccountNumber uint32
+
 // ClusterName represents name of cluster in format c8590f31-e97e-4b85-b506-c45ce1911a12
 type ClusterName string
 
@@ -46,8 +49,9 @@ const (
 
 // ClusterEntry  represents the entries retrieved from the DB
 type ClusterEntry struct {
-	OrgID       OrgID
-	ClusterName ClusterName
+	OrgID         OrgID
+	AccountNumber AccountNumber
+	ClusterName   ClusterName
 }
 
 // RuleContent wraps all the content available for a rule into a single structure.


### PR DESCRIPTION
# Description

We now retrieve account number for each report in addition to cluster name and org_id, and use it to notify the correct customer.

Fixes #30 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Testing steps

Manual testing, populating DB with three entries corresponding to two different accounts to verify instant notifications and weekly notifications behavior.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
