### PR TITLE
Revert "do not cleanup on startup"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -95,7 +95,7 @@ objects:
           command:
             - /bin/sh
             - -c
-            - ./ccx-notification-service --instant-reports --verbose
+            - ./ccx-notification-service --instant-reports --cleanup-on-startup --max-age '${CLEANUP_MAX_AGE}' --verbose
 
     kafkaTopics:
       - topicName: ${OUTGOING_TOPIC}


### PR DESCRIPTION
This reverts commit ba6ca40a3d947a06982dc3d821dbf4321b61a750.

# Description

Clean up of data older than 8 days in `reported` and `new_reports` table will now be executed before each run

