### PR TITLE
[CCXDEV-8800] Include org_id field in the generated event for instant reports

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -241,7 +241,11 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 			continue
 		}
 
-		notificationMsg := generateInstantNotificationMessage(&notificationClusterDetailsURI, fmt.Sprint(cluster.AccountNumber), string(cluster.ClusterName))
+		notificationMsg := generateInstantNotificationMessage(
+			&notificationClusterDetailsURI,
+			fmt.Sprint(cluster.AccountNumber),
+			fmt.Sprint(cluster.OrgID),
+			string(cluster.ClusterName))
 		notifiedAt := types.Timestamp(time.Now())
 
 		for _, r := range deserialized.Reports {
@@ -419,7 +423,7 @@ func setupNotificationProducer(brokerConfig conf.KafkaConfiguration) {
 // generateInstantNotificationMessage function generates a notification message
 // container with no events for a given account+cluster
 func generateInstantNotificationMessage(
-	clusterURI *string, accountID string, clusterID string) (
+	clusterURI *string, accountID, orgID, clusterID string) (
 	notification types.NotificationMessage) {
 	events := []types.Event{}
 	context := toJSONEscapedString(types.NotificationContext{
@@ -437,6 +441,7 @@ func generateInstantNotificationMessage(
 		EventType:   types.InstantNotif.ToString(),
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
 		AccountID:   accountID,
+		OrgID:       orgID,
 		Events:      events,
 		Context:     context,
 	}

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -123,9 +123,10 @@ func TestToJSONEscapedStringInvalidJSON(t *testing.T) {
 func TestGenerateInstantReportNotificationMessage(t *testing.T) {
 	clusterURI := "the_cluster_uri_in_ocm_for_{cluster_id}"
 	accountID := "a_stringified_account_id"
+	orgID := "a_stringified_org_id"
 	clusterID := "the_displayed_cluster_ID"
 
-	notificationMsg := generateInstantNotificationMessage(&clusterURI, accountID, clusterID)
+	notificationMsg := generateInstantNotificationMessage(&clusterURI, accountID, orgID, clusterID)
 
 	assert.NotEmpty(t, notificationMsg, "the generated notification message is empty")
 	assert.Empty(t, notificationMsg.Events, "the generated notification message should not have any events")
@@ -134,13 +135,15 @@ func TestGenerateInstantReportNotificationMessage(t *testing.T) {
 	assert.Equal(t, notificationBundleName, notificationMsg.Bundle, "Generated notifications should indicate 'openshift' as bundle")
 	assert.Equal(t, notificationApplicationName, notificationMsg.Application, "Generated notifications should indicate 'openshift' as application name")
 	assert.Equal(t, accountID, notificationMsg.AccountID, "Generated notifications does not have expected account ID")
+	assert.Equal(t, orgID, notificationMsg.OrgID, "Generated notifications does not have expected org ID")
 }
 
 func TestAppendEventsToExistingInstantReportNotificationMsg(t *testing.T) {
 	clusterURI := "the_cluster_uri_in_ocm"
 	accountID := "a_stringified_account_id"
+	orgID := "a_stringified_org_id"
 	clusterID := "the_displayed_cluster_ID"
-	notificationMsg := generateInstantNotificationMessage(&clusterURI, accountID, clusterID)
+	notificationMsg := generateInstantNotificationMessage(&clusterURI, accountID, orgID, clusterID)
 
 	assert.Empty(t, notificationMsg.Events, "the generated notification message should not have any events")
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ The "end-to-end" data flow is described there (including Notification Writer ser
 1. `ccx-notification-writer` service stores insights results into AWS RDS database into `new_reports` table.
 1. Content of that table is consumed by `ccx-notification-service` periodically.
 1. Newest results from `new_reports` table is compared with results stored in `reported` table.
-1. If changes (new issues) has been found, notification message is sent into Kafka topic named `platform.notifications.ingress`.
+1. If changes (new issues) has been found, notification message is sent into Kafka topic named `platform.notifications.ingress`. The expected format of the message can be found [here](https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/send-notification.html#_kafka).
 1. New issues is also sent to Service Log via REST API
 1. The newest result is stored into `reported` table to be used in the next `ccx-notification-service` iteration.
 

--- a/types/types.go
+++ b/types/types.go
@@ -213,6 +213,7 @@ type NotificationMessage struct {
 	EventType   string  `json:"event_type"`
 	Timestamp   string  `json:"timestamp"`
 	AccountID   string  `json:"account_id"`
+	OrgID       string  `json:"org_id"`
 	Events      []Event `json:"events"`
 	Context     string  `json:"context"`
 }


### PR DESCRIPTION
# Description

As part of the EBS account number deprecation, the notification backend is currently requiring its clients to send both the org_id and the account number (account number will be removed later).

([We have a Kafka message example with the org ID field here](https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/send-notification.html#_kafka))


## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

Added UTs + run service locally with all dependencies to check behavior

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
