### PR TITLE
Restore total risk calculation

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -178,6 +178,10 @@ func showConfiguration(config conf.ConfigStruct) {
 		Msg("Metrics configuration")
 }
 
+func calculateTotalRisk(impact, likelihood int) int {
+	return (impact + likelihood) / 2
+}
+
 // ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report
 // ->
 // cluster_wide_proxy_auth_check
@@ -196,11 +200,12 @@ func findRuleByNameAndErrorKey(
 	ruleContent types.RulesMap, ruleName types.RuleName, errorKey types.ErrorKey) (
 	likelihood int, impact int, totalRisk int, description string) {
 	rc := ruleContent[string(ruleName)]
-	ek := rc.ErrorKeys[string(errorKey)]
-	likelihood = ek.Metadata.Likelihood
-	description = ek.Metadata.Description
-	impact = ek.Metadata.Impact.Impact
-	totalRisk = ek.TotalRisk
+	ek := rc.ErrorKeys
+	val := ek[string(errorKey)]
+	likelihood = val.Metadata.Likelihood
+	description = val.Metadata.Description
+	impact = val.Metadata.Impact.Impact
+	totalRisk = calculateTotalRisk(likelihood, impact)
 	return
 }
 

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -363,6 +363,29 @@ func TestShowConfiguration(t *testing.T) {
 }
 
 //---------------------------------------------------------------------------------------
+func TestTotalRiskCalculation(t *testing.T) {
+	type testStruct struct {
+		impact       int
+		likelihood   int
+		expectedRisk int
+	}
+	testVals := []testStruct{
+		{0, 0, 0},
+		{3, 1, 2},
+		{1, 0, 0},
+		{0, 3, 1},
+		{2, 2, 2},
+		{3, 1, 2},
+		{2, 3, 2},
+		{3, 3, 3},
+		{4, 3, 3},
+		{3, 4, 3},
+	}
+    for _, item := range testVals {
+		assert.Equal(t, item.expectedRisk, calculateTotalRisk(item.impact, item.likelihood))
+    }
+}
+
 func TestModuleNameToRuleNameValidRuleName(t *testing.T) {
 	moduleName := types.ModuleName("ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check.report")
 	ruleName := types.RuleName("cluster_wide_proxy_auth_check")

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -381,9 +381,9 @@ func TestTotalRiskCalculation(t *testing.T) {
 		{4, 3, 3},
 		{3, 4, 3},
 	}
-    for _, item := range testVals {
+	for _, item := range testVals {
 		assert.Equal(t, item.expectedRisk, calculateTotalRisk(item.impact, item.likelihood))
-    }
+	}
 }
 
 func TestModuleNameToRuleNameValidRuleName(t *testing.T) {
@@ -505,7 +505,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
-			TotalRisk: 2,
 		},
 		"RULE_2": {
 			Metadata: utypes.ErrorKeyMetadata{
@@ -517,7 +516,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 				Likelihood: 3,
 			},
 			HasReason: false,
-			TotalRisk: 2,
 		},
 	}
 
@@ -678,7 +676,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
-			TotalRisk: 3,
 		},
 		"RULE_2": {
 			Metadata: utypes.ErrorKeyMetadata{
@@ -690,7 +687,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 				Likelihood: 3,
 			},
 			HasReason: false,
-			TotalRisk: 3,
 		},
 	}
 
@@ -870,7 +866,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
-			TotalRisk: 4,
 		},
 		"RULE_2": {
 			Metadata: utypes.ErrorKeyMetadata{
@@ -882,7 +877,6 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 				Likelihood: 4,
 			},
 			HasReason: false,
-			TotalRisk: 4,
 		},
 	}
 
@@ -1202,7 +1196,6 @@ func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
 			},
 			Reason:    "rule 1 reason",
 			HasReason: true,
-			TotalRisk: 4,
 		},
 		"RULE_2": {
 			Metadata: utypes.ErrorKeyMetadata{
@@ -1214,7 +1207,6 @@ func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
 				Likelihood: 4,
 			},
 			HasReason: false,
-			TotalRisk: 4,
 		},
 	}
 


### PR DESCRIPTION
# Description

The total risk of a given issue still needs to be calculated. The field added to the error key structure is just a placeholder that is currently being filled by the smart-proxy, not the insights-content-service itself.

(Fix issue detected in stage env when delivered)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Local testing + UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
