### PR TITLE
Temporaly augment cronjob's deadline to 5 hours for DB migration

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -22,8 +22,7 @@ objects:
         schedule: ${JOB_SCHEDULE}
         restartPolicy: Never
         concurrencyPolicy: Forbid
-        # In PROD 1 cronjob takes around 45 min. Deadline set to 60 mins.
-        activeDeadlineSeconds: 3600
+        activeDeadlineSeconds: 18000
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           resources:


### PR DESCRIPTION
# Description

Augment cronjob's deadline to ensure it does not die continuously during notification DB migration.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
