### PR TITLE
[CCXDEV-6557] Add retry mechanism for pushed metrics

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -137,10 +137,12 @@ type NotificationsConfiguration struct {
 
 // MetricsConfiguration holds metrics related configuration
 type MetricsConfiguration struct {
-	Job              string `mapstructure:"job_name" toml:"job_name"`
-	Namespace        string `mapstructure:"namespace" toml:"namespace"`
-	GatewayURL       string `mapstructure:"gateway_url" toml:"gateway_url"`
-	GatewayAuthToken string `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
+	Job              string        `mapstructure:"job_name" toml:"job_name"`
+	Namespace        string        `mapstructure:"namespace" toml:"namespace"`
+	GatewayURL       string        `mapstructure:"gateway_url" toml:"gateway_url"`
+	GatewayAuthToken string        `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
+	Retries          int           `mapstructure:"retries" toml:"retries"`
+	RetryAfter       time.Duration `mapstructure:"retry_after" toml:"retry_after"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ debug = true
 log_level = "info"
 
 [kafka_broker]
-address = "kafka:9092" #provide in deployment env or as secret
+address = "kafka:29092" #provide in deployment env or as secret
 topic = "platform.notifications.ingress" #provide in deployment env or as secret
 timeout = "60s"
 
@@ -31,6 +31,8 @@ job_name = "ccx_notification_service"
 namespace = "ccx_notification_service"
 gateway_url = "localhost:9091"
 gateway_auth_token = ""
+retries = 3
+retry_after = "60s"
 
 [cleaner]
 max_age = "90 days"

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -623,8 +623,8 @@ func pushMetrics(metricsConf conf.MetricsConfiguration) {
 				log.Info().Msg("Metrics pushed successfully. Terminating notification service successfully.")
 				return
 			}
+			log.Err(err).Msg(metricsPushFailedMessage)
 		}
-		log.Err(err).Msg(metricsPushFailedMessage)
 		os.Exit(ExitStatusMetricsError)
 	}
 	log.Info().Msg("Metrics pushed successfully. Terminating notification service successfully.")

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -615,6 +615,9 @@ func pushMetrics(metricsConf conf.MetricsConfiguration) {
 	err := PushMetrics(metricsConf)
 	if err != nil {
 		log.Err(err).Msg(metricsPushFailedMessage)
+		if metricsConf.RetryAfter == 0 || metricsConf.Retries == 0 {
+			os.Exit(ExitStatusMetricsError)
+		}
 		for i := metricsConf.Retries; i > 0; i-- {
 			time.Sleep(metricsConf.RetryAfter)
 			log.Info().Msgf("Push metrics. Retrying (%d/%d attempts left)", i, metricsConf.Retries)


### PR DESCRIPTION
# Description

Sometimes, the CCX Notification service cronjob exits with an error, when what happens is that the metrics couldn't be pushed. With this change, a retrial mechanism can be enabled (number of attempts and how much to wait between each attempt).

Fixes CCXDEV-6557

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Tested locally with prometheus push gateway (available, not available, and returning 502)

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
