### PR TITLE
Make max_age for cleanup configurable in deployment file

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -95,7 +95,7 @@ objects:
           command:
             - /bin/sh
             - -c
-            - ./ccx-notification-service --instant-reports --cleanup-on-startup --max-age '8 days' --verbose
+            - ./ccx-notification-service --instant-reports --cleanup-on-startup --max-age ${CLEANUP_MAX_AGE} --verbose
 
     kafkaTopics:
       - topicName: ${OUTGOING_TOPIC}
@@ -154,3 +154,6 @@ parameters:
   value: '3'
 - name: METRIS_PUSH_RETRIES_COOLDOWN
   value: 60s
+- description: Maximum age for reports cleanup on startup
+  name: CLEANUP_MAX_AGE
+  value: '8 days'


### PR DESCRIPTION
# Description

Make max_age for cleanup configurable in deployment file, so we can configure it in each environment

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
