### PR TITLE
Rename differ's Init function to avoid mixups with Go's init

### DIFF
--- a/ccx_notification_service.go
+++ b/ccx_notification_service.go
@@ -27,7 +27,7 @@ func main() {
 
 	log.Info().Msg("Started")
 
-	differ.Init()
+	differ.Run()
 
 	log.Info().Msg("Finished")
 }

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -492,8 +492,8 @@ func checkArgs(args *types.CliFlags) {
 	}
 }
 
-// Init function is entry point to the differ
-func Init() {
+// Run function is entry point to the differ
+func Run() {
 	var cliFlags types.CliFlags
 
 	// define and parse all command line options


### PR DESCRIPTION
# Description

Rename differ's Init function to avoid mixups with Go's init

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
