### PR TITLE
Push prometheus metrics to push gateway instead of waiting for polling

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -135,22 +135,14 @@ type NotificationsConfiguration struct {
 	RuleDetailsURI     string `mapstructure:"rule_details_uri"    toml:"rule_details_uri"`
 }
 
-// MetricsGroup represents the config used to group the exported prometheus metrics
-type MetricsGroup struct {
-	Name  string
-	Value string
-}
-
-// MetricsGroups represents a slice of MetricsGroup objects
-type MetricsGroups []MetricsGroup
-
 // MetricsConfiguration holds metrics related configuration
 type MetricsConfiguration struct {
-	Job              string        `mapstructure:"job_name" toml:"job_name"`
-	Namespace        string        `mapstructure:"namespace" toml:"namespace"`
-	GatewayURL       string        `mapstructure:"gateway_url" toml:"gateway_url"`
-	GatewayAuthToken string        `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
-	Groups           MetricsGroups `mapstructure:"grouping" toml:"grouping"`
+	Job              string `mapstructure:"job_name" toml:"job_name"`
+	Namespace        string `mapstructure:"namespace" toml:"namespace"`
+	GatewayURL       string `mapstructure:"gateway_url" toml:"gateway_url"`
+	GatewayAuthToken string `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
+	GroupingSaasFile string `mapstructure:"grouping_saas_file_name" toml:"grouping_saas_file_name"`
+	GroupingEnvName  string `mapstructure:"grouping_env_name" toml:"grouping_env_name"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in

--- a/conf/config.go
+++ b/conf/config.go
@@ -146,11 +146,11 @@ type MetricsGroups []MetricsGroup
 
 // MetricsConfiguration holds metrics related configuration
 type MetricsConfiguration struct {
-	Job        string        `mapstructure:"job_name" toml:"job_name"`
-	Namespace  string        `mapstructure:"namespace" toml:"namespace"`
-	GatewayURL string        `mapstructure:"gateway_url" toml:"gateway_url"`
-	AuthToken  string        `mapstructure:"auth_token" toml:"auth_token"`
-	Groups     MetricsGroups `mapstructure:"grouping" toml:"grouping"`
+	Job              string        `mapstructure:"job_name" toml:"job_name"`
+	Namespace        string        `mapstructure:"namespace" toml:"namespace"`
+	GatewayURL       string        `mapstructure:"gateway_url" toml:"gateway_url"`
+	GatewayAuthToken string        `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
+	Groups           MetricsGroups `mapstructure:"grouping" toml:"grouping"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in

--- a/conf/config.go
+++ b/conf/config.go
@@ -135,20 +135,22 @@ type NotificationsConfiguration struct {
 	RuleDetailsURI     string `mapstructure:"rule_details_uri"    toml:"rule_details_uri"`
 }
 
+// MetricsGroup represents the config used to group the exported prometheus metrics
 type MetricsGroup struct {
-	Name string
+	Name  string
 	Value string
 }
 
+// MetricsGroups represents a slice of MetricsGroup objects
 type MetricsGroups []MetricsGroup
 
 // MetricsConfiguration holds metrics related configuration
 type MetricsConfiguration struct {
-	Job           string `mapstructure:"job_name" toml:"job_name"`
-	Namespace     string `mapstructure:"namespace" toml:"namespace"`
-	GatewayURL    string `mapstructure:"gateway_url" toml:"gateway_url""`
-	AuthToken     string `mapstructure:"auth_token" toml:"auth_token"`
-	Groups        MetricsGroups `mapstructure:"grouping" toml:"grouping"`
+	Job        string        `mapstructure:"job_name" toml:"job_name"`
+	Namespace  string        `mapstructure:"namespace" toml:"namespace"`
+	GatewayURL string        `mapstructure:"gateway_url" toml:"gateway_url"`
+	AuthToken  string        `mapstructure:"auth_token" toml:"auth_token"`
+	Groups     MetricsGroups `mapstructure:"grouping" toml:"grouping"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in

--- a/conf/config.go
+++ b/conf/config.go
@@ -135,10 +135,20 @@ type NotificationsConfiguration struct {
 	RuleDetailsURI     string `mapstructure:"rule_details_uri"    toml:"rule_details_uri"`
 }
 
+type MetricsGroup struct {
+	Name string
+	Value string
+}
+
+type MetricsGroups []MetricsGroup
+
 // MetricsConfiguration holds metrics related configuration
 type MetricsConfiguration struct {
-	Namespace string `mapstructure:"namespace" toml:"namespace"`
-	Address   string `mapstructure:"address" toml:"address"`
+	Job           string `mapstructure:"job_name" toml:"job_name"`
+	Namespace     string `mapstructure:"namespace" toml:"namespace"`
+	GatewayURL    string `mapstructure:"gateway_url" toml:"gateway_url""`
+	AuthToken     string `mapstructure:"auth_token" toml:"auth_token"`
+	Groups        MetricsGroups `mapstructure:"grouping" toml:"grouping"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -190,3 +190,22 @@ func TestLoadConfigurationFromEnvVariableClowderEnabled(t *testing.T) {
 	mustSetEnv(t, "ACG_CONFIG", "tests/clowder_config.json")
 	mustLoadConfiguration("CCX_NOTIFICATION_SERVICE_CONFIG_FILE")
 }
+
+// TestLoadNotificationsConfiguration tests loading the notifications configuration sub-tree
+func TestLoadMetricsConfiguration(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+
+	mustSetEnv(t, envVar, "../tests/config2")
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	conf := conf.GetMetricsConfiguration(config)
+
+	assert.Equal(t, "ccx_notification_service_namespace", conf.Namespace)
+	assert.Equal(t, ":9091", conf.GatewayURL)
+	assert.Equal(t, "", conf.AuthToken)
+	assert.Equal(t, "first_grouping_name", conf.Groups[0].Name)
+	assert.Equal(t, "first_grouping_value", conf.Groups[0].Value)
+	assert.Equal(t, "second_grouping_name", conf.Groups[1].Name)
+	assert.Equal(t, "second_grouping_value", conf.Groups[1].Value)
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -203,7 +203,7 @@ func TestLoadMetricsConfiguration(t *testing.T) {
 
 	assert.Equal(t, "ccx_notification_service_namespace", conf.Namespace)
 	assert.Equal(t, ":9091", conf.GatewayURL)
-	assert.Equal(t, "", conf.AuthToken)
+	assert.Equal(t, "", conf.GatewayAuthToken)
 	assert.Equal(t, "first_grouping_name", conf.Groups[0].Name)
 	assert.Equal(t, "first_grouping_value", conf.Groups[0].Value)
 	assert.Equal(t, "second_grouping_name", conf.Groups[1].Name)

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -204,8 +204,6 @@ func TestLoadMetricsConfiguration(t *testing.T) {
 	assert.Equal(t, "ccx_notification_service_namespace", conf.Namespace)
 	assert.Equal(t, ":9091", conf.GatewayURL)
 	assert.Equal(t, "", conf.GatewayAuthToken)
-	assert.Equal(t, "first_grouping_name", conf.Groups[0].Name)
-	assert.Equal(t, "first_grouping_value", conf.Groups[0].Value)
-	assert.Equal(t, "second_grouping_name", conf.Groups[1].Name)
-	assert.Equal(t, "second_grouping_value", conf.Groups[1].Value)
+	assert.Equal(t, "saas_file_name_value", conf.GroupingSaasFile)
+	assert.Equal(t, "env_name_value", conf.GroupingEnvName)
 }

--- a/config.toml
+++ b/config.toml
@@ -31,12 +31,8 @@ job_name = "ccx_notification_service"
 namespace = "ccx_notification_service"
 gateway_url = "localhost:9091"
 gateway_auth_token = ""
-[[metrics.grouping]]
-name = "saas_file_name"
-value = "saas_file_name_value"
-[[metrics.grouping]]
-name = "env_name"
-value = "env_name_value"
+grouping_saas_file_name = "saas_file_name_value"
+grouping_env_name = "env_name_value"
 
 [cleaner]
 max_age = "90 days"

--- a/config.toml
+++ b/config.toml
@@ -3,28 +3,40 @@ debug = true
 log_level = "info"
 
 [kafka_broker]
-address = "" #provide in deployment env or as secret
-topic = "" #provide in deployment env or as secret
+address = "kafka:9092" #provide in deployment env or as secret
+topic = "platform.notifications.ingress" #provide in deployment env or as secret
 timeout = "60s"
 
 [storage]
 db_driver = "postgres"
-pg_username = "" #provide in deployment env or as secret
-pg_password = "" #provide in deployment env or as secret
-pg_host = "" #provide in deployment env or as secret
-pg_port = 0 #provide in deployment env or as secret
-pg_db_name = "" #provide in deployment env or as secret
+pg_username = "postgres" #provide in deployment env or as secret
+pg_password = "34ebad34" #provide in deployment env or as secret
+pg_host = "localhost" #provide in deployment env or as secret
+pg_port = 5432 #provide in deployment env or as secret
+pg_db_name = "ccx-notification-db2" #provide in deployment env or as secret
 pg_params = "sslmode=disable"
 log_sql_queries = true
 
 [dependencies]
-content_server = "" #provide in deployment env or as secret
-content_endpoint = "" #provide in deployment env or as secret
+content_server = "localhost:8080" #provide in deployment env or as secret
+content_endpoint = "/api/v1/content" #provide in deployment env or as secret
 
 [notifications]
-insights_advisor_url = "" #provide in deployment env or as secret
-cluster_details_uri = "" #provide in deployment env or as secret
-rule_details_uri = "" #provide in deployment env or as secret
+insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"
+cluster_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}#insights"
+rule_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}/insights/{module}/{error_key}"
+
+[metrics]
+job_name = "ccx_notification_service_local"
+namespace = "ccx_notification_service_namespace__"
+gateway_url = "localhost:9091"
+auth_token = ""
+[[metrics.grouping]]
+name = "saas_file_name"
+value = "saas_file_name_value"
+[[metrics.grouping]]
+name = "env_name"
+value = "env_name_value"
 
 [cleaner]
 max_age = "90 days"

--- a/config.toml
+++ b/config.toml
@@ -27,10 +27,10 @@ cluster_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}
 rule_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}/insights/{module}/{error_key}"
 
 [metrics]
-job_name = "ccx_notification_service_local"
-namespace = "ccx_notification_service_namespace__"
+job_name = "ccx_notification_service"
+namespace = "ccx_notification_service"
 gateway_url = "localhost:9091"
-auth_token = ""
+gateway_auth_token = ""
 [[metrics.grouping]]
 name = "saas_file_name"
 value = "saas_file_name_value"

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -165,18 +165,10 @@ func showConfiguration(config conf.ConfigStruct) {
 
 	metricsConfig := conf.GetMetricsConfiguration(config)
 
-	//Authentication token and metrics groups value is omitted on purpose
-	metricsGroups := []string{}
-	if len(metricsConfig.Groups) > 0 {
-		for _, item := range metricsConfig.Groups {
-			metricsGroups = append(metricsGroups, item.Name)
-		}
-	}
-
+	//Authentication token and metrics groups values are omitted on purpose
 	log.Info().
 		Str("Namespace", metricsConfig.Namespace).
 		Str("Push Gateway", metricsConfig.GatewayURL).
-		Strs("Grouping", metricsGroups).
 		Msg("Metrics configuration")
 }
 
@@ -609,7 +601,7 @@ func closeNotifier() {
 }
 
 func pushMetrics(metricsConf conf.MetricsConfiguration) {
-	err := PushMetrics(metricsConf.GatewayURL, metricsConf.GatewayAuthToken, metricsConf.Job, metricsConf.Groups)
+	err := PushMetrics(metricsConf)
 	if err != nil {
 		log.Err(err).Msg(metricsPushFailedMessage)
 		os.Exit(ExitStatusMetricsError)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -609,7 +609,7 @@ func closeNotifier() {
 }
 
 func pushMetrics(metricsConf conf.MetricsConfiguration) {
-	err := PushMetrics(metricsConf.GatewayURL, metricsConf.AuthToken, metricsConf.Job, metricsConf.Groups)
+	err := PushMetrics(metricsConf.GatewayURL, metricsConf.GatewayAuthToken, metricsConf.Job, metricsConf.Groups)
 	if err != nil {
 		log.Err(err).Msg(metricsPushFailedMessage)
 		os.Exit(ExitStatusMetricsError)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -164,9 +164,19 @@ func showConfiguration(config conf.ConfigStruct) {
 		Msg("Notifications configuration")
 
 	metricsConfig := conf.GetMetricsConfiguration(config)
+
+	//Authentication token and metrics groups value is omitted on purpose
+	metricsGroups := []string{}
+	if len(metricsConfig.Groups) > 0 {
+		for _, item := range metricsConfig.Groups {
+			metricsGroups = append(metricsGroups, item.Name)
+		}
+	}
+
 	log.Info().
 		Str("Namespace", metricsConfig.Namespace).
-		Str("Address", metricsConfig.Address).
+		Str("Push Gateway", metricsConfig.GatewayURL).
+		Strs("Grouping", metricsGroups).
 		Msg("Metrics configuration")
 }
 

--- a/differ/metrics.go
+++ b/differ/metrics.go
@@ -82,7 +82,7 @@ func (pgc *PushGatewayClient) Do(request *http.Request) (*http.Response, error) 
 }
 
 // FetchContentErrors shows number of errors during fetch from content service
-var FetchContentErrors = prometheus.NewCounter(prometheus.CounterOpts{
+var FetchContentErrors = promauto.NewCounter(prometheus.CounterOpts{
 	Name: FetchContentErrorsName,
 	Help: FetchContentErrorsHelp,
 })

--- a/differ/metrics_test.go
+++ b/differ/metrics_test.go
@@ -44,3 +44,5 @@ func TestAddMetricsWithNamespace(t *testing.T) {
 	assert.NotNil(t, differ.NotificationNotSentErrorState)
 	assert.NotNil(t, differ.NotificationSent)
 }
+
+// TODO: TestPushMetrics

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -28,3 +28,14 @@ rule_details_uri = "url_to_specific_rule"
 
 [cleaner]
 max_age = "90 days"
+
+[metrics]
+namespace ="ccx_notification_service_namespace"
+gateway_url = "localhost:9091"
+auth_token = ""
+[[metrics.grouping]]
+name = "saas_file_name"
+value = "saas_file_name_value"
+[[metrics.grouping]]
+name = "env_name"
+value = "env_name_value"

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -33,9 +33,5 @@ max_age = "90 days"
 namespace ="ccx_notification_service_namespace"
 gateway_url = ":9091"
 auth_token = ""
-[[metrics.grouping]]
-name = "first_grouping_name"
-value = "first_grouping_value"
-[[metrics.grouping]]
-name = "second_grouping_name"
-value = "second_grouping_value"
+grouping_saas_file_name = "saas_file_name_value"
+grouping_env_name = "env_name_value"

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -31,11 +31,11 @@ max_age = "90 days"
 
 [metrics]
 namespace ="ccx_notification_service_namespace"
-gateway_url = "localhost:9091"
+gateway_url = ":9091"
 auth_token = ""
 [[metrics.grouping]]
-name = "saas_file_name"
-value = "saas_file_name_value"
+name = "first_grouping_name"
+value = "first_grouping_value"
 [[metrics.grouping]]
-name = "env_name"
-value = "env_name_value"
+name = "second_grouping_name"
+value = "second_grouping_value"


### PR DESCRIPTION
# Description

The notification service is deployed as a cronjob. Since it is a short-lived job, using polling to collect the metrics is not the best choice as the time series can have a lot of missing points if the polling doesn't happen when the job is alive.

- The metrics configuration has been updated to include:
  - the push gateway URL
  - the required information to group our metrics as expected by app-sre
 

Fixes #132

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Added some unit tests, but prometheus push gateway has been tested locally with a push gateway instance. 

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
