### PR TITLE
[CCXDEV-8782] Check the event target before notifying

### DIFF
--- a/differ/comparator_test.go
+++ b/differ/comparator_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package differ
 
 import (
+	"testing"
+
 	"github.com/RedHatInsights/ccx-notification-service/tests/mocks"
 	"github.com/RedHatInsights/ccx-notification-service/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 var (
@@ -380,7 +381,7 @@ func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 
 	previouslyReported, _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours")
 	for _, issue := range newReport.Reports {
-		assert.True(t, shouldNotify(testCluster, issue))
+		assert.True(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
 	}
 }
 
@@ -400,6 +401,7 @@ func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
 					Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_4|RULE_4\",\"component\":\"ccx_rules_ocp.external.rules.rule_4.report\",\"type\":\"rule\",\"key\":\"RULE_4\",\"details\":{\"degraded_operators\":[{\"available\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:45:10Z\",\"reason\":\"AsExpected\",\"message\":\"Available: 2 nodes are active; 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"degraded\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:46:14Z\",\"reason\":\"NodeInstallerDegradedInstallerPodFailed\",\"message\":\"NodeControllerDegraded: All master nodes are ready\\nStaticPodsDegraded: nodes/ip-10-0-137-172.us-east-2.compute.internal pods/kube-apiserver-ip-10-0-137-172.us-east-2.compute.internal container=\\\"kube-apiserver-3\\\" is not ready\"},\"name\":\"kube-apiserver\",\"progressing\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:43:00Z\",\"reason\":\"\",\"message\":\"Progressing: 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"upgradeable\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:42:52Z\",\"reason\":\"AsExpected\",\"message\":\"\"},\"version\":\"4.3.13\"}],\"type\":\"rule\",\"error_key\":\"NODE_INSTALLER_DEGRADED\"},\"tags\":[],\"links\":{\"kcs\":[\"https://access.redhat.com/solutions/4849711\"]}}]}",
 					NotifiedAt:         types.Timestamp(testTimestamp),
 					ErrorLog:           "",
+					EventTarget:        types.NotificationBackendTarget,
 				},
 			}
 		},
@@ -420,7 +422,7 @@ func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
 
 	previouslyReported, _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours")
 	for _, issue := range newReport.Reports {
-		assert.True(t, shouldNotify(testCluster, issue))
+		assert.True(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
 	}
 }
 
@@ -440,6 +442,7 @@ func TestShouldNotifyIssueNotFoundInPreviousRecords(t *testing.T) {
 					Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_4|RULE_4\",\"component\":\"ccx_rules_ocp.external.rules.rule_4.report\",\"type\":\"rule\",\"key\":\"RULE_4\",\"details\":{\"degraded_operators\":[{\"available\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:45:10Z\",\"reason\":\"AsExpected\",\"message\":\"Available: 2 nodes are active; 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"degraded\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:46:14Z\",\"reason\":\"NodeInstallerDegradedInstallerPodFailed\",\"message\":\"NodeControllerDegraded: All master nodes are ready\\nStaticPodsDegraded: nodes/ip-10-0-137-172.us-east-2.compute.internal pods/kube-apiserver-ip-10-0-137-172.us-east-2.compute.internal container=\\\"kube-apiserver-3\\\" is not ready\"},\"name\":\"kube-apiserver\",\"progressing\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:43:00Z\",\"reason\":\"\",\"message\":\"Progressing: 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"upgradeable\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:42:52Z\",\"reason\":\"AsExpected\",\"message\":\"\"},\"version\":\"4.3.13\"}],\"type\":\"rule\",\"error_key\":\"NODE_INSTALLER_DEGRADED\"},\"tags\":[],\"links\":{\"kcs\":[\"https://access.redhat.com/solutions/4849711\"]}}]}",
 					NotifiedAt:         types.Timestamp(testTimestamp),
 					ErrorLog:           "",
+					EventTarget:        types.NotificationBackendTarget,
 				},
 			}
 		},
@@ -461,6 +464,6 @@ func TestShouldNotifyIssueNotFoundInPreviousRecords(t *testing.T) {
 	previouslyReported, _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours")
 
 	for _, issue := range newReport.Reports {
-		assert.True(t, shouldNotify(testCluster, issue))
+		assert.True(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
 	}
 }

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -89,6 +89,7 @@ const (
 	metricsPushFailedMessage    = "Couldn't push prometheus metrics"
 	eventFilterNotSetMessage    = "Event filter not set"
 	evaluationErrorMessage      = "Evaluation error"
+	differentReportMessage      = "Different report from the last one"
 )
 
 // Constants for notification message top level fields
@@ -348,14 +349,40 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 					Int("impact", impact).
 					Int(totalRiskAttribute, totalRisk).
 					Msg("Report with high impact detected")
-				if !shouldNotify(cluster, r) {
-					continue
+
+				// Notification backend
+				if shouldNotify(cluster, r, types.NotificationBackendTarget) {
+					// if new report differs from the older one -> send notification
+					log.Info().
+						Str("EventTarget", "notification backend").
+						Str(clusterName, string(cluster.ClusterName)).
+						Msg(differentReportMessage)
+					ReportWithHighImpact.Inc()
+					notificationPayloadURL := generateNotificationPayloadURL(
+						&notificationRuleDetailsURI,
+						string(cluster.ClusterName),
+						module,
+						errorKey,
+					)
+					appendEventToNotificationMessage(
+						notificationPayloadURL,
+						&notificationMsg,
+						description,
+						totalRisk,
+						time.Time(cluster.UpdatedAt).UTC().Format(time.RFC3339Nano),
+					)
 				}
-				// if new report differs from the older one -> send notification
-				log.Info().Str(clusterName, string(cluster.ClusterName)).Msg("Different report from the last one")
-				ReportWithHighImpact.Inc()
-				notificationPayloadURL := generateNotificationPayloadURL(&notificationRuleDetailsURI, string(cluster.ClusterName), module, errorKey)
-				appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, description, totalRisk, time.Time(cluster.UpdatedAt).UTC().Format(time.RFC3339Nano))
+				// Service Log
+				if shouldNotify(cluster, r, types.ServiceLogTarget) {
+					// if new report differs from the older one -> send notification
+					log.Info().
+						Str("EventTarget", "service log").
+						Str(clusterName, string(cluster.ClusterName)).
+						Msg(differentReportMessage)
+					// TODO: ServiceLogReportWithHighImpact.Inc()
+					// TODO: serviceLogPayloadURL := generateServiceLogPayloadURL(...)
+					// TODO: appendEventToServiceLogMessage -> update serviceLogMsg
+				}
 			}
 		}
 

--- a/differ/slice_util.go
+++ b/differ/slice_util.go
@@ -1,0 +1,29 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import "strings"
+
+// inClauseFromStringSlice is a helper function to construct `in` clause for SQL
+// statement from a given slice of string items. If the slice is empty, an
+// empty string will be returned, making the in clause fail.
+func inClauseFromStringSlice(slice []string) string {
+	if len(slice) == 0 {
+		return ""
+	}
+	return "'" + strings.Join(slice, `','`) + `'`
+}

--- a/differ/slice_util_test.go
+++ b/differ/slice_util_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test the checkArgs function when flag for --show-version is set
+func TestInClauseFromSlice(t *testing.T) {
+	stringSlice := make([]string, 0)
+	assert.Equal(t, "", inClauseFromStringSlice(stringSlice))
+
+	stringSlice = []string{"first item", "second item"}
+	assert.Equal(t, "'first item','second item'", inClauseFromStringSlice(stringSlice))
+}

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -199,16 +199,6 @@ const (
 `
 )
 
-// inClauseFromStringSlice is a helper function to construct `in` clause for SQL
-// statement from a given slice of string items. If the slice is empty, an
-// empty string will be returned, making the in clause fail.
-func inClauseFromStringSlice(slice []string) string {
-	if len(slice) == 0 {
-		return ""
-	}
-	return "'" + strings.Join(slice, `','`) + `'`
-}
-
 // NewStorage function creates and initializes a new instance of Storage interface
 func NewStorage(configuration conf.StorageConfiguration) (*DBStorage, error) {
 	driverType, driverName, dataSource, err := initAndGetDriver(configuration)

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -54,7 +54,7 @@ func TestReadLastNotifiedRecordForClusterList(t *testing.T) {
 	)
 
 	db, mock := newMock(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	sut := differ.NewFromConnection(db, types.DBDriverPostgres)
 

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/DATA-DOG/go-sqlmock v1.4.1 // indirect
 	github.com/RedHatInsights/insights-operator-utils v1.23.9
 	github.com/RedHatInsights/insights-results-types v1.3.12 // indirect
 	github.com/Shopify/sarama v1.27.1
 	github.com/lib/pq v1.7.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/prometheus/client_golang v1.10.0
-	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/redhatinsights/app-common-go v1.5.1
 	github.com/rs/zerolog v1.21.0
 	github.com/spf13/viper v1.7.2-0.20210415161207-7fdb267c730d

--- a/types/types.go
+++ b/types/types.go
@@ -237,6 +237,7 @@ type NotificationRecord struct {
 	Report             ClusterReport
 	NotifiedAt         Timestamp
 	ErrorLog           string
+	EventTarget        EventTarget
 }
 
 // ClusterOrgKey is a slice with two items: an organization ID and a cluster UUID

--- a/types/types.go
+++ b/types/types.go
@@ -25,8 +25,9 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/RedHatInsights/insights-results-types"
 	"time"
+
+	types "github.com/RedHatInsights/insights-results-types"
 )
 
 // Timestamp represents any timestamp in a form gathered from database
@@ -58,6 +59,8 @@ type NotificationTypeID int
 // StateID represents ID value in `states` table.
 type StateID int
 
+type EventTarget int8
+
 const (
 	// DBDriverSQLite3 shows that db driver is sqlite
 	DBDriverSQLite3 DBDriver = iota
@@ -65,6 +68,10 @@ const (
 	DBDriverPostgres
 	// DBDriverGeneral general sql(used for mock now)
 	DBDriverGeneral
+	// NotificationBackendTarget matches the notification backend int code in the database (CCXDEV-8767)
+	NotificationBackendTarget EventTarget = 1
+	// ServiceLogTarget matches the service log int code in the database (CCXDEV-8767)
+	ServiceLogTarget EventTarget = 2
 )
 
 // ClusterEntry represents the entries retrieved from the DB

--- a/types/types.go
+++ b/types/types.go
@@ -59,6 +59,7 @@ type NotificationTypeID int
 // StateID represents ID value in `states` table.
 type StateID int
 
+// EventTarget represents where the notifications are sent (CCXDEV-8767)
 type EventTarget int8
 
 const (
@@ -246,5 +247,15 @@ type ClusterOrgKey struct {
 	ClusterName ClusterName
 }
 
+// ClusterOrgTargetKey is a slice with three items: an organization ID, a cluster UUID and the
+// backend target where the notification has been sent
+type ClusterOrgTargetKey struct {
+	ClusterOrgKey
+	EventTarget EventTarget
+}
+
 // NotifiedRecordsPerCluster maps a string representation of ClusterOrgKey to a NotificationRecord
 type NotifiedRecordsPerCluster map[ClusterOrgKey]NotificationRecord
+
+// NotifiedRecordsPerClusterAndTarget maps a string representation of ClusterOrgTargetKey to a NotificationRecord
+type NotifiedRecordsPerClusterAndTarget map[ClusterOrgTargetKey]NotificationRecord


### PR DESCRIPTION
# Description

Check the event target in the `shouldNotify` function. This way, we won't send notifications for issues that has already been notified for a given target.

Fixes #CCXDEV-8782

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Unit tests (not enough)

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
