### PR TITLE
Make producer interface more flexible

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -493,16 +493,16 @@ func processClusters(ruleContent types.RulesMap, storage Storage, clusters []typ
 }
 
 // setupNotificationProducer function creates a kafka producer using the provided configuration
-func setupNotificationProducer(brokerConfig conf.KafkaConfiguration) {
+func setupNotificationProducer(config conf.ConfigStruct) {
 	// broker enable/disable is very important information, let's inform
 	// admins about the state
-	if brokerConfig.Enabled {
+	if conf.GetKafkaBrokerConfiguration(config).Enabled {
 		log.Info().Msg("Broker config for Notification Service is enabled")
 	} else {
 		log.Info().Msg("Broker config for Notification Service is disabled")
 	}
 
-	producer, err := producer.New(brokerConfig)
+	producer, err := producer.New(config)
 	if err != nil {
 		ProducerSetupErrors.Inc()
 		log.Error().
@@ -799,7 +799,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	log.Info().Int("previously reported issues still in cooldown", len(previouslyReported)).Msg("Get previously reported issues: done")
 	log.Info().Msg(separator)
 	log.Info().Msg("Preparing Kafka producer")
-	setupNotificationProducer(conf.GetKafkaBrokerConfiguration(config))
+	setupNotificationProducer(config)
 	log.Info().Msg("Kafka producer ready")
 	log.Info().Msg(separator)
 	log.Info().Msg("Checking new issues for all new reports")

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -333,15 +333,17 @@ func TestModuleNameToRuleNameValidRuleName(t *testing.T) {
 //---------------------------------------------------------------------------------------
 func TestSetupNotificationProducerInvalidBrokerConf(t *testing.T) {
 	if os.Getenv("SETUP_PRODUCER") == "1" {
-		brokerConfig := conf.KafkaConfiguration{
-			Address:     "invalid_address",
-			Topic:       "",
-			Timeout:     0,
-			Enabled:     true,
-			EventFilter: "totalRisk >= totalRiskThreshold",
+		testConfig := conf.ConfigStruct{
+			Kafka: conf.KafkaConfiguration{
+				Address:     "invalid_address",
+				Topic:       "",
+				Timeout:     0,
+				Enabled:     true,
+				EventFilter: "totalRisk >= totalRiskThreshold",
+			},
 		}
 
-		setupNotificationProducer(brokerConfig)
+		setupNotificationProducer(testConfig)
 	}
 	cmd := exec.Command(os.Args[0], "-test.run=TestSetupNotificationProducerInvalidBrokerConf")
 	cmd.Env = append(os.Environ(), "SETUP_PRODUCER=1")
@@ -373,15 +375,17 @@ func TestSetupNotificationProducerValidBrokerConf(t *testing.T) {
 				SetOffset("", brokerCfg.Topic, 0, 0, "", sarama.ErrNoError),
 		})
 
-	testConfig := conf.KafkaConfiguration{
-		Address: mockBroker.Addr(),
-		Topic:   brokerCfg.Topic,
-		Timeout: brokerCfg.Timeout,
-		Enabled: brokerCfg.Enabled,
+	testConfig := conf.ConfigStruct{
+		Kafka: conf.KafkaConfiguration{
+			Address: mockBroker.Addr(),
+			Topic:   brokerCfg.Topic,
+			Timeout: brokerCfg.Timeout,
+			Enabled: brokerCfg.Enabled,
+		},
 	}
 
 	kafkaProducer := producer.KafkaProducer{
-		Configuration: testConfig,
+		Configuration: conf.GetKafkaBrokerConfiguration(testConfig),
 		Producer:      nil,
 	}
 

--- a/producer/kafka_producer.go
+++ b/producer/kafka_producer.go
@@ -40,16 +40,17 @@ type KafkaProducer struct {
 }
 
 // New constructs new implementation of Producer interface
-func New(brokerCfg conf.KafkaConfiguration) (*KafkaProducer, error) {
-	//TODO: Think about a tolerant config for the producer
-	producer, err := sarama.NewSyncProducer([]string{brokerCfg.Address}, nil)
+func New(config conf.ConfigStruct) (*KafkaProducer, error) {
+	kafkaConfig := conf.GetKafkaBrokerConfiguration(config)
+
+	producer, err := sarama.NewSyncProducer([]string{kafkaConfig.Address}, nil)
 	if err != nil {
-		log.Error().Err(err).Msg("unable to create a new Kafka producer")
+		log.Error().Err(err).Msgf("unable to start a Kafka producer with broker address %s", config.Kafka.Address)
 		return nil, err
 	}
 
 	return &KafkaProducer{
-		Configuration: brokerCfg,
+		Configuration: kafkaConfig,
 		Producer:      producer,
 	}, nil
 }

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -31,7 +31,7 @@ import (
 
 // Producer represents any producer
 type Producer interface {
-	New(brokerCfg conf.KafkaConfiguration) (Producer, error)
+	New(configStruct conf.ConfigStruct) (Producer, error)
 	ProduceMessage(msg types.NotificationMessage) (int32, int64, error)
 	Close() error
 }

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -47,15 +47,18 @@ func init() {
 // This test assumes there is no local kafka instance currently running
 func TestNewProducerBadBroker(t *testing.T) {
 	const expectedErr = "kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"
-	_, err := New(conf.KafkaConfiguration{
-		Address: "",
-		Topic:   "whatever",
-		Timeout: 0,
-		Enabled: true,
-	})
+	_, err := New(conf.ConfigStruct{
+		Kafka: conf.KafkaConfiguration{
+			Address: "",
+			Topic:   "whatever",
+			Timeout: 0,
+			Enabled: true,
+		}})
 	assert.EqualError(t, err, expectedErr)
 
-	_, err = New(brokerCfg)
+	_, err = New(conf.ConfigStruct{
+		Kafka: brokerCfg,
+	})
 	assert.EqualError(t, err, expectedErr)
 }
 
@@ -90,12 +93,12 @@ func TestProducerNew(t *testing.T) {
 	}
 	mockBroker.SetHandlerByMap(handlerMap)
 
-	prod, err := New(
-		conf.KafkaConfiguration{
+	prod, err := New(conf.ConfigStruct{
+		Kafka: conf.KafkaConfiguration{
 			Address: mockBroker.Addr(),
 			Topic:   brokerCfg.Topic,
 			Timeout: brokerCfg.Timeout,
-		})
+		}})
 	helpers.FailOnError(t, err)
 
 	helpers.FailOnError(t, prod.Close())


### PR DESCRIPTION
# Description

Changes the `Producer` interface so that it does not refer to configuration specific to Kafka producer anymore.

[https://issues.redhat.com/browse/CCXDEV-8780](https://issues.redhat.com/browse/CCXDEV-8780)

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Run the unit tests, run with sample data in local setup.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
