### PR TITLE
[CCXDEV-8755] Add url, access_token and timeout to service_log configuration

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -137,12 +137,15 @@ type KafkaConfiguration struct {
 
 // ServiceLogConfiguration represents configuration of ServiceLog REST API
 type ServiceLogConfiguration struct {
-	Enabled             bool   `mapstructure:"enabled" toml:"enabled"`
-	LikelihoodThreshold int    `mapstructure:"likelihood_threshold" toml:"likelihood_threshold"`
-	ImpactThreshold     int    `mapstructure:"impact_threshold" toml:"impact_threshold"`
-	SeverityThreshold   int    `mapstructure:"severity_threshold" toml:"severity_threshold"`
-	TotalRiskThreshold  int    `mapstructure:"total_risk_threshold" toml:"total_risk_threshold"`
-	EventFilter         string `mapstructure:"event_filter" toml:"event_filter"`
+	Enabled             bool          `mapstructure:"enabled" toml:"enabled"`
+	AccessToken         string        `mapstructure:"access_token" toml:"access_token"`
+	URL                 string        `mapstructure:"url" toml:"url"`
+	Timeout             time.Duration `mapstructure:"timeout" toml:"timeout"`
+	LikelihoodThreshold int           `mapstructure:"likelihood_threshold" toml:"likelihood_threshold"`
+	ImpactThreshold     int           `mapstructure:"impact_threshold" toml:"impact_threshold"`
+	SeverityThreshold   int           `mapstructure:"severity_threshold" toml:"severity_threshold"`
+	TotalRiskThreshold  int           `mapstructure:"total_risk_threshold" toml:"total_risk_threshold"`
+	EventFilter         string        `mapstructure:"event_filter" toml:"event_filter"`
 }
 
 // NotificationsConfiguration represents the configuration specific to the content of notifications

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -112,6 +112,7 @@ func TestLoadBrokerConfiguration(t *testing.T) {
 // sub-tree
 func TestLoadServiceLogConfiguration(t *testing.T) {
 	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	expectedTimeout, _ := time.ParseDuration("15s")
 
 	mustSetEnv(t, envVar, "../tests/config2")
 	config, err := conf.LoadConfiguration(envVar, "")
@@ -121,6 +122,9 @@ func TestLoadServiceLogConfiguration(t *testing.T) {
 
 	assert.False(t, serviceLogCfg.Enabled)
 	assert.Equal(t, 3, serviceLogCfg.TotalRiskThreshold)
+	assert.Equal(t, "test", serviceLogCfg.AccessToken)
+	assert.Equal(t, "localhost:8000/api/service_logs/v1/cluster_logs/", serviceLogCfg.URL)
+	assert.Equal(t, expectedTimeout, serviceLogCfg.Timeout)
 }
 
 // TestLoadStorageConfiguration tests loading the storage configuration sub-tree

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -15,6 +15,9 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
+access_token = ""
+url = "localhost:8000/api/service_logs/v1/cluster_logs/"
+timeout = "15s"
 likelihood_threshold = 0
 impact_threshold = 0
 severity_threshold = 0

--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,9 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
+access_token = ""
+url = "https://api.openshift.com/api/service_logs/v1/cluster_logs/"
+timeout = "15s"
 likelihood_threshold = 0
 impact_threshold = 0
 severity_threshold = 0

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -11,6 +11,9 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
+access_token = "test"
+url = "localhost:8000/api/service_logs/v1/cluster_logs/"
+timeout = "15s"
 likelihood_threshold = 0
 impact_threshold = 0
 severity_threshold = 0


### PR DESCRIPTION
# Description

Add url, access_token and timeout to service_log configuration.

Fixes #CCXDEV-8755

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

BDD tests: https://github.com/RedHatInsights/insights-behavioral-spec/pull/116

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
