### PR TITLE
Update hitting recommendations URLs

### DIFF
--- a/config-devel.toml
+++ b/config-devel.toml
@@ -22,7 +22,7 @@ content_server = "localhost:8082" #provide in deployment env or as secret
 content_endpoint = "/api/v1/content" #provide in deployment env or as secret
 
 [notifications]
-insights_advisor_url = "https://console.redhat.com/beta/openshift/insights/advisor/clusters/{cluster_id}"
+insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"
 cluster_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}#insights"
 rule_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}/insights/{module}/{error_key}"
 

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -1,0 +1,28 @@
+[logging]
+debug = true
+log_level = "info"
+
+[kafka_broker]
+address = "kafka:29092" #provide in deployment env or as secret
+topic = "platform.notifications.ingress" #provide in deployment env or as secret
+timeout = "60s"
+
+[storage]
+db_driver = "postgres"
+pg_username = "user" #provide in deployment env or as secret
+pg_password = "password" #provide in deployment env or as secret
+pg_host = "localhost" #provide in deployment env or as secret
+pg_port = 5432 #provide in deployment env or as secret
+pg_db_name = "notification" #provide in deployment env or as secret
+pg_params = "sslmode=disable"
+log_sql_queries = true
+
+[dependencies]
+content_server = "localhost:8082" #provide in deployment env or as secret
+content_endpoint = "/api/v1/content" #provide in deployment env or as secret
+
+[notifications]
+insights_advisor_url = "https://console.redhat.com/beta/openshift/insights/advisor/clusters/{cluster_id}"
+cluster_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}#insights"
+rule_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}/insights/{module}/{error_key}"
+

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -213,17 +213,18 @@ func TestAppendEventsToExistingInstantReportNotificationMsg(t *testing.T) {
 	totalRisk := 1
 	module := "a.module"
 	errorKey := "an_error_key"
-	appendEventToNotificationMessage(ruleURI, &notificationMsg, ruleName, totalRisk, publishDate, clusterID, module, errorKey)
+
+	notificationPayloadURL := generateNotificationPayloadURL(ruleURI, clusterID, module, errorKey)
+	appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, ruleName, totalRisk, publishDate)
 	assert.Equal(t, len(notificationMsg.Events), 1, "the notification message should have 1 event")
 	assert.Equal(t, notificationMsg.Events[0].Metadata, types.EventMetadata{}, "All notification messages should have empty metadata")
 
 	payload := Payload{}
 	err := json.Unmarshal([]byte(notificationMsg.Events[0].Payload), &payload)
 	assert.Nil(t, err, fmt.Sprintf("Unexpected behavior: Cannot unmarshall notification payload %q", notificationMsg.Events[0].Payload))
-
 	assert.Equal(t, payload.RuleURL, "a_given_uri/the_displayed_cluster_ID/a|module/an_error_key", fmt.Sprintf("The rule URL %s is not correct", payload.RuleURL))
 
-	appendEventToNotificationMessage(ruleURI, &notificationMsg, ruleName, totalRisk, publishDate, clusterID, module, errorKey)
+	appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, ruleName, totalRisk, publishDate)
 	assert.Equal(t, len(notificationMsg.Events), 2, "the notification message should have 2 events")
 	assert.Equal(t, notificationMsg.Events[1].Metadata, types.EventMetadata{}, "All notification messages should have empty metadata")
 }

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -18,6 +18,14 @@ package differ
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
 	"github.com/RedHatInsights/ccx-notification-service/conf"
 	"github.com/RedHatInsights/ccx-notification-service/producer"
 	"github.com/RedHatInsights/ccx-notification-service/tests/mocks"
@@ -26,11 +34,6 @@ import (
 	samara_mocks "github.com/Shopify/sarama/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"io"
-	"os"
-	"os/exec"
-	"testing"
-	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -47,6 +50,13 @@ var (
 	testPartitionID = 0
 	testOffset      = 0
 )
+
+type Payload struct {
+	PublishDate     string `json:"publish_date"`
+	RuleDescription string `json:"rule_description"`
+	RuleURL         string `json:"rule_url"`
+	TotalRisk       string `json:"total_risk"`
+}
 
 func init() {
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
@@ -174,7 +184,7 @@ func TestToJSONEscapedStringInvalidJSON(t *testing.T) {
 
 //---------------------------------------------------------------------------------------
 func TestGenerateInstantReportNotificationMessage(t *testing.T) {
-	clusterURI := "the_cluster_uri_in_ocm"
+	clusterURI := "the_cluster_uri_in_ocm_for_{cluster_id}"
 	accountID := "a_stringified_account_id"
 	clusterID := "the_displayed_cluster_ID"
 
@@ -183,7 +193,7 @@ func TestGenerateInstantReportNotificationMessage(t *testing.T) {
 	assert.NotEmpty(t, notificationMsg, "the generated notification message is empty")
 	assert.Empty(t, notificationMsg.Events, "the generated notification message should not have any events")
 	assert.Equal(t, types.InstantNotif.String(), notificationMsg.EventType, "the generated notification message should be for instant notifications")
-	assert.Equal(t, "{\"display_name\":\"the_displayed_cluster_ID\",\"host_url\":\"the_cluster_uri_in_ocm\"}", notificationMsg.Context, "Notification context is different from expected.")
+	assert.Equal(t, "{\"display_name\":\"the_displayed_cluster_ID\",\"host_url\":\"the_cluster_uri_in_ocm_for_the_displayed_cluster_ID\"}", notificationMsg.Context, "Notification context is different from expected.")
 	assert.Equal(t, notificationBundleName, notificationMsg.Bundle, "Generated notifications should indicate 'openshift' as bundle")
 	assert.Equal(t, notificationApplicationName, notificationMsg.Application, "Generated notifications should indicate 'openshift' as application name")
 	assert.Equal(t, accountID, notificationMsg.AccountID, "Generated notifications does not have expected account ID")
@@ -197,15 +207,23 @@ func TestAppendEventsToExistingInstantReportNotificationMsg(t *testing.T) {
 
 	assert.Empty(t, notificationMsg.Events, "the generated notification message should not have any events")
 
-	ruleURI := "a_given_uri/{rule}/details"
+	ruleURI := "a_given_uri/{cluster_id}/{module}/{error_key}"
 	ruleName := "a_given_rule_name"
 	publishDate := "the_date_of_today"
 	totalRisk := 1
-	appendEventToNotificationMessage(ruleURI, &notificationMsg, ruleName, totalRisk, publishDate)
+	module := "a.module"
+	errorKey := "an_error_key"
+	appendEventToNotificationMessage(ruleURI, &notificationMsg, ruleName, totalRisk, publishDate, clusterID, module, errorKey)
 	assert.Equal(t, len(notificationMsg.Events), 1, "the notification message should have 1 event")
 	assert.Equal(t, notificationMsg.Events[0].Metadata, types.EventMetadata{}, "All notification messages should have empty metadata")
 
-	appendEventToNotificationMessage(ruleURI, &notificationMsg, ruleName, totalRisk, publishDate)
+	payload := Payload{}
+	err := json.Unmarshal([]byte(notificationMsg.Events[0].Payload), &payload)
+	assert.Nil(t, err, fmt.Sprintf("Unexpected behavior: Cannot unmarshall notification payload %q", notificationMsg.Events[0].Payload))
+
+	assert.Equal(t, payload.RuleURL, "a_given_uri/the_displayed_cluster_ID/a|module/an_error_key", fmt.Sprintf("The rule URL %s is not correct", payload.RuleURL))
+
+	appendEventToNotificationMessage(ruleURI, &notificationMsg, ruleName, totalRisk, publishDate, clusterID, module, errorKey)
 	assert.Equal(t, len(notificationMsg.Events), 2, "the notification message should have 2 events")
 	assert.Equal(t, notificationMsg.Events[1].Metadata, types.EventMetadata{}, "All notification messages should have empty metadata")
 }


### PR DESCRIPTION
# Description

Update the cluster URL and rules URLs to the new requirements. Also added a `config-devel.toml` to make the development process easier.

Fixes #110

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Ran a local setup with Kafka+PostgreSQL, `insights-content-service` and `ccx-notification-writer`. Publish some risk-3 messages to Kafka and check that the URLs match the requirements. For example:

```json
{
  "bundle": "openshift",
  "application": "advisor",
  "event_type": "new-recommendation",
  "timestamp": "2021-08-17T13:37:00Z",
  "account_id": "6089719",
  "events": [
    {
      "metadata": {},
      "payload": "{\"publish_date\":\"2021-08-17T15:36:42.749512Z\",\"rule_description\":\"node_installer_degraded\",\"rule_url\":\"https://console.redhat.com/openshift/details/5d5892d3-1f74-4ccf-91af-548dfc9767aa/insights/ccx_rules_ocp|external|rules|node_installer_degraded|report/NODE_INSTALLER_DEGRADED\",\"total_risk\":\"3\"}"
    },
    {
      "metadata": {},
      "payload": "{\"publish_date\":\"2021-08-17T15:36:42.749512Z\",\"rule_description\":\"unsupported_cni_plugin\",\"rule_url\":\"https://console.redhat.com/openshift/details/5d5892d3-1f74-4ccf-91af-548dfc9767aa/insights/ccx_rules_ocp|external|rules|unsupported_cni_plugin|report/UNSUPPORTED_CNI_PLUGIN\",\"total_risk\":\"3\"}"
    }
  ],
  "context": "{\"display_name\":\"5d5892d3-1f74-4ccf-91af-548dfc9767aa\",\"host_url\":\"https://console.redhat.com/openshift/details/5d5892d3-1f74-4ccf-91af-548dfc9767aa#insights\"}"
}
```

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
