### PR TITLE
Compare current reports with reports with state=sent from reported

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -95,8 +95,8 @@ func getNotificationResolution(issue types.ReportItem, record types.Notification
 }
 
 func shouldNotify(storage Storage, cluster types.ClusterEntry, issue types.ReportItem) bool {
-	// check if the issue of the given cluster has previously be reported
-	reported, err := storage.ReadLastNNotificationRecords(cluster, 1)
+	// check if the issue of the given cluster has previously been reported
+	reported, err := storage.ReadLastNNotifiedRecords(cluster, 1)
 	if err != nil {
 		log.Error().Err(err).Str(clusterName, string(cluster.ClusterName)).Msg("Read last report failed")
 	}

--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -84,7 +84,8 @@ func getNotificationResolution(issue types.ReportItem, record types.Notification
 	if !resolution {
 		log.Info().Msg("Issue already notified in previous report")
 		// Issue is in previous report, let's see if we should notify again since cooldown has passed
-		elapsedSinceLastNotification := time.Now().Sub(time.Time(record.NotifiedAt))
+		_, tzOffset := time.Now().Zone()
+		elapsedSinceLastNotification := time.Now().Sub(time.Time(record.NotifiedAt).Add(-time.Second * time.Duration(tzOffset)))
 		resolution = elapsedSinceLastNotification >= notificationCooldown
 		log.Info().
 			Time("Last notification", time.Time(record.NotifiedAt)).

--- a/differ/comparator_test.go
+++ b/differ/comparator_test.go
@@ -418,9 +418,12 @@ func TestShouldNotifyPreviousRecordForGivenClusterIsIdenticalCooldownNotPassed(t
 			},
 		},
 	}
+
+	notificationCooldown = 61 * time.Minute
 	for _, issue := range newReport.Reports {
 		assert.False(t, shouldNotify(&storage, testCluster, issue))
 	}
+	notificationCooldown = 0
 }
 
 func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
@@ -545,7 +548,7 @@ func TestGetNotificationResolutionIssueInOldRecordDifferentDetails(t *testing.T)
 }
 
 func TestGetNotificationResolutionIssueInOldRecord(t *testing.T) {
-	notificationCooldown = time.Duration(time.Hour)
+	notificationCooldown = 61 * time.Minute
 
 	record := types.NotificationRecord{
 		OrgID:              testCluster.OrgID,

--- a/differ/comparator_test.go
+++ b/differ/comparator_test.go
@@ -358,7 +358,7 @@ func TestIssueNotInReportLessItemsInNewReportAndIssueFoundInOldReports(t *testin
 
 func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 	storage := mocks.Storage{}
-	storage.On("ReadLastNNotificationRecords",
+	storage.On("ReadLastNNotifiedRecords",
 		mock.AnythingOfType("types.ClusterEntry"),
 		mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
@@ -386,7 +386,7 @@ func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 
 func TestShouldNotifyPreviousRecordForGivenClusterIsIdenticalCooldownNotPassed(t *testing.T) {
 	storage := mocks.Storage{}
-	storage.On("ReadLastNNotificationRecords",
+	storage.On("ReadLastNNotifiedRecords",
 		mock.AnythingOfType("types.ClusterEntry"),
 		mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
@@ -425,7 +425,7 @@ func TestShouldNotifyPreviousRecordForGivenClusterIsIdenticalCooldownNotPassed(t
 
 func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
 	storage := mocks.Storage{}
-	storage.On("ReadLastNNotificationRecords",
+	storage.On("ReadLastNNotifiedRecords",
 		mock.AnythingOfType("types.ClusterEntry"),
 		mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
@@ -464,7 +464,7 @@ func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
 
 func TestShouldNotifyIssueNotFoundInPreviousRecords(t *testing.T) {
 	storage := mocks.Storage{}
-	storage.On("ReadLastNNotificationRecords",
+	storage.On("ReadLastNNotifiedRecords",
 		mock.AnythingOfType("types.ClusterEntry"),
 		mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -1115,7 +1115,7 @@ func TestProcessClustersAllIssuesAlreadyNotified(t *testing.T) {
 					ClusterName:        "a cluster",
 					UpdatedAt:          types.Timestamp(time.Now().Add(1 * time.Hour)),
 					NotificationTypeID: 0,
-					StateID:            0,
+					StateID:            1,
 					Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_1|RULE_1\",\"component\":\"ccx_rules_ocp.external.rules.rule_1.report\",\"type\":\"rule\",\"key\":\"RULE_1\",\"details\":\"some details\"}]}",
 					NotifiedAt:         types.Timestamp(time.Now().Add(1 * time.Hour)),
 					ErrorLog:           "",
@@ -1139,16 +1139,16 @@ func TestProcessClustersAllIssuesAlreadyNotified(t *testing.T) {
 	)
 
 	notificationType = types.InstantNotif
-
+	notificationCooldown = 24 * time.Hour
 	processClusters(ruleContent, &storage, clusters)
-
+	notificationCooldown = 0
 	assert.Contains(t, buf.String(), "{\"level\":\"info\",\"message\":\"No new issues to notify for cluster first_cluster\"}\n", "Notification already sent for first_cluster's report, but corresponding log not found.")
 	assert.Contains(t, buf.String(), "{\"level\":\"info\",\"message\":\"No new issues to notify for cluster second_cluster\"}\n", "Notification already sent for second_cluster's report, but corresponding log not found.")
 
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
 }
 
-func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
+func TestProcessClustersSomeIssuesAlreadyNotified(t *testing.T) {
 	buf := new(bytes.Buffer)
 	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
@@ -1270,7 +1270,7 @@ func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
 					ClusterName:        "a cluster",
 					UpdatedAt:          types.Timestamp(testTimestamp),
 					NotificationTypeID: 0,
-					StateID:            0,
+					StateID:            1,
 					Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_1|RULE_1\",\"component\":\"ccx_rules_ocp.external.rules.rule_1.report\",\"type\":\"rule\",\"key\":\"RULE_4\",\"details\":\"some details\"}]}",
 					NotifiedAt:         types.Timestamp(testTimestamp.Add(-2)),
 					ErrorLog:           "",

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -567,7 +567,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 			return nil
 		},
 	)
-	storage.On("ReadLastNNotificationRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
+	storage.On("ReadLastNNotifiedRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
 			return []types.NotificationRecord{
 				{
@@ -738,7 +738,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 			return nil
 		},
 	)
-	storage.On("ReadLastNNotificationRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
+	storage.On("ReadLastNNotifiedRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
 			// Return a record that is different from the one that will be processed so notification is sent
 			return []types.NotificationRecord{
@@ -928,7 +928,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 			return nil
 		},
 	)
-	storage.On("ReadLastNNotificationRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
+	storage.On("ReadLastNNotifiedRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
 			return []types.NotificationRecord{
 				{
@@ -1105,7 +1105,7 @@ func TestProcessClustersAllIssuesAlreadyNotified(t *testing.T) {
 			return nil
 		},
 	)
-	storage.On("ReadLastNNotificationRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
+	storage.On("ReadLastNNotifiedRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
 			// Return the same record, therefore notification message should not beproduced
 			return []types.NotificationRecord{
@@ -1258,7 +1258,7 @@ func TestProcessClustersSomeIssuesAlreadyReported(t *testing.T) {
 			return nil
 		},
 	)
-	storage.On("ReadLastNNotificationRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
+	storage.On("ReadLastNNotifiedRecords", mock.AnythingOfType("types.ClusterEntry"), mock.AnythingOfType("int")).Return(
 		func(clusterEntry types.ClusterEntry, numberOfRecords int) []types.NotificationRecord {
 			// We return three reports, one of them is in the
 			// report, and the others are not -> issues should be

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -64,7 +64,7 @@ type Storage interface {
 		orgID types.OrgID, clusterName types.ClusterName,
 		offset types.KafkaOffset) (types.ClusterReport, error,
 	)
-	ReadLastNNotificationRecords(
+	ReadLastNNotifiedRecords(
 		clusterEntry types.ClusterEntry,
 		numberOfRecords int) ([]types.NotificationRecord, error)
 	WriteNotificationRecord(
@@ -523,16 +523,15 @@ func (storage DBStorage) WriteNotificationRecordForCluster(
 		notifiedAt, errorLog)
 }
 
-// ReadLastNNotificationRecords method returns the last N notification records
-// for given org ID and cluster name.
-func (storage DBStorage) ReadLastNNotificationRecords(clusterEntry types.ClusterEntry,
+// ReadLastNNotifiedRecords method returns the last N notification records
+// with state = 'sent' for given org ID and cluster name.
+func (storage DBStorage) ReadLastNNotifiedRecords(clusterEntry types.ClusterEntry,
 	numberOfRecords int) ([]types.NotificationRecord, error) {
 	var notificationRecords = make([]types.NotificationRecord, 0)
 
-	query := `
-                  select org_id, account_number, cluster, notification_type, state, report, updated_at, notified_at, error_log
+	query := `select org_id, account_number, cluster, notification_type, state, report, updated_at, notified_at, error_log
 		    from reported
-		   where org_id = $1 and cluster = $2
+		   where org_id = $1 and cluster = $2 and state = 1
 		   order by notified_at desc
 		   limit $3;
 		   `

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -61,8 +61,8 @@ func (_m *Storage) ReadClusterList() ([]types.ClusterEntry, error) {
 	return r0, r1
 }
 
-// ReadLastNNotificationRecords provides a mock function with given fields: clusterEntry, numberOfRecords
-func (_m *Storage) ReadLastNNotificationRecords(clusterEntry types.ClusterEntry, numberOfRecords int) ([]types.NotificationRecord, error) {
+// ReadLastNNotifiedRecords provides a mock function with given fields: clusterEntry, numberOfRecords
+func (_m *Storage) ReadLastNNotifiedRecords(clusterEntry types.ClusterEntry, numberOfRecords int) ([]types.NotificationRecord, error) {
 	ret := _m.Called(clusterEntry, numberOfRecords)
 
 	var r0 []types.NotificationRecord


### PR DESCRIPTION
# Description

This commit includes two fixes:
- When comparing timestamp from time.Now() with the timestamp stored in the database, there is a discrepancy created by the fact that time.Now() contains the local timezone info, while the other timestamp does not.
- When comparing current issues with previously notified reports, we should compare with the latest entry with `state=sent`.

Fixes CCXDEV-7026

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Updated corresponding UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
