### PR TITLE
Fix kafka producer's total risk threshold config

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -131,7 +131,7 @@ var (
 	notificationClusterDetailsURI  string
 	notificationRuleDetailsURI     string
 	notificationInsightsAdvisorURL string
-	totalRiskThreshold             int = DefaultTotalRiskThreshold
+	totalRiskThreshold             int
 	previouslyReported             types.NotifiedRecordsPerCluster
 	eventFilter                    string = DefaultEventFilter
 )
@@ -708,14 +708,15 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage) {
 	notificationRuleDetailsURI = notifConfig.RuleDetailsURI
 	notificationInsightsAdvisorURL = notifConfig.InsightsAdvisorURL
 	totalRiskThreshold = conf.GetKafkaBrokerConfiguration(config).TotalRiskThreshold
+	if totalRiskThreshold == 0 {
+		totalRiskThreshold = DefaultTotalRiskThreshold
+	}
 	eventFilter = conf.GetKafkaBrokerConfiguration(config).EventFilter
-
 	if eventFilter == "" {
 		err := fmt.Errorf("Configuration problem")
 		log.Err(err).Msg(eventFilterNotSetMessage)
 		os.Exit(ExitStatusEventFilterError)
 	}
-
 	setupNotificationStates(storage)
 	setupNotificationTypes(storage)
 

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -490,6 +490,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 		},
 	)
 
+	totalRiskThreshold = DefaultTotalRiskThreshold
 	processClusters(ruleContent, &storage, clusters)
 
 	executionLog := buf.String()


### PR DESCRIPTION
# Description

- The clowdapp file must include the total risk threshold configuration for each producer or else it will set it to 0.
- Use the `DefaultTotalRiskThreshold` constant if `total_risk_threshold`  is not configured to a value >= 1.

Fixes #214 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

local run

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
