### PR TITLE
Remove duplicated types and update related code

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -192,19 +192,19 @@ func moduleToRuleName(module types.ModuleName) types.RuleName {
 }
 
 func findRuleByNameAndErrorKey(
-	ruleContent types.RulesMap, impacts types.Impacts, ruleName types.RuleName, errorKey types.ErrorKey) (
+	ruleContent types.RulesMap, ruleName types.RuleName, errorKey types.ErrorKey) (
 	likelihood int, impact int, totalRisk int, description string) {
 	rc := ruleContent[string(ruleName)]
 	ek := rc.ErrorKeys
-	val := ek[errorKey]
+	val := ek[string(errorKey)]
 	likelihood = val.Metadata.Likelihood
 	description = val.Metadata.Description
-	impact = impacts[val.Metadata.Impact]
+	impact = val.Metadata.Impact.Impact
 	totalRisk = calculateTotalRisk(likelihood, impact)
 	return
 }
 
-func processReportsByCluster(ruleContent types.RulesMap, impacts types.Impacts, storage Storage, clusters []types.ClusterEntry, notificationConfig conf.NotificationsConfiguration) {
+func processReportsByCluster(ruleContent types.RulesMap, storage Storage, clusters []types.ClusterEntry, notificationConfig conf.NotificationsConfiguration) {
 	for i, cluster := range clusters {
 		log.Info().
 			Int("#", i).
@@ -249,7 +249,7 @@ func processReportsByCluster(ruleContent types.RulesMap, impacts types.Impacts, 
 			module := r.Module
 			ruleName := moduleToRuleName(module)
 			errorKey := r.ErrorKey
-			likelihood, impact, totalRisk, description := findRuleByNameAndErrorKey(ruleContent, impacts, ruleName, errorKey)
+			likelihood, impact, totalRisk, description := findRuleByNameAndErrorKey(ruleContent, ruleName, errorKey)
 
 			log.Info().
 				Int("#", i).
@@ -310,7 +310,7 @@ func updateDigestNotificationCounters(digest *types.Digest, totalRisk int) {
 }
 
 // processAllReportsFromCurrentWeek function creates weekly digest with for all the clusters corresponding to each user account
-func processAllReportsFromCurrentWeek(ruleContent types.RulesMap, impacts types.Impacts, storage Storage, clusters []types.ClusterEntry, notificationConfig conf.NotificationsConfiguration) {
+func processAllReportsFromCurrentWeek(ruleContent types.RulesMap, storage Storage, clusters []types.ClusterEntry, notificationConfig conf.NotificationsConfiguration) {
 	digestByAccount := map[types.AccountNumber]types.Digest{}
 	digest := types.Digest{}
 
@@ -349,7 +349,7 @@ func processAllReportsFromCurrentWeek(ruleContent types.RulesMap, impacts types.
 			moduleName := r.Module
 			ruleName := moduleToRuleName(moduleName)
 			errorKey := r.ErrorKey
-			likelihood, impact, totalRisk, _ := findRuleByNameAndErrorKey(ruleContent, impacts, ruleName, errorKey)
+			likelihood, impact, totalRisk, _ := findRuleByNameAndErrorKey(ruleContent, ruleName, errorKey)
 
 			log.Info().
 				Int("#", i).
@@ -391,13 +391,13 @@ func processAllReportsFromCurrentWeek(ruleContent types.RulesMap, impacts types.
 }
 
 // processClusters function creates desired notification messages for all the clusters obtained from the database
-func processClusters(ruleContent types.RulesMap, impacts types.Impacts, storage Storage, clusters []types.ClusterEntry, config conf.ConfigStruct) {
+func processClusters(ruleContent types.RulesMap, storage Storage, clusters []types.ClusterEntry, config conf.ConfigStruct) {
 	notificationConfig := conf.GetNotificationsConfiguration(config)
 
 	if notificationType == types.InstantNotif {
-		processReportsByCluster(ruleContent, impacts, storage, clusters, notificationConfig)
+		processReportsByCluster(ruleContent, storage, clusters, notificationConfig)
 	} else if notificationType == types.WeeklyDigest {
-		processAllReportsFromCurrentWeek(ruleContent, impacts, storage, clusters, notificationConfig)
+		processAllReportsFromCurrentWeek(ruleContent, storage, clusters, notificationConfig)
 	}
 }
 
@@ -632,7 +632,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage) {
 
 	log.Info().Msg("Getting rule content and impacts from content service")
 
-	ruleContent, impacts, err := fetchAllRulesContent(conf.GetDependenciesConfiguration(config))
+	ruleContent, err := fetchAllRulesContent(conf.GetDependenciesConfiguration(config))
 	if err != nil {
 		FetchContentErrors.Inc()
 		os.Exit(ExitStatusFetchContentError)
@@ -665,7 +665,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage) {
 	log.Info().Msg("Kafka producer ready")
 	log.Info().Msg(separator)
 	log.Info().Msg("Checking new issues for all new reports")
-	processClusters(ruleContent, impacts, storage, clusters, config)
+	processClusters(ruleContent, storage, clusters, config)
 	log.Info().Msg(separator)
 	closeStorage(storage)
 	log.Info().Msg(separator)

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	utypes "github.com/RedHatInsights/insights-operator-utils/types"
+
 	"github.com/RedHatInsights/ccx-notification-service/conf"
 	"github.com/RedHatInsights/ccx-notification-service/producer"
 	"github.com/RedHatInsights/ccx-notification-service/tests/mocks"
@@ -457,23 +459,27 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 		},
 	}
 
-	errorKeys := map[types.ErrorKey]types.RuleErrorKeyContent{
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
 		"RULE_1": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 1 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 1 error key description",
-				Impact:      "impact_1",
-				Likelihood:  2,
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 3,
+				},
+				Likelihood: 2,
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
 		},
 		"RULE_2": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 2 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 2 error key description",
-				Impact:      "impact_2",
-				Likelihood:  3,
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 2,
+				},
+				Likelihood: 3,
 			},
 			HasReason: false,
 		},
@@ -496,11 +502,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 			ErrorKeys:  errorKeys,
 			HasReason:  false,
 		},
-	}
-
-	impacts := types.Impacts{
-		"impact_1": 3,
-		"impact_2": 2,
 	}
 
 	clusters := []types.ClusterEntry{
@@ -584,7 +585,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 	notifier, _ = producerMock.New(config.Kafka)
 
 	notificationType = types.InstantNotif
-	processClusters(ruleContent, impacts, &storage, clusters, config)
+	processClusters(ruleContent, &storage, clusters, config)
 
 	assert.Contains(t, buf.String(), "No new issues to notify for cluster first_cluster", "processClusters shouldn't generate any notification for 'first_cluster' with given data")
 	assert.Contains(t, buf.String(), "No new issues to notify for cluster second_cluster", "processClusters shouldn't generate any notification for 'second_cluster' with given data")
@@ -629,23 +630,26 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 		},
 	}
 
-	errorKeys := map[types.ErrorKey]types.RuleErrorKeyContent{
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
 		"RULE_1": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 1 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 1 error key description",
-				Impact:      "impact_1",
-				Likelihood:  4,
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 3,
+				},
+				Likelihood: 4,
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
 		},
 		"RULE_2": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 2 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 2 error key description",
-				Impact:      "impact_2",
-				Likelihood:  3,
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 3,
+				}, Likelihood: 3,
 			},
 			HasReason: false,
 		},
@@ -668,11 +672,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 			ErrorKeys:  errorKeys,
 			HasReason:  false,
 		},
-	}
-
-	impacts := types.Impacts{
-		"impact_1": 3,
-		"impact_2": 3,
 	}
 
 	clusters := []types.ClusterEntry{
@@ -773,7 +772,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 
 	notificationType = types.InstantNotif
 
-	processClusters(ruleContent, impacts, &storage, clusters, config)
+	processClusters(ruleContent, &storage, clusters, config)
 
 	assert.Contains(t, buf.String(), "Report with high impact detected", "processClusters should calculate a totalRisk of 3 for 'first_cluster' with given data")
 	assert.Contains(t, buf.String(), "Producing instant notification for cluster first_cluster with 1 events", "processClusters should generate one notification for 'first_cluster' with given data")
@@ -821,23 +820,27 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 		},
 	}
 
-	errorKeys := map[types.ErrorKey]types.RuleErrorKeyContent{
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
 		"RULE_1": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 1 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 1 error key description",
-				Impact:      "impact_1",
-				Likelihood:  4,
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 4,
+				},
+				Likelihood: 4,
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
 		},
 		"RULE_2": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 2 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 2 error key description",
-				Impact:      "impact_2",
-				Likelihood:  4,
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 4,
+				},
+				Likelihood: 4,
 			},
 			HasReason: false,
 		},
@@ -860,11 +863,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 			ErrorKeys:  errorKeys,
 			HasReason:  false,
 		},
-	}
-
-	impacts := types.Impacts{
-		"impact_1": 4,
-		"impact_2": 4,
 	}
 
 	clusters := []types.ClusterEntry{
@@ -964,7 +962,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 
 	notificationType = types.InstantNotif
 
-	processClusters(ruleContent, impacts, &storage, clusters, config)
+	processClusters(ruleContent, &storage, clusters, config)
 
 	assert.Contains(t, buf.String(), "{\"level\":\"warn\",\"totalRisk\":4,\"message\":\"Report with high impact detected\"}\n")
 
@@ -1015,23 +1013,27 @@ func TestProcessClustersAllIssuesAlreadyNotified(t *testing.T) {
 		},
 	}
 
-	errorKeys := map[types.ErrorKey]types.RuleErrorKeyContent{
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
 		"RULE_1": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 1 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 1 error key description",
-				Impact:      "impact_1",
-				Likelihood:  4,
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 3,
+				},
+				Likelihood: 4,
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
 		},
 		"RULE_2": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 2 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 2 error key description",
-				Impact:      "impact_2",
-				Likelihood:  3,
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 3,
+				},
+				Likelihood: 3,
 			},
 			HasReason: false,
 		},
@@ -1054,11 +1056,6 @@ func TestProcessClustersAllIssuesAlreadyNotified(t *testing.T) {
 			ErrorKeys:  errorKeys,
 			HasReason:  false,
 		},
-	}
-
-	impacts := types.Impacts{
-		"impact_1": 3,
-		"impact_2": 3,
 	}
 
 	clusters := []types.ClusterEntry{
@@ -1125,7 +1122,7 @@ func TestProcessClustersAllIssuesAlreadyNotified(t *testing.T) {
 
 	notificationType = types.InstantNotif
 
-	processClusters(ruleContent, impacts, &storage, clusters, config)
+	processClusters(ruleContent, &storage, clusters, config)
 
 	assert.Contains(t, buf.String(), "{\"level\":\"info\",\"message\":\"No new issues to notify for cluster first_cluster\"}\n", "Notification already sent for first_cluster's report, but corresponding log not found.")
 	assert.Contains(t, buf.String(), "{\"level\":\"info\",\"message\":\"No new issues to notify for cluster second_cluster\"}\n", "Notification already sent for second_cluster's report, but corresponding log not found.")
@@ -1169,23 +1166,27 @@ func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
 		},
 	}
 
-	errorKeys := map[types.ErrorKey]types.RuleErrorKeyContent{
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
 		"RULE_1": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 1 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 1 error key description",
-				Impact:      "impact_1",
-				Likelihood:  4,
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 4,
+				},
+				Likelihood: 4,
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
 		},
 		"RULE_2": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 2 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 2 error key description",
-				Impact:      "impact_2",
-				Likelihood:  4,
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 4,
+				},
+				Likelihood: 4,
 			},
 			HasReason: false,
 		},
@@ -1208,11 +1209,6 @@ func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
 			ErrorKeys:  errorKeys,
 			HasReason:  false,
 		},
-	}
-
-	impacts := types.Impacts{
-		"impact_1": 4,
-		"impact_2": 4,
 	}
 
 	clusters := []types.ClusterEntry{
@@ -1315,7 +1311,7 @@ func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
 
 	notificationType = types.InstantNotif
 
-	processClusters(ruleContent, impacts, &storage, clusters, config)
+	processClusters(ruleContent, &storage, clusters, config)
 
 	assert.Contains(t, buf.String(), "{\"level\":\"warn\",\"totalRisk\":4,\"message\":\"Report with high impact detected\"}\n")
 
@@ -1367,23 +1363,27 @@ func TestProcessClustersWeeklyDigest(t *testing.T) {
 		},
 	}
 
-	errorKeys := map[types.ErrorKey]types.RuleErrorKeyContent{
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
 		"RULE_1": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 1 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 1 error key description",
-				Impact:      "impact_1",
-				Likelihood:  2,
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 3,
+				},
+				Likelihood: 2,
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
 		},
 		"RULE_2": {
-			Metadata: types.ErrorKeyMetadata{
-				Condition:   "rule 2 error key condition",
+			Metadata: utypes.ErrorKeyMetadata{
 				Description: "rule 2 error key description",
-				Impact:      "impact_2",
-				Likelihood:  3,
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 2,
+				},
+				Likelihood: 3,
 			},
 			HasReason: false,
 		},
@@ -1406,11 +1406,6 @@ func TestProcessClustersWeeklyDigest(t *testing.T) {
 			ErrorKeys:  errorKeys,
 			HasReason:  false,
 		},
-	}
-
-	impacts := types.Impacts{
-		"impact_1": 3,
-		"impact_2": 2,
 	}
 
 	clusters := []types.ClusterEntry{
@@ -1464,7 +1459,7 @@ func TestProcessClustersWeeklyDigest(t *testing.T) {
 	notifier, _ = producerMock.New(config.Kafka)
 
 	notificationType = types.WeeklyDigest
-	processClusters(ruleContent, impacts, &storage, clusters, config)
+	processClusters(ruleContent, &storage, clusters, config)
 
 	print(buf.String())
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/RedHatInsights/insights-operator-utils v1.14.0
+	github.com/RedHatInsights/insights-operator-utils v1.21.2
 	github.com/Shopify/sarama v1.27.1
 	github.com/lib/pq v1.7.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -35,11 +35,11 @@ github.com/RedHatInsights/insights-operator-utils v1.0.2-0.20200610143236-c868b2
 github.com/RedHatInsights/insights-operator-utils v1.4.1-0.20200729093922-bca68530a5ef/go.mod h1:F7KKAdWFR70H+3fa89ciXqimNycHdqO9HjLWRdZwOug=
 github.com/RedHatInsights/insights-operator-utils v1.6.2/go.mod h1:RW9Jq4LgqIkV3WY6AS2EkopYyZDIr5BNGiU5I75HryM=
 github.com/RedHatInsights/insights-operator-utils v1.6.7/go.mod h1:ott1/rkxcyQtK6XdYj1Ur3XGSYRAHTplJiV5RKkij2o=
-github.com/RedHatInsights/insights-operator-utils v1.8.1 h1:tAZWWKDv8Ufh6n/qxDWSX2RffIoKRmEXaRUpNNXY6j0=
-github.com/RedHatInsights/insights-operator-utils v1.8.1/go.mod h1:iJLr3riVJOdTf2eKNP12co18G3Zwew16/ZB8fHKN+HE=
 github.com/RedHatInsights/insights-operator-utils v1.8.3/go.mod h1:L6alrkNSM+uBzlQdIihhGnwTpdw+bD8i8Fdh/OE9rdo=
-github.com/RedHatInsights/insights-operator-utils v1.14.0 h1:bROfP6PaOnxuFBiYDVsyzerKgy5FRlCV0UBATKHuTt8=
-github.com/RedHatInsights/insights-operator-utils v1.14.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
+github.com/RedHatInsights/insights-operator-utils v1.21.2 h1:xE2VyoOr+7LWAT59D234/n4PW6PlkV1wAOrJPDtCOoE=
+github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c h1:/kb5AwNxizPf+0R4OWWRvWbLqAwf07Bu97R4WVHk2Uw=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
@@ -47,6 +47,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556 h1:id0piGUdHbHhze/RXSqUjd1mQdnCxqm2WaW32xPsg7k=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
 github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023/go.mod h1:SDeBuNY8AIwkD4JB5/I54ArWG7qngP5/Ydn7xbu2iZo=
+github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbiccYJ8whbpLLvNGMiaFzyMPs1A/2/Jh0P2U9DXF+4=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/types/types.go
+++ b/types/types.go
@@ -25,6 +25,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/RedHatInsights/insights-operator-utils/types"
 	"time"
 )
 
@@ -104,44 +105,8 @@ type States struct {
 	ErrorState      StateID
 }
 
-// RuleContent wraps all the content available for a rule into a single structure.
-type RuleContent struct {
-	Summary    string                           `json:"summary"`
-	Reason     string                           `json:"reason"`
-	Resolution string                           `json:"resolution"`
-	MoreInfo   string                           `json:"more_info"`
-	ErrorKeys  map[ErrorKey]RuleErrorKeyContent `json:"error_keys"`
-	HasReason  bool
-}
-
-// RuleErrorKeyContent wraps content of a single error key.
-type RuleErrorKeyContent struct {
-	Generic   string           `json:"generic"`
-	Metadata  ErrorKeyMetadata `json:"metadata"`
-	Reason    string           `json:"reason"`
-	HasReason bool
-}
-
 // RulesMap contains a map of RuleContent objects accesible indexed by rule names
-type RulesMap map[string]RuleContent
-
-// RuleContentDirectory contains content for all available rules in a directory.
-type RuleContentDirectory struct {
-	Config GlobalRuleConfig
-	Rules  RulesMap
-}
-
-// ErrorKeyMetadata is a Go representation of the `metadata.yaml`
-// file inside of an error key content directory.
-type ErrorKeyMetadata struct {
-	Condition   string   `yaml:"condition" json:"condition"`
-	Description string   `yaml:"description" json:"description"`
-	Impact      string   `yaml:"impact" json:"impact"`
-	Likelihood  int      `yaml:"likelihood" json:"likelihood"`
-	PublishDate string   `yaml:"publish_date" json:"publish_date"`
-	Status      string   `yaml:"status" json:"status"`
-	Tags        []string `yaml:"tags" json:"tags"`
-}
+type RulesMap map[string]types.RuleContent
 
 // MissingMandatoryFile is an error raised while parsing, when a mandatory file is missing
 type MissingMandatoryFile struct {
@@ -190,15 +155,6 @@ type ReportItem struct {
 	Module   ModuleName      `json:"component"`
 	ErrorKey ErrorKey        `json:"key"`
 	Details  json.RawMessage `json:"details"`
-}
-
-// Impacts represents the impacts parsed from the global config file
-type Impacts map[string]int
-
-// GlobalRuleConfig represents the file that contains
-// metadata globally applicable to any/all rule content.
-type GlobalRuleConfig struct {
-	Impact Impacts `yaml:"impact" json:"impact"`
 }
 
 // EventType represents the allowed event types in notification messages


### PR DESCRIPTION
# Description

When insights-operator.utils structs are updated, ccx-notification-service types need to be updated manually to keep up with it. This change fixes that, and fixes the current issue with the impact field of the error_key metadata.

A struct { Name, Impact } is now expected in impact fiel, instead of a string.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

local testing + CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
