### PR TITLE
[CCXDEV-8784] Update job name

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -18,7 +18,7 @@ objects:
     testing:
       iqePlugin: ccx
     jobs:
-      - name: instance
+      - name: to-notification-backend
         schedule: ${JOB_SCHEDULE}
         restartPolicy: Never
         concurrencyPolicy: Forbid


### PR DESCRIPTION
# Description

Update the job name. Instead of `instance`, let's call it `to-notification-backend`. This way, the job name in OCP will be 

```ccx-notification-service-to-notifications-backend-{TIMESTAMP}``` 

instead of 

```ccx-notification-service-instance-{TIMESTAMP}```

This will be useful for having more than 1 jobs under this clowdapp (f.e [integration with service log](https://issues.redhat.com/browse/CCXDEV-8370)).

Fixes #[CCXDEV-8784](https://issues.redhat.com/browse/CCXDEV-8784)

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

None.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
