### PR TITLE
Ability to display and cleanup old DB records

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ List of all available command line options:
     	show version and exit
   -weekly-reports
     	create weekly reports
+  -max-age string
+    	max age for displaying/cleaning old records
+  -new-reports-cleanup
+    	perform new reports clean up
+  -old-reports-cleanup
+    	perform old reports clean up
+  -print-new-reports-for-cleanup
+    	print new reports to be cleaned up
+  -print-old-reports-for-cleanup
+    	print old reports to be cleaned up
 ```
 
 ## Database

--- a/abcgo.sh
+++ b/abcgo.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-threshold=75
+threshold=85
 
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)

--- a/differ/cleaner.go
+++ b/differ/cleaner.go
@@ -1,0 +1,100 @@
+/*
+Copyright © 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"errors"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/RedHatInsights/ccx-notification-service/types"
+)
+
+// Messages
+const (
+	databasePrintNewReportsForCleanupOperationFailedMessage = "Print records from `new_reports` table prepared for cleanup failed"
+	databasePrintOldReportsForCleanupOperationFailedMessage = "Print records from `reported` table prepared for cleanup failed"
+	databaseCleanupNewReportsOperationFailedMessage         = "Cleanup records from `new_reports` table failed"
+	databaseCleanupOldReportsOperationFailedMessage         = "Cleanup records from `reported` table failed"
+	rowsDeletedMessage                                      = "Rows deleted"
+)
+
+// PerformCleanupOperation function performs selected cleanup operation
+func PerformCleanupOperation(storage *DBStorage, cliFlags types.CliFlags) error {
+	switch {
+	case cliFlags.PrintNewReportsForCleanup:
+		return printNewReportsForCleanup(storage, cliFlags)
+	case cliFlags.PerformNewReportsCleanup:
+		return performNewReportsCleanup(storage, cliFlags)
+	case cliFlags.PrintOldReportsForCleanup:
+		return printOldReportsForCleanup(storage, cliFlags)
+	case cliFlags.PerformOldReportsCleanup:
+		return performOldReportsCleanup(storage, cliFlags)
+	default:
+		return errors.New("Unknown operation selected")
+	}
+}
+
+// printNewReportsForCleanup function print all reports for `new_reports` table
+// that are older than specified max age.
+func printNewReportsForCleanup(storage *DBStorage, cliFlags types.CliFlags) error {
+	err := storage.PrintNewReportsForCleanup(cliFlags.MaxAge)
+	if err != nil {
+		log.Error().Err(err).Msg(databasePrintNewReportsForCleanupOperationFailedMessage)
+		return err
+	}
+
+	return nil
+}
+
+// performNewReportsCleanup function deletes all reports from `new_reports`
+// table that are older than specified max age.
+func performNewReportsCleanup(storage *DBStorage, cliFlags types.CliFlags) error {
+	affected, err := storage.CleanupNewReports(cliFlags.MaxAge)
+	if err != nil {
+		log.Error().Err(err).Msg(databaseCleanupNewReportsOperationFailedMessage)
+		return err
+	}
+	log.Info().Int(rowsDeletedMessage, affected).Msg("Cleanup `new_reports` finished")
+
+	return nil
+}
+
+// printOldReportsForCleanup function print all reports for `reported` table
+// that are older than specified max age.
+func printOldReportsForCleanup(storage *DBStorage, cliFlags types.CliFlags) error {
+	err := storage.PrintOldReportsForCleanup(cliFlags.MaxAge)
+	if err != nil {
+		log.Error().Err(err).Msg(databasePrintOldReportsForCleanupOperationFailedMessage)
+		return err
+	}
+
+	return nil
+}
+
+// performOldReportsCleanup function deletes all reports from `reported` table
+// that are older than specified max age.
+func performOldReportsCleanup(storage *DBStorage, cliFlags types.CliFlags) error {
+	affected, err := storage.CleanupOldReports(cliFlags.MaxAge)
+	if err != nil {
+		log.Error().Err(err).Msg(databaseCleanupOldReportsOperationFailedMessage)
+		return err
+	}
+	log.Info().Int(rowsDeletedMessage, affected).Msg("Cleanup `reported` finished")
+
+	return nil
+}

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -613,6 +613,13 @@ func closeNotifier() {
 	}
 }
 
+func deleteOperationSpecified(cliFlags types.CliFlags) bool {
+	return cliFlags.PrintNewReportsForCleanup ||
+		cliFlags.PerformNewReportsCleanup ||
+		cliFlags.PrintOldReportsForCleanup ||
+		cliFlags.PerformOldReportsCleanup
+}
+
 // Run function is entry point to the differ
 func Run() {
 	var cliFlags types.CliFlags
@@ -658,10 +665,7 @@ func Run() {
 		os.Exit(ExitStatusStorageError)
 	}
 
-	if cliFlags.PrintNewReportsForCleanup ||
-		cliFlags.PerformNewReportsCleanup ||
-		cliFlags.PrintOldReportsForCleanup ||
-		cliFlags.PerformOldReportsCleanup {
+	if deleteOperationSpecified(cliFlags) {
 		err := PerformCleanupOperation(storage, cliFlags)
 		if err != nil {
 			os.Exit(ExitStatusCleanerError)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -68,6 +68,8 @@ const (
 	ExitStatusKafkaConnectionNotClosedError
 	// ExitStatusHTTPServerError is raised when HTTP server cannot be started
 	ExitStatusHTTPServerError
+	// ExitStatusCleanerError is raised when clean operation is not successful
+	ExitStatusCleanerError
 )
 
 // Messages
@@ -621,6 +623,11 @@ func Run() {
 	flag.BoolVar(&cliFlags.ShowVersion, "show-version", false, "show version and exit")
 	flag.BoolVar(&cliFlags.ShowAuthors, "show-authors", false, "show authors and exit")
 	flag.BoolVar(&cliFlags.ShowConfiguration, "show-configuration", false, "show configuration")
+	flag.BoolVar(&cliFlags.PrintNewReportsForCleanup, "print-new-reports-for-cleanup", false, "print new reports to be cleaned up")
+	flag.BoolVar(&cliFlags.PerformNewReportsCleanup, "new-reports-cleanup", false, "perform new reports clean up")
+	flag.BoolVar(&cliFlags.PrintOldReportsForCleanup, "print-old-reports-for-cleanup", false, "print old reports to be cleaned up")
+	flag.BoolVar(&cliFlags.PerformOldReportsCleanup, "old-reports-cleanup", false, "perform old reports clean up")
+	flag.StringVar(&cliFlags.MaxAge, "max-age", "", "max age for displaying/cleaning old records")
 	flag.Parse()
 	checkArgs(&cliFlags)
 
@@ -642,6 +649,27 @@ func Run() {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
 
+	// prepare the storage
+	storageConfiguration := conf.GetStorageConfiguration(config)
+	storage, err := NewStorage(storageConfiguration)
+	if err != nil {
+		StorageSetupErrors.Inc()
+		log.Err(err).Msg(operationFailedMessage)
+		os.Exit(ExitStatusStorageError)
+	}
+
+	if cliFlags.PrintNewReportsForCleanup ||
+		cliFlags.PerformNewReportsCleanup ||
+		cliFlags.PrintOldReportsForCleanup ||
+		cliFlags.PerformOldReportsCleanup {
+		err := PerformCleanupOperation(storage, cliFlags)
+		if err != nil {
+			os.Exit(ExitStatusCleanerError)
+		} else {
+			os.Exit(ExitStatusOK)
+		}
+	}
+
 	log.Info().Msg("Differ started")
 	log.Info().Msg(separator)
 
@@ -659,15 +687,6 @@ func Run() {
 
 	log.Info().Msg(separator)
 	log.Info().Msg("Read cluster list")
-
-	// prepare the storage
-	storageConfiguration := conf.GetStorageConfiguration(config)
-	storage, err := NewStorage(storageConfiguration)
-	if err != nil {
-		StorageSetupErrors.Inc()
-		log.Err(err).Msg(operationFailedMessage)
-		os.Exit(ExitStatusStorageError)
-	}
 
 	//TODO: Set notificationConfig global variables here to avoid passing so much parameters
 

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -598,7 +598,7 @@ func (storage DBStorage) CleanupForOrganization(orgID types.OrgID, maxAge string
 
 	log.Info().
 		Str(MaxAgeAttribute, maxAge).
-		Str("DeleteStatement", printableStatement).
+		Str(DeleteStatement, printableStatement).
 		Int(OrgIDMessage, int(orgID)).
 		Msg("Cleanup operation for organization")
 
@@ -771,7 +771,7 @@ func (storage DBStorage) PrintOldReportsForCleanup(maxAge string) error {
 func (storage DBStorage) Cleanup(maxAge string, statement string) (int, error) {
 	log.Info().
 		Str(MaxAgeAttribute, maxAge).
-		Str("DeleteStatement", statement).
+		Str(DeleteStatement, statement).
 		Msg("Cleanup operation for all organizations")
 
 	// perform the SQL statement

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -274,3 +274,27 @@ func (_m *Storage) DeleteRowFromNewReports(
 	notifiedAt types.Timestamp) (int, error) {
 	return 0, nil
 }
+
+// PrintNewReportsForCleanup is a mocked reimplementation of the real
+// PrintNewReportsForCleanup method.
+func (_m *Storage) PrintNewReportsForCleanup(maxAge string) error {
+	return nil
+}
+
+// CleanupNewReports is a mocked reimplementation of the real CleanupNewReports
+// method.
+func (_m *Storage) CleanupNewReports(maxAge string) (int, error) {
+	return 1, nil
+}
+
+// PrintOldReportsForCleanup is a mocked reimplementation of the real
+// PrintOldReportsForCleanup method.
+func (_m *Storage) PrintOldReportsForCleanup(maxAge string) error {
+	return nil
+}
+
+// CleanupOldReports is a mocked reimplementation of the real CleanupOldReports
+// method.
+func (_m *Storage) CleanupOldReports(maxAge string) (int, error) {
+	return 1, nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -154,11 +154,16 @@ func (err MissingMandatoryFile) Error() string {
 
 // CliFlags represents structure holding all command line arguments/flags.
 type CliFlags struct {
-	InstantReports    bool
-	WeeklyReports     bool
-	ShowVersion       bool
-	ShowAuthors       bool
-	ShowConfiguration bool
+	InstantReports            bool
+	WeeklyReports             bool
+	ShowVersion               bool
+	ShowAuthors               bool
+	ShowConfiguration         bool
+	PrintNewReportsForCleanup bool
+	PerformNewReportsCleanup  bool
+	PrintOldReportsForCleanup bool
+	PerformOldReportsCleanup  bool
+	MaxAge                    string
 }
 
 // Report represents report send in a message consumed from any broker


### PR DESCRIPTION
# Description

Ability to display and cleanup old DB records

Fixes #121

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
