### PR TITLE
Display rule's description instead of title in instant notifications

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -143,16 +143,17 @@ func moduleToRuleName(module string) string {
 	return result
 }
 
-func findRuleByNameAndErrorKey(ruleContent types.RulesMap, impacts types.Impacts, ruleName string, errorKey string) (int, int, int, string) {
+func findRuleByNameAndErrorKey(
+	ruleContent types.RulesMap, impacts types.Impacts, ruleName string, errorKey string) (
+	likelihood int, impact int, totalRisk int, description string) {
 	rc := ruleContent[ruleName]
 	ek := rc.ErrorKeys
 	val := ek[errorKey]
-	likelihood := val.Metadata.Likelihood
-	description := val.Metadata.Description
-	impact := impacts[val.Metadata.Impact]
-	totalRisk := calculateTotalRisk(likelihood, impact)
-
-	return likelihood, impact, totalRisk, description
+	likelihood = val.Metadata.Likelihood
+	description = val.Metadata.Description
+	impact = impacts[val.Metadata.Impact]
+	totalRisk = calculateTotalRisk(likelihood, impact)
+	return
 }
 
 func processReportsByCluster(ruleContent types.RulesMap, impacts types.Impacts, storage Storage, clusters []types.ClusterEntry, notificationConfig conf.NotificationsConfiguration) {

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -208,14 +208,14 @@ func TestAppendEventsToExistingInstantReportNotificationMsg(t *testing.T) {
 	assert.Empty(t, notificationMsg.Events, "the generated notification message should not have any events")
 
 	ruleURI := "a_given_uri/{cluster_id}/{module}/{error_key}"
-	ruleName := "a_given_rule_name"
+	ruleDescription := "a_given_rule_name"
 	publishDate := "the_date_of_today"
 	totalRisk := 1
 	module := "a.module"
 	errorKey := "an_error_key"
 
 	notificationPayloadURL := generateNotificationPayloadURL(ruleURI, clusterID, module, errorKey)
-	appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, ruleName, totalRisk, publishDate)
+	appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, ruleDescription, totalRisk, publishDate)
 	assert.Equal(t, len(notificationMsg.Events), 1, "the notification message should have 1 event")
 	assert.Equal(t, notificationMsg.Events[0].Metadata, types.EventMetadata{}, "All notification messages should have empty metadata")
 
@@ -224,7 +224,7 @@ func TestAppendEventsToExistingInstantReportNotificationMsg(t *testing.T) {
 	assert.Nil(t, err, fmt.Sprintf("Unexpected behavior: Cannot unmarshall notification payload %q", notificationMsg.Events[0].Payload))
 	assert.Equal(t, payload.RuleURL, "a_given_uri/the_displayed_cluster_ID/a|module/an_error_key", fmt.Sprintf("The rule URL %s is not correct", payload.RuleURL))
 
-	appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, ruleName, totalRisk, publishDate)
+	appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, ruleDescription, totalRisk, publishDate)
 	assert.Equal(t, len(notificationMsg.Events), 2, "the notification message should have 2 events")
 	assert.Equal(t, notificationMsg.Events[1].Metadata, types.EventMetadata{}, "All notification messages should have empty metadata")
 }


### PR DESCRIPTION
# Description

Small change in the instant notification's payload to display rule's description instead of title.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
