### PR TITLE
Fix broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Notification templates used to send e-mails etc. to customers are stored in diff
 [https://github.com/RedHatInsights/notifications-backend/](https://github.com/RedHatInsights/notifications-backend/)
 
 Templates used by this notification service are available at:
-[https://github.com/RedHatInsights/notifications-backend/tree/master/backend/src/main/resources/templates/AdvisorOpenshift](https://github.com/RedHatInsights/notifications-backend/tree/master/backend/src/main/resources/templates/AdvisorOpenshift)
+[https://github.com/RedHatInsights/notifications-backend/tree/master/backend/src/main/resources/templates/AdvisorOpenshift](https://github.com/RedHatInsights/notifications-backend/tree/master/engine/src/main/resources/templates/AdvisorOpenshift)
 
 ## Package manifest
 


### PR DESCRIPTION
# Description

I think the url has changed from `backend` to `engine`.

## Type of change

- Documentation update

## Testing steps

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
