### PR TITLE
[CCXDEV-8782] Add the new types

### DIFF
--- a/differ/storage.go
+++ b/differ/storage.go
@@ -48,9 +48,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// NotificationBackendEventTypeID represent an event for the notification backend
-const NotificationBackendEventTypeID = 1
-
 // Storage represents an interface to almost any database or storage system
 type Storage interface {
 	Close() error
@@ -89,7 +86,7 @@ type Storage interface {
 		updatedAt types.Timestamp,
 		notifiedAt types.Timestamp,
 		errorLog string,
-		eventType int) error
+		eventType types.EventTarget) error
 	CleanupNewReportsForOrganization(orgID types.OrgID, maxAge string) (int, error)
 	CleanupOldReportsForOrganization(orgID types.OrgID, maxAge string) (int, error)
 	DeleteRowFromNewReports(
@@ -486,7 +483,7 @@ func (storage DBStorage) WriteNotificationRecord(
 		notificationRecord.NotificationTypeID, notificationRecord.StateID,
 		notificationRecord.Report, notificationRecord.UpdatedAt,
 		notificationRecord.NotifiedAt, notificationRecord.ErrorLog,
-		NotificationBackendEventTypeID)
+		types.NotificationBackendTarget)
 }
 
 // WriteNotificationRecordImpl method writes a report (with given state and
@@ -504,7 +501,7 @@ func (storage DBStorage) WriteNotificationRecordImpl(
 	updatedAt types.Timestamp,
 	notifiedAt types.Timestamp,
 	errorLog string,
-	eventTarget int) error {
+	eventTarget types.EventTarget) error {
 
 	const insertStatement = `
             INSERT INTO reported
@@ -533,10 +530,11 @@ func (storage DBStorage) WriteNotificationRecordForCluster(
 	notifiedAt types.Timestamp,
 	errorLog string) error {
 
+	// TODO: Accept event target too!!!!!
 	return storage.WriteNotificationRecordImpl(clusterEntry.OrgID,
 		clusterEntry.AccountNumber, clusterEntry.ClusterName,
 		notificationTypeID, stateID, report, clusterEntry.UpdatedAt,
-		notifiedAt, errorLog, NotificationBackendEventTypeID)
+		notifiedAt, errorLog, types.NotificationBackendTarget)
 }
 
 // ReadLastNotifiedRecordForClusterList method returns the last notification

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -371,11 +371,11 @@ func (_m *Storage) WriteNotificationRecordForCluster(clusterEntry types.ClusterE
 }
 
 // WriteNotificationRecordImpl provides a mock function with given fields: orgID, accountNumber, clusterName, notificationTypeID, stateID, report, updatedAt, notifiedAt, errorLog, eventType
-func (_m *Storage) WriteNotificationRecordImpl(orgID types.OrgID, accountNumber types.AccountNumber, clusterName types.ClusterName, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, updatedAt types.Timestamp, notifiedAt types.Timestamp, errorLog string, eventType int) error {
+func (_m *Storage) WriteNotificationRecordImpl(orgID types.OrgID, accountNumber types.AccountNumber, clusterName types.ClusterName, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, updatedAt types.Timestamp, notifiedAt types.Timestamp, errorLog string, eventType types.EventTarget) error {
 	ret := _m.Called(orgID, accountNumber, clusterName, notificationTypeID, stateID, report, updatedAt, notifiedAt, errorLog, eventType)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(types.OrgID, types.AccountNumber, types.ClusterName, types.NotificationTypeID, types.StateID, types.ClusterReport, types.Timestamp, types.Timestamp, string, int) error); ok {
+	if rf, ok := ret.Get(0).(func(types.OrgID, types.AccountNumber, types.ClusterName, types.NotificationTypeID, types.StateID, types.ClusterReport, types.Timestamp, types.Timestamp, string, types.EventTarget) error); ok {
 		r0 = rf(orgID, accountNumber, clusterName, notificationTypeID, stateID, report, updatedAt, notifiedAt, errorLog, eventType)
 	} else {
 		r0 = ret.Error(0)

--- a/types/types.go
+++ b/types/types.go
@@ -25,8 +25,9 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/RedHatInsights/insights-results-types"
 	"time"
+
+	types "github.com/RedHatInsights/insights-results-types"
 )
 
 // Timestamp represents any timestamp in a form gathered from database
@@ -58,6 +59,9 @@ type NotificationTypeID int
 // StateID represents ID value in `states` table.
 type StateID int
 
+// EventTarget matches the backend int code in the database where the notifications are sent (CCXDEV-8767)
+type EventTarget int8
+
 const (
 	// DBDriverSQLite3 shows that db driver is sqlite
 	DBDriverSQLite3 DBDriver = iota
@@ -65,6 +69,10 @@ const (
 	DBDriverPostgres
 	// DBDriverGeneral general sql(used for mock now)
 	DBDriverGeneral
+	// NotificationBackendTarget matches the notification backend int code in the database (CCXDEV-8767)
+	NotificationBackendTarget EventTarget = 1
+	// ServiceLogTarget matches the service log int code in the database (CCXDEV-8767)
+	ServiceLogTarget EventTarget = 2
 )
 
 // ClusterEntry represents the entries retrieved from the DB
@@ -230,6 +238,7 @@ type NotificationRecord struct {
 	Report             ClusterReport
 	NotifiedAt         Timestamp
 	ErrorLog           string
+	EventTarget        EventTarget // this is the event_type_id (CCXDEV-8767)
 }
 
 // ClusterOrgKey is a slice with two items: an organization ID and a cluster UUID
@@ -240,3 +249,6 @@ type ClusterOrgKey struct {
 
 // NotifiedRecordsPerCluster maps a string representation of ClusterOrgKey to a NotificationRecord
 type NotifiedRecordsPerCluster map[ClusterOrgKey]NotificationRecord
+
+// NotifiedRecordsPerClusterByTarget let us split the notified records by their target (CCXDEV-8767)
+type NotifiedRecordsPerClusterByTarget map[EventTarget]NotifiedRecordsPerCluster


### PR DESCRIPTION
# Description

I'm splitting https://github.com/RedHatInsights/ccx-notification-service/pull/243 into smaller pieces. This one adds the `event_target_id` value in the database as a new type, instead of using an int.

Part of #CCXDEV-8782

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

BDD testing + unit testing.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
