### PR TITLE
Performance optimizitations round 1

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -33,7 +33,7 @@ import (
 
 // Messages
 const (
-	clusterName = "cluster"
+	clusterName   = "cluster"
 	resolutionKey = "resolution"
 	resolutionMsg = "Should notify user"
 
@@ -148,7 +148,7 @@ func IssueNotInReport(oldReport types.Report, issue types.ReportItem) bool {
 		}
 	}
 
-	log.Info().Msg("New report does not contain the new issue")
+	log.Info().Msg("Old report does not contain the new issue")
 	return true
 }
 

--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -34,6 +34,8 @@ import (
 // Messages
 const (
 	clusterName = "cluster"
+	resolutionKey = "resolution"
+	resolutionMsg = "Should notify user"
 
 	notificationTypeInstant = "instant"
 	notificationTypeWeekly  = "weekly"
@@ -74,7 +76,7 @@ func shouldNotify(storage Storage, cluster types.ClusterEntry, issue types.Repor
 		log.Error().Err(err).Str(clusterName, string(cluster.ClusterName)).Msg("Read last report failed")
 	}
 	if len(reported) == 0 {
-		log.Info().Bool("resolution", true).Msg("Should notify user")
+		log.Info().Bool(resolutionKey, true).Msg(resolutionMsg)
 		return true
 	}
 
@@ -89,7 +91,7 @@ func shouldNotify(storage Storage, cluster types.ClusterEntry, issue types.Repor
 	}
 
 	notify := IssueNotInReport(oldReport, issue)
-	log.Info().Bool("resolution", notify).Msg("Should notify user")
+	log.Info().Bool(resolutionKey, notify).Msg(resolutionMsg)
 	return notify
 }
 

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -235,16 +235,11 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 			continue
 		}
 
-		notifiedAt := types.Timestamp(time.Now())
-		if !shouldNotify(storage, cluster, deserialized) {
-			updateNotificationRecordSameState(storage, cluster, report, notifiedAt)
-			continue
-		}
-
 		// if new report differs from the older one -> send notification
 		log.Info().Str(clusterName, string(cluster.ClusterName)).Msg("Different report from the last one")
 
 		notificationMsg := generateInstantNotificationMessage(&notificationClusterDetailsURI, fmt.Sprint(cluster.AccountNumber), string(cluster.ClusterName))
+		notifiedAt := types.Timestamp(time.Now())
 
 		for i, r := range deserialized.Reports {
 			module := r.Module
@@ -262,6 +257,9 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 				Int(totalRiskAttribute, totalRisk).
 				Msg("Report")
 			if totalRisk >= totalRiskThreshold {
+				if !shouldNotify(storage, cluster, r) {
+					continue
+				}
 				ReportWithHighImpact.Inc()
 				log.Warn().Int(totalRiskAttribute, totalRisk).Msg("Report with high impact detected")
 				notificationPayloadURL := generateNotificationPayloadURL(&notificationRuleDetailsURI, string(cluster.ClusterName), module, errorKey)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -173,10 +173,6 @@ func showConfiguration(config conf.ConfigStruct) {
 		Msg("Metrics configuration")
 }
 
-func calculateTotalRisk(impact, likelihood int) int {
-	return (impact + likelihood) / 2
-}
-
 // ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report
 // ->
 // cluster_wide_proxy_auth_check
@@ -195,12 +191,11 @@ func findRuleByNameAndErrorKey(
 	ruleContent types.RulesMap, ruleName types.RuleName, errorKey types.ErrorKey) (
 	likelihood int, impact int, totalRisk int, description string) {
 	rc := ruleContent[string(ruleName)]
-	ek := rc.ErrorKeys
-	val := ek[string(errorKey)]
-	likelihood = val.Metadata.Likelihood
-	description = val.Metadata.Description
-	impact = val.Metadata.Impact.Impact
-	totalRisk = calculateTotalRisk(likelihood, impact)
+	ek := rc.ErrorKeys[string(errorKey)]
+	likelihood = ek.Metadata.Likelihood
+	description = ek.Metadata.Description
+	impact = ek.Metadata.Impact.Impact
+	totalRisk = ek.TotalRisk
 	return
 }
 

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -166,10 +166,6 @@ func showConfiguration(config conf.ConfigStruct) {
 		Str("Rule details URI", notificationConfig.RuleDetailsURI).
 		Msg("Notifications configuration")
 
-	notificationClusterDetailsURI = notificationConfig.ClusterDetailsURI
-	notificationRuleDetailsURI = notificationConfig.RuleDetailsURI
-	notificationInsightsAdvisorURL = notificationConfig.InsightsAdvisorURL
-
 	metricsConfig := conf.GetMetricsConfiguration(config)
 
 	// Authentication token and metrics groups values are omitted on
@@ -177,6 +173,8 @@ func showConfiguration(config conf.ConfigStruct) {
 	log.Info().
 		Str("Namespace", metricsConfig.Namespace).
 		Str("Push Gateway", metricsConfig.GatewayURL).
+		Int("Retries", metricsConfig.Retries).
+		Str("Retry after", metricsConfig.RetryAfter.String()).
 		Msg("Metrics configuration")
 }
 
@@ -648,7 +646,10 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage) {
 	log.Info().Msg(separator)
 	log.Info().Msg("Read cluster list")
 
-	//TODO: Set notificationConfig global variables here to avoid passing so much parameters
+	notifConfig := conf.GetNotificationsConfiguration(config)
+	notificationClusterDetailsURI = notifConfig.ClusterDetailsURI
+	notificationRuleDetailsURI = notifConfig.RuleDetailsURI
+	notificationInsightsAdvisorURL = notifConfig.InsightsAdvisorURL
 
 	setupNotificationStates(storage)
 	setupNotificationTypes(storage)

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -341,7 +341,7 @@ func (storage DBStorage) ReadStates() ([]types.State, error) {
 func (storage DBStorage) ReadClusterList() ([]types.ClusterEntry, error) {
 	var clusterList = make([]types.ClusterEntry, 0)
 
-	rows, err := storage.connection.Query( `
+	rows, err := storage.connection.Query(`
 		SELECT DISTINCT ON (cluster)
 		org_id, account_number, cluster, kafka_offset, updated_at
 		FROM new_reports

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -341,7 +341,11 @@ func (storage DBStorage) ReadStates() ([]types.State, error) {
 func (storage DBStorage) ReadClusterList() ([]types.ClusterEntry, error) {
 	var clusterList = make([]types.ClusterEntry, 0)
 
-	rows, err := storage.connection.Query("SELECT org_id, account_number, cluster, kafka_offset, updated_at FROM new_reports ORDER BY updated_at")
+	rows, err := storage.connection.Query( `
+		SELECT DISTINCT ON (cluster)
+		org_id, account_number, cluster, kafka_offset, updated_at
+		FROM new_reports
+		ORDER BY cluster, updated_at DESC`)
 	if err != nil {
 		return clusterList, err
 	}


### PR DESCRIPTION
# Description

This service is taking way more time than expected when dealing with our production data. These "small" optimisations aim to improve its performance  by reducing to a minimum the amount of work done. The idea is to decide if there is a need to introduce concurrency  AFTER verifying the improvements in production.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)

## Testing steps

- Updated existing UTs and validated new behaviour through previously tested scenarios 
- `make bdd_tests` passes
- Each commit of this PR has been tested and benchmarked separately to see if it optimises the processing or not.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
