### PR TITLE
Add Service Log integration

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -68,6 +68,10 @@ objects:
             value: http://ccx-insights-content-service:${CONTENT_SERVICE_PORT}/api/v1/
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_ENDPOINT
             value: content
+          - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_SERVER
+            value: http://localhost:8083/
+          - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_ENDPOINT
+            value: rendered_reports
           - name: CCX_NOTIFICATION_SERVICE__NOTIFICATIONS__INSIGHTS_ADVISOR_URL
             value: "https://${PLATFORM_UI_HOSTNAME}/openshift/insights/advisor/clusters/{cluster_id}"
           - name: CCX_NOTIFICATION_SERVICE__NOTIFICATIONS__CLUSTER_DETAILS_URI

--- a/producer/kafka/kafka_producer_test.go
+++ b/producer/kafka/kafka_producer_test.go
@@ -139,7 +139,6 @@ func TestProducerSendNotificationMessageNoEvents(t *testing.T) {
 		Events:      nil,
 		Context:     "{}",
 	}
-
 	msgBytes, err := json.Marshal(msg)
 	helpers.FailOnError(t, err)
 
@@ -225,7 +224,7 @@ func TestProducerSendNotificationMessageMultipleEvents(t *testing.T) {
 func TestProducerSend(t *testing.T) {
 
 	producer, err := sarama.NewSyncProducer([]string{brokerCfg.Address}, nil)
-	kafkaProducer := KafkaProducer{
+	kafkaProducer := Producer{
 		Configuration: brokerCfg,
 		Producer:  producer   ,
 	}


### PR DESCRIPTION
# Description

Adding connection to content template render service. The service is used to interpolate rule description and reason templates with data from reports and the result is sent to the Service Log.

Deployment of the content template renderer service is necessary for the functionality of proposed changes.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

The functionality was tested with locally deployed external data pipeline and debugging prints, as well as with modified tests.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
