### PR TITLE
Fix typo in start command

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -95,7 +95,7 @@ objects:
           command:
             - /bin/sh
             - -c
-            - ./ccx-notification-service --instant-reports --cleanup-on-startup --max-age ${CLEANUP_MAX_AGE} --verbose
+            - ./ccx-notification-service --instant-reports --cleanup-on-startup --max-age '${CLEANUP_MAX_AGE}' --verbose
 
     kafkaTopics:
       - topicName: ${OUTGOING_TOPIC}


### PR DESCRIPTION
# Description

Max age is not properly set if not enclosed in quote

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Launched locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
