### PR TITLE
Refactored out filtering

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -128,7 +128,7 @@ const (
 	DefaultEventFilter         = "totalRisk >= totalRiskThreshold"
 )
 
-// EventThreshold structure contains all threshold values for event filter
+// EventThresholds structure contains all threshold values for event filter
 // evaluator
 type EventThresholds struct {
 	TotalRisk  int

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -128,18 +128,37 @@ const (
 	DefaultEventFilter         = "totalRisk >= totalRiskThreshold"
 )
 
+// EventThreshold structure contains all threshold values for event filter
+// evaluator
+type EventThresholds struct {
+	TotalRisk  int
+	Likelihood int
+	Impact     int
+	Severity   int
+}
+
+// EventValue structure contains all event values for event filter evaluator
+type EventValue struct {
+	TotalRisk  int
+	Likelihood int
+	Impact     int
+	Severity   int
+}
+
 var (
 	notificationType               types.EventType
 	notifier                       *producer.KafkaProducer
 	notificationClusterDetailsURI  string
 	notificationRuleDetailsURI     string
 	notificationInsightsAdvisorURL string
-	likelihoodThreshold            int = DefaultLikelihoodThreshold
-	impactThreshold                int = DefaultImpactThreshold
-	severityThreshold              int = DefaultSeverityThreshold
-	totalRiskThreshold             int = DefaultTotalRiskThreshold
-	previouslyReported             types.NotifiedRecordsPerCluster
-	eventFilter                    string = DefaultEventFilter
+	eventThresholds                EventThresholds = EventThresholds{
+		TotalRisk:  DefaultTotalRiskThreshold,
+		Likelihood: DefaultLikelihoodThreshold,
+		Impact:     DefaultImpactThreshold,
+		Severity:   DefaultSeverityThreshold,
+	}
+	previouslyReported types.NotifiedRecordsPerCluster
+	eventFilter        string = DefaultEventFilter
 )
 
 // showVersion function displays version information.
@@ -246,19 +265,18 @@ func findRuleByNameAndErrorKey(
 
 // evaluateFilterExpression function tries to evaluate event filter expression
 // based on provided threshold values and actual reccomendation values
-func evaluateFilterExpression(eventFilter string,
-	likelihoodThreshold int, impactThreshold int, severityThreshold int, totalRiskThreshold int,
-	likelihood int, impact int, totalRisk int) (int, error) {
+func evaluateFilterExpression(eventFilter string, thresholds EventThresholds, eventValue EventValue) (int, error) {
 
 	// values to be passed into expression evaluator
 	values := make(map[string]int)
-	values["likelihoodThreshold"] = likelihoodThreshold
-	values["impactThreshold"] = impactThreshold
-	values["severityThreshold"] = severityThreshold
-	values["totalRiskThreshold"] = totalRiskThreshold
-	values["likelihood"] = likelihood
-	values["impact"] = impact
-	values["totalRisk"] = totalRisk
+	values["likelihoodThreshold"] = thresholds.Likelihood
+	values["impactThreshold"] = thresholds.Impact
+	values["severityThreshold"] = thresholds.Severity
+	values["totalRiskThreshold"] = thresholds.TotalRisk
+	values["likelihood"] = eventValue.Likelihood
+	values["impact"] = eventValue.Impact
+	values["severity"] = eventValue.Severity
+	values["totalRisk"] = eventValue.TotalRisk
 
 	// try to evaluate event filter expression
 	return evaluator.Evaluate(eventFilter, values)
@@ -306,12 +324,15 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 			ruleName := moduleToRuleName(module)
 			errorKey := r.ErrorKey
 			likelihood, impact, totalRisk, description := findRuleByNameAndErrorKey(ruleContent, ruleName, errorKey)
+			eventValue := EventValue{
+				Likelihood: likelihood,
+				Impact:     impact,
+				TotalRisk:  totalRisk,
+			}
 
 			// try to evaluate event filter expression
 			result, err := evaluateFilterExpression(eventFilter,
-				likelihoodThreshold, impactThreshold,
-				severityThreshold, totalRiskThreshold, likelihood,
-				impact, totalRisk)
+				eventThresholds, eventValue)
 
 			if err != nil {
 				log.Err(err).Msg(evaluationErrorMessage)
@@ -736,10 +757,10 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage) {
 	notificationClusterDetailsURI = notifConfig.ClusterDetailsURI
 	notificationRuleDetailsURI = notifConfig.RuleDetailsURI
 	notificationInsightsAdvisorURL = notifConfig.InsightsAdvisorURL
-	likelihoodThreshold = conf.GetKafkaBrokerConfiguration(config).LikelihoodThreshold
-	impactThreshold = conf.GetKafkaBrokerConfiguration(config).ImpactThreshold
-	severityThreshold = conf.GetKafkaBrokerConfiguration(config).SeverityThreshold
-	totalRiskThreshold = conf.GetKafkaBrokerConfiguration(config).TotalRiskThreshold
+	eventThresholds.Likelihood = conf.GetKafkaBrokerConfiguration(config).LikelihoodThreshold
+	eventThresholds.Impact = conf.GetKafkaBrokerConfiguration(config).ImpactThreshold
+	eventThresholds.Severity = conf.GetKafkaBrokerConfiguration(config).SeverityThreshold
+	eventThresholds.TotalRisk = conf.GetKafkaBrokerConfiguration(config).TotalRiskThreshold
 	eventFilter = conf.GetKafkaBrokerConfiguration(config).EventFilter
 
 	if eventFilter == "" {

--- a/differ/evaluator_test.go
+++ b/differ/evaluator_test.go
@@ -117,3 +117,89 @@ func TestEvaluatorIncorrectExpression(t *testing.T) {
 		}
 	}
 }
+
+type TestCase struct {
+	name          string
+	expression    string
+	expectedValue int
+	expectedError bool
+}
+
+// TestEvaluatorRelational checks the evaluator.Evaluate function for simple
+// relational expression
+func TestEvaluatorRelational(t *testing.T) {
+	testCases := []TestCase{
+		{
+			name:          "less than",
+			expression:    "totalRisk < totalRiskThreshold",
+			expectedValue: 1,
+		},
+		{
+			name:          "less then or equal",
+			expression:    "totalRisk <= totalRiskThreshold",
+			expectedValue: 1,
+		},
+		{
+			name:          "equal",
+			expression:    "totalRisk == totalRiskThreshold",
+			expectedValue: 0,
+		},
+		{
+			name:          "greater or equal",
+			expression:    "totalRisk >= totalRiskThreshold",
+			expectedValue: 0,
+		},
+		{
+			name:          "greater than",
+			expression:    "totalRisk > totalRiskThreshold",
+			expectedValue: 0,
+		},
+		{
+			name:          "not equal",
+			expression:    "totalRisk != totalRiskThreshold",
+			expectedValue: 1,
+		},
+		{
+			name:          "arithmetic + less than",
+			expression:    "totalRisk + 1 < totalRiskThreshold",
+			expectedValue: 0,
+		},
+		{
+			name:          "arithmetic + less then or equal",
+			expression:    "totalRisk + 1 <= totalRiskThreshold",
+			expectedValue: 1,
+		},
+		{
+			name:          "arithmetic + equal",
+			expression:    "totalRisk + 1 == totalRiskThreshold",
+			expectedValue: 1,
+		},
+		{
+			name:          "arithmetic + greater or equal",
+			expression:    "totalRisk + 1 >= totalRiskThreshold",
+			expectedValue: 1,
+		},
+		{
+			name:          "arithmetic + greater than",
+			expression:    "totalRisk + 1 > totalRiskThreshold",
+			expectedValue: 0,
+		},
+		{
+			name:          "arithmetic + not equal",
+			expression:    "totalRisk + 1 != totalRiskThreshold",
+			expectedValue: 0,
+		},
+	}
+
+	const totalRiskThreshold = 3
+	const totalRisk = 2
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := evaluateFilterExpression(tc.expression,
+				0, 0, 0, totalRiskThreshold,
+				0, 0, totalRisk)
+			assert.NoError(t, err, "unexpected error")
+			assert.Equal(t, tc.expectedValue, result)
+		})
+	}
+}

--- a/differ/evaluator_test.go
+++ b/differ/evaluator_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEvaluatorDefaultExpression function checks the filter expression
+// evaluator for default expression used by Notification Service
+func TestEvaluatorDefaultExpression(t *testing.T) {
+	const expression = "totalRisk >= totalRiskThreshold"
+	const totalRiskThreshold = 3
+
+	// try all combinations of totalRisk
+	for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+		// try to evaluate the expression
+		result, err := evaluateFilterExpression(expression,
+			0, 0, 0, totalRiskThreshold,
+			0, 0, totalRisk)
+
+		// expression should be evaluated w/o errors
+		assert.NoError(t, err, "Error is not expected there")
+
+		// repeat the expression, but now in Go
+		if totalRisk >= totalRiskThreshold {
+			assert.Equal(t, 1, result, "Result should be 1")
+		} else {
+			assert.Equal(t, 0, result, "Result should be 0")
+		}
+	}
+}
+
+// TestEvaluatorComplicatedExpression function checks the filter expression
+// evaluator for custom expression
+func TestEvaluatorComplicatedExpression(t *testing.T) {
+	const expression = "totalRisk >= totalRiskThreshold && likelihood+2 > likelihoodThreshold"
+	const totalRiskThreshold = 3
+	const likelihoodThreshold = 2
+
+	// try all combinations of likelihood and totalRisk
+	for likelihood := 0; likelihood <= 5; likelihood++ {
+		for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+			// try to evaluate the expression
+			result, err := evaluateFilterExpression(expression,
+				likelihoodThreshold, 0, 0, totalRiskThreshold,
+				likelihood, 0, totalRisk)
+
+			// expression should be evaluated w/o errors
+			assert.NoError(t, err, "Error is not expected there")
+
+			// repeat the expression, but now in Go
+			if totalRisk >= totalRiskThreshold && likelihood+2 > likelihoodThreshold {
+				assert.Equal(t, 1, result, "Result should be 1")
+			} else {
+				assert.Equal(t, 0, result, "Result should be 0")
+			}
+		}
+	}
+}
+
+// TestEvaluatorEmptyExpression function checks the filter expression
+// evaluator for expression that is empty
+func TestEvaluatorEmptyExpression(t *testing.T) {
+	const expression = ""
+	const totalRiskThreshold = 3
+	const likelihoodThreshold = 2
+
+	// try all combinations of likelihood and totalRisk
+	for likelihood := 0; likelihood <= 5; likelihood++ {
+		for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+			// try to evaluate the expression
+			_, err := evaluateFilterExpression(expression,
+				likelihoodThreshold, 0, 0, totalRiskThreshold,
+				likelihood, 0, totalRisk)
+
+			// error should be reported for incorrect expression
+			assert.Error(t, err, "Error is expected there")
+		}
+	}
+}
+
+// TestEvaluatorIncorrectExpression function checks the filter expression
+// evaluator for expression that is not correct
+func TestEvaluatorIncorrectExpression(t *testing.T) {
+	// this is wrong expression
+	const expression = "totalRisk >="
+	const totalRiskThreshold = 3
+	const likelihoodThreshold = 2
+
+	// try all combinations of likelihood and totalRisk
+	for likelihood := 0; likelihood <= 5; likelihood++ {
+		for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+			// try to evaluate the expression
+			_, err := evaluateFilterExpression(expression,
+				likelihoodThreshold, 0, 0, totalRiskThreshold,
+				likelihood, 0, totalRisk)
+
+			// error should be reported for incorrect expression
+			assert.Error(t, err, "Error is expected there")
+		}
+	}
+}

--- a/differ/evaluator_test.go
+++ b/differ/evaluator_test.go
@@ -122,7 +122,6 @@ type TestCase struct {
 	name          string
 	expression    string
 	expectedValue int
-	expectedError bool
 }
 
 // TestEvaluatorRelational checks the evaluator.Evaluate function for simple

--- a/differ/evaluator_test.go
+++ b/differ/evaluator_test.go
@@ -28,12 +28,28 @@ func TestEvaluatorDefaultExpression(t *testing.T) {
 	const expression = "totalRisk >= totalRiskThreshold"
 	const totalRiskThreshold = 3
 
+	thresholds := EventThresholds{
+		Likelihood: 0,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  totalRiskThreshold,
+	}
+
+	eventValue := EventValue{
+		Likelihood: 0,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  3,
+	}
+
 	// try all combinations of totalRisk
 	for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+		// update event value
+		eventValue.TotalRisk = totalRisk
+
 		// try to evaluate the expression
 		result, err := evaluateFilterExpression(expression,
-			0, 0, 0, totalRiskThreshold,
-			0, 0, totalRisk)
+			thresholds, eventValue)
 
 		// expression should be evaluated w/o errors
 		assert.NoError(t, err, "Error is not expected there")
@@ -54,13 +70,30 @@ func TestEvaluatorComplicatedExpression(t *testing.T) {
 	const totalRiskThreshold = 3
 	const likelihoodThreshold = 2
 
+	thresholds := EventThresholds{
+		Likelihood: likelihoodThreshold,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  totalRiskThreshold,
+	}
+
+	eventValue := EventValue{
+		Likelihood: 0,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  0,
+	}
+
 	// try all combinations of likelihood and totalRisk
 	for likelihood := 0; likelihood <= 5; likelihood++ {
 		for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+			// update event value
+			eventValue.TotalRisk = totalRisk
+			eventValue.Likelihood = likelihood
+
 			// try to evaluate the expression
 			result, err := evaluateFilterExpression(expression,
-				likelihoodThreshold, 0, 0, totalRiskThreshold,
-				likelihood, 0, totalRisk)
+				thresholds, eventValue)
 
 			// expression should be evaluated w/o errors
 			assert.NoError(t, err, "Error is not expected there")
@@ -82,13 +115,30 @@ func TestEvaluatorEmptyExpression(t *testing.T) {
 	const totalRiskThreshold = 3
 	const likelihoodThreshold = 2
 
+	thresholds := EventThresholds{
+		Likelihood: likelihoodThreshold,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  totalRiskThreshold,
+	}
+
+	eventValue := EventValue{
+		Likelihood: 0,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  0,
+	}
+
 	// try all combinations of likelihood and totalRisk
 	for likelihood := 0; likelihood <= 5; likelihood++ {
 		for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+			// update event value
+			eventValue.TotalRisk = totalRisk
+			eventValue.Likelihood = likelihood
+
 			// try to evaluate the expression
 			_, err := evaluateFilterExpression(expression,
-				likelihoodThreshold, 0, 0, totalRiskThreshold,
-				likelihood, 0, totalRisk)
+				thresholds, eventValue)
 
 			// error should be reported for incorrect expression
 			assert.Error(t, err, "Error is expected there")
@@ -104,13 +154,30 @@ func TestEvaluatorIncorrectExpression(t *testing.T) {
 	const totalRiskThreshold = 3
 	const likelihoodThreshold = 2
 
+	thresholds := EventThresholds{
+		Likelihood: likelihoodThreshold,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  totalRiskThreshold,
+	}
+
+	eventValue := EventValue{
+		Likelihood: 0,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  0,
+	}
+
 	// try all combinations of likelihood and totalRisk
 	for likelihood := 0; likelihood <= 5; likelihood++ {
 		for totalRisk := 0; totalRisk <= 5; totalRisk++ {
+			// update event value
+			eventValue.TotalRisk = totalRisk
+			eventValue.Likelihood = likelihood
+
 			// try to evaluate the expression
 			_, err := evaluateFilterExpression(expression,
-				likelihoodThreshold, 0, 0, totalRiskThreshold,
-				likelihood, 0, totalRisk)
+				thresholds, eventValue)
 
 			// error should be reported for incorrect expression
 			assert.Error(t, err, "Error is expected there")
@@ -192,11 +259,26 @@ func TestEvaluatorRelational(t *testing.T) {
 
 	const totalRiskThreshold = 3
 	const totalRisk = 2
+
+	thresholds := EventThresholds{
+		Likelihood: 0,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  totalRiskThreshold,
+	}
+
+	eventValue := EventValue{
+		Likelihood: 0,
+		Impact:     0,
+		Severity:   0,
+		TotalRisk:  totalRisk,
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// try to evaluate the expression
 			result, err := evaluateFilterExpression(tc.expression,
-				0, 0, 0, totalRiskThreshold,
-				0, 0, totalRisk)
+				thresholds, eventValue)
 			assert.NoError(t, err, "unexpected error")
 			assert.Equal(t, tc.expectedValue, result)
 		})


### PR DESCRIPTION
# Description

Refactored out filtering

Basically the most important functions in `differ.go` code use global module variables so it's quite hard to cover them correctly by using unit tests. It would be nice to refactore such long and complicated code. This is the first attempt, just for the filter. The refactored function is isolated from global module variables and thus testable.

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
