### PR TITLE
[CCXDEV-7402] Fix random cpu limit on stage

### DIFF
--- a/deploy/ccx-notification-service.yaml
+++ b/deploy/ccx-notification-service.yaml
@@ -32,6 +32,8 @@ objects:
     failedJobsHistoryLimit: 3
     jobTemplate:
       spec:
+        # In PROD 1 cronjob takes around 45 min. Deadline set to 60 mins.
+        activeDeadlineSeconds: 3600
         template:
           spec:
             containers:


### PR DESCRIPTION
# Description

In stage env our completed cronjobs are counted into the CPU/mem quota. To not count the cronjobs into the quota, we need to use activeDeadlineSeconds for cronjobs to not count the completed jobs into quota.

The activeDeadlineSeconds stops a pod after the specified timeout if it does not complete earlier.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
