### PR TITLE
Ability to delete old reports for given organization on demand

### DIFF
--- a/differ/storage.go
+++ b/differ/storage.go
@@ -514,7 +514,7 @@ func (storage DBStorage) ReadLastNNotificationRecords(clusterEntry types.Cluster
 // relative time for given organization ID.
 //
 // This method is to be used to cleanup older reports after weekly summary is
-// send.
+// sent.
 //
 // The method return number of deleted records.
 func (storage DBStorage) CleanupForOrganization(orgID types.OrgID, maxAge string, statement string) (int, error) {
@@ -543,7 +543,7 @@ func (storage DBStorage) CleanupForOrganization(orgID types.OrgID, maxAge string
 // restricted for given organization ID.
 //
 // This method is to be used to cleanup older reports after weekly summary is
-// send.
+// sent.
 //
 // The method return number of deleted records.
 func (storage DBStorage) CleanupNewReportsForOrganization(orgID types.OrgID, maxAge string) (int, error) {
@@ -556,7 +556,7 @@ func (storage DBStorage) CleanupNewReportsForOrganization(orgID types.OrgID, max
 // given organization ID.
 //
 // This method is to be used to cleanup older reports after weekly summary is
-// send.
+// sent.
 //
 // The method return number of deleted records.
 func (storage DBStorage) CleanupOldReportsForOrganization(orgID types.OrgID, maxAge string) (int, error) {

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -538,9 +538,9 @@ func (storage DBStorage) CleanupForOrganization(orgID types.OrgID, maxAge string
 	return int(affected), nil
 }
 
-// CleanupNewReports method deletes all reports from `new_reports` table older
-// than specified relative time. Delete operation is restricted for given
-// organization ID.
+// CleanupNewReportsForOrganization method deletes all reports from
+// `new_reports` table older than specified relative time. Delete operation is
+// restricted for given organization ID.
 //
 // This method is to be used to cleanup older reports after weekly summary is
 // send.
@@ -551,9 +551,9 @@ func (storage DBStorage) CleanupNewReportsForOrganization(orgID types.OrgID, max
 	return storage.CleanupForOrganization(orgID, maxAge, sqlStatement)
 }
 
-// CleanupOldReports method deletes all reports from `reported` table older
-// than specified relative time. Delete operation is restricted for given
-// organization ID.
+// CleanupOldReportsForOrganization method deletes all reports from `reported`
+// table older than specified relative time. Delete operation is restricted for
+// given organization ID.
 //
 // This method is to be used to cleanup older reports after weekly summary is
 // send.

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -227,3 +227,18 @@ func (_m *Storage) WriteNotificationRecordImpl(orgID types.OrgID, accountNumber 
 
 	return r0
 }
+
+// CleanupForOrganization is just a stub for a proper mock method
+func (_m *Storage) CleanupForOrganization(orgID types.OrgID, maxAge string, statement string) (int, error) {
+	return 0, nil
+}
+
+// CleanupNewReportsForOrganization is just a stub for a proper mock method
+func (_m *Storage) CleanupNewReportsForOrganization(orgID types.OrgID, maxAge string) (int, error) {
+	return 0, nil
+}
+
+// CleanupOldReportsForOrganization is just a stub for a proper mock method
+func (_m *Storage) CleanupOldReportsForOrganization(orgID types.OrgID, maxAge string) (int, error) {
+	return 0, nil
+}


### PR DESCRIPTION
# Description

Ability to delete old reports for given organization on demand

Fixes #35

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
