### PR TITLE
[CCXDEV-8782] Use the new type

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -25,9 +25,10 @@ package differ
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+
 	"github.com/RedHatInsights/ccx-notification-service/types"
 	"github.com/rs/zerolog/log"
-	"os"
 )
 
 // Messages
@@ -84,10 +85,10 @@ func getNotificationResolution(issue types.ReportItem, record types.Notification
 	return
 }
 
-func shouldNotify(cluster types.ClusterEntry, issue types.ReportItem) bool {
+func shouldNotify(cluster types.ClusterEntry, issue types.ReportItem, eventTarget types.EventTarget) bool {
 	// check if the issue of the given cluster has previously been reported
 	key := types.ClusterOrgKey{OrgID: cluster.OrgID, ClusterName: cluster.ClusterName}
-	reported, ok := previouslyReported[key]
+	reported, ok := previouslyReported[eventTarget][key]
 	if !ok {
 		log.Info().Bool(resolutionKey, true).Msg(resolutionMsg)
 		return true

--- a/differ/comparator_test.go
+++ b/differ/comparator_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package differ
 
 import (
+	"testing"
+
 	"github.com/RedHatInsights/ccx-notification-service/tests/mocks"
 	"github.com/RedHatInsights/ccx-notification-service/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 var (
@@ -75,7 +76,7 @@ var (
 
 func init() {
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
-	previouslyReported = make(types.NotifiedRecordsPerCluster)
+	previouslyReported = make(types.NotifiedRecordsPerClusterByTarget)
 }
 
 func TestGetState(t *testing.T) {
@@ -359,14 +360,17 @@ func TestIssueNotInReportLessItemsInNewReportAndIssueFoundInOldReports(t *testin
 func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 	storage := mocks.Storage{}
 	storage.On("ReadLastNotifiedRecordForClusterList",
-		mock.AnythingOfType("[]types.ClusterEntry"), mock.AnythingOfType("string")).Return(
-		func(clusterEntries []types.ClusterEntry, timeOffset string) types.NotifiedRecordsPerCluster {
-			return types.NotifiedRecordsPerCluster{}
-		},
-		func(clusterEntries []types.ClusterEntry, timeOffset string) error {
-			return nil
-		},
-	)
+		mock.AnythingOfType("[]types.ClusterEntry"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).
+		Return(
+			func(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) types.NotifiedRecordsPerCluster {
+				return types.NotifiedRecordsPerCluster{}
+			},
+			func(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) error {
+				return nil
+			},
+		)
 	newReport := types.Report{
 		Reports: []types.ReportItem{
 			{
@@ -378,35 +382,38 @@ func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 		},
 	}
 
-	previouslyReported, _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours")
+	previouslyReported[types.NotificationBackendTarget], _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours", types.NotificationBackendTarget)
 	for _, issue := range newReport.Reports {
-		assert.True(t, shouldNotify(testCluster, issue))
+		assert.True(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
 	}
 }
 
 func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
 	storage := mocks.Storage{}
 	storage.On("ReadLastNotifiedRecordForClusterList",
-		mock.AnythingOfType("[]types.ClusterEntry"), mock.AnythingOfType("string")).Return(
-		func(clusterEntries []types.ClusterEntry, timeOffset string) types.NotifiedRecordsPerCluster {
-			return types.NotifiedRecordsPerCluster{
-				types.ClusterOrgKey{OrgID: testCluster.OrgID, ClusterName: testCluster.ClusterName}: {
-					OrgID:              testCluster.OrgID,
-					AccountNumber:      testCluster.AccountNumber,
-					ClusterName:        testCluster.ClusterName,
-					UpdatedAt:          types.Timestamp(testTimestamp),
-					NotificationTypeID: 1,
-					StateID:            1,
-					Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_4|RULE_4\",\"component\":\"ccx_rules_ocp.external.rules.rule_4.report\",\"type\":\"rule\",\"key\":\"RULE_4\",\"details\":{\"degraded_operators\":[{\"available\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:45:10Z\",\"reason\":\"AsExpected\",\"message\":\"Available: 2 nodes are active; 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"degraded\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:46:14Z\",\"reason\":\"NodeInstallerDegradedInstallerPodFailed\",\"message\":\"NodeControllerDegraded: All master nodes are ready\\nStaticPodsDegraded: nodes/ip-10-0-137-172.us-east-2.compute.internal pods/kube-apiserver-ip-10-0-137-172.us-east-2.compute.internal container=\\\"kube-apiserver-3\\\" is not ready\"},\"name\":\"kube-apiserver\",\"progressing\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:43:00Z\",\"reason\":\"\",\"message\":\"Progressing: 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"upgradeable\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:42:52Z\",\"reason\":\"AsExpected\",\"message\":\"\"},\"version\":\"4.3.13\"}],\"type\":\"rule\",\"error_key\":\"NODE_INSTALLER_DEGRADED\"},\"tags\":[],\"links\":{\"kcs\":[\"https://access.redhat.com/solutions/4849711\"]}}]}",
-					NotifiedAt:         types.Timestamp(testTimestamp),
-					ErrorLog:           "",
-				},
-			}
-		},
-		func(clusterEntries []types.ClusterEntry, timeOffset string) error {
-			return nil
-		},
-	)
+		mock.AnythingOfType("[]types.ClusterEntry"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).
+		Return(
+			func(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) types.NotifiedRecordsPerCluster {
+				return types.NotifiedRecordsPerCluster{
+					types.ClusterOrgKey{OrgID: testCluster.OrgID, ClusterName: testCluster.ClusterName}: {
+						OrgID:              testCluster.OrgID,
+						AccountNumber:      testCluster.AccountNumber,
+						ClusterName:        testCluster.ClusterName,
+						UpdatedAt:          types.Timestamp(testTimestamp),
+						NotificationTypeID: 1,
+						StateID:            1,
+						Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_4|RULE_4\",\"component\":\"ccx_rules_ocp.external.rules.rule_4.report\",\"type\":\"rule\",\"key\":\"RULE_4\",\"details\":{\"degraded_operators\":[{\"available\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:45:10Z\",\"reason\":\"AsExpected\",\"message\":\"Available: 2 nodes are active; 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"degraded\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:46:14Z\",\"reason\":\"NodeInstallerDegradedInstallerPodFailed\",\"message\":\"NodeControllerDegraded: All master nodes are ready\\nStaticPodsDegraded: nodes/ip-10-0-137-172.us-east-2.compute.internal pods/kube-apiserver-ip-10-0-137-172.us-east-2.compute.internal container=\\\"kube-apiserver-3\\\" is not ready\"},\"name\":\"kube-apiserver\",\"progressing\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:43:00Z\",\"reason\":\"\",\"message\":\"Progressing: 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"upgradeable\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:42:52Z\",\"reason\":\"AsExpected\",\"message\":\"\"},\"version\":\"4.3.13\"}],\"type\":\"rule\",\"error_key\":\"NODE_INSTALLER_DEGRADED\"},\"tags\":[],\"links\":{\"kcs\":[\"https://access.redhat.com/solutions/4849711\"]}}]}",
+						NotifiedAt:         types.Timestamp(testTimestamp),
+						ErrorLog:           "",
+					},
+				}
+			},
+			func(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) error {
+				return nil
+			},
+		)
 	newReport := types.Report{
 		Reports: []types.ReportItem{
 			{
@@ -418,35 +425,38 @@ func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
 		},
 	}
 
-	previouslyReported, _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours")
+	previouslyReported[types.NotificationBackendTarget], _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours", types.NotificationBackendTarget)
 	for _, issue := range newReport.Reports {
-		assert.True(t, shouldNotify(testCluster, issue))
+		assert.True(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
 	}
 }
 
 func TestShouldNotifyIssueNotFoundInPreviousRecords(t *testing.T) {
 	storage := mocks.Storage{}
 	storage.On("ReadLastNotifiedRecordForClusterList",
-		mock.AnythingOfType("[]types.ClusterEntry"), mock.AnythingOfType("string")).Return(
-		func(clusterEntries []types.ClusterEntry, timeOffset string) types.NotifiedRecordsPerCluster {
-			return types.NotifiedRecordsPerCluster{
-				types.ClusterOrgKey{OrgID: testCluster.OrgID, ClusterName: testCluster.ClusterName}: {
-					OrgID:              testCluster.OrgID,
-					AccountNumber:      testCluster.AccountNumber,
-					ClusterName:        testCluster.ClusterName,
-					UpdatedAt:          types.Timestamp(testTimestamp),
-					NotificationTypeID: 1,
-					StateID:            1,
-					Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_4|RULE_4\",\"component\":\"ccx_rules_ocp.external.rules.rule_4.report\",\"type\":\"rule\",\"key\":\"RULE_4\",\"details\":{\"degraded_operators\":[{\"available\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:45:10Z\",\"reason\":\"AsExpected\",\"message\":\"Available: 2 nodes are active; 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"degraded\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:46:14Z\",\"reason\":\"NodeInstallerDegradedInstallerPodFailed\",\"message\":\"NodeControllerDegraded: All master nodes are ready\\nStaticPodsDegraded: nodes/ip-10-0-137-172.us-east-2.compute.internal pods/kube-apiserver-ip-10-0-137-172.us-east-2.compute.internal container=\\\"kube-apiserver-3\\\" is not ready\"},\"name\":\"kube-apiserver\",\"progressing\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:43:00Z\",\"reason\":\"\",\"message\":\"Progressing: 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"upgradeable\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:42:52Z\",\"reason\":\"AsExpected\",\"message\":\"\"},\"version\":\"4.3.13\"}],\"type\":\"rule\",\"error_key\":\"NODE_INSTALLER_DEGRADED\"},\"tags\":[],\"links\":{\"kcs\":[\"https://access.redhat.com/solutions/4849711\"]}}]}",
-					NotifiedAt:         types.Timestamp(testTimestamp),
-					ErrorLog:           "",
-				},
-			}
-		},
-		func(clusterEntries []types.ClusterEntry, timeOffset string) error {
-			return nil
-		},
-	)
+		mock.AnythingOfType("[]types.ClusterEntry"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).
+		Return(
+			func(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) types.NotifiedRecordsPerCluster {
+				return types.NotifiedRecordsPerCluster{
+					types.ClusterOrgKey{OrgID: testCluster.OrgID, ClusterName: testCluster.ClusterName}: {
+						OrgID:              testCluster.OrgID,
+						AccountNumber:      testCluster.AccountNumber,
+						ClusterName:        testCluster.ClusterName,
+						UpdatedAt:          types.Timestamp(testTimestamp),
+						NotificationTypeID: 1,
+						StateID:            1,
+						Report:             "{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_4|RULE_4\",\"component\":\"ccx_rules_ocp.external.rules.rule_4.report\",\"type\":\"rule\",\"key\":\"RULE_4\",\"details\":{\"degraded_operators\":[{\"available\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:45:10Z\",\"reason\":\"AsExpected\",\"message\":\"Available: 2 nodes are active; 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"degraded\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:46:14Z\",\"reason\":\"NodeInstallerDegradedInstallerPodFailed\",\"message\":\"NodeControllerDegraded: All master nodes are ready\\nStaticPodsDegraded: nodes/ip-10-0-137-172.us-east-2.compute.internal pods/kube-apiserver-ip-10-0-137-172.us-east-2.compute.internal container=\\\"kube-apiserver-3\\\" is not ready\"},\"name\":\"kube-apiserver\",\"progressing\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:43:00Z\",\"reason\":\"\",\"message\":\"Progressing: 1 nodes are at revision 0; 2 nodes are at revision 2; 0 nodes have achieved new revision 3\"},\"upgradeable\":{\"status\":true,\"last_trans_time\":\"2020-04-21T12:42:52Z\",\"reason\":\"AsExpected\",\"message\":\"\"},\"version\":\"4.3.13\"}],\"type\":\"rule\",\"error_key\":\"NODE_INSTALLER_DEGRADED\"},\"tags\":[],\"links\":{\"kcs\":[\"https://access.redhat.com/solutions/4849711\"]}}]}",
+						NotifiedAt:         types.Timestamp(testTimestamp),
+						ErrorLog:           "",
+					},
+				}
+			},
+			func(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) error {
+				return nil
+			},
+		)
 	newReport := types.Report{
 		Reports: []types.ReportItem{
 			{
@@ -458,9 +468,9 @@ func TestShouldNotifyIssueNotFoundInPreviousRecords(t *testing.T) {
 		},
 	}
 
-	previouslyReported, _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours")
+	previouslyReported[types.NotificationBackendTarget], _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours", types.NotificationBackendTarget)
 
 	for _, issue := range newReport.Reports {
-		assert.True(t, shouldNotify(testCluster, issue))
+		assert.True(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
 	}
 }

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -157,8 +157,11 @@ var (
 		Impact:     DefaultImpactThreshold,
 		Severity:   DefaultSeverityThreshold,
 	}
-	previouslyReported types.NotifiedRecordsPerCluster
-	eventFilter        string = DefaultEventFilter
+	previouslyReported = types.NotifiedRecordsPerClusterByTarget{
+		types.NotificationBackendTarget: types.NotifiedRecordsPerCluster{},
+		types.ServiceLogTarget:          types.NotifiedRecordsPerCluster{},
+	}
+	eventFilter string = DefaultEventFilter
 )
 
 // showVersion function displays version information.
@@ -353,7 +356,7 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 					Int("impact", impact).
 					Int(totalRiskAttribute, totalRisk).
 					Msg("Report with high impact detected")
-				if !shouldNotify(cluster, r) {
+				if !shouldNotify(cluster, r, types.NotificationBackendTarget) {
 					continue
 				}
 				// if new report differs from the older one -> send notification
@@ -797,7 +800,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	log.Info().Int(clustersAttribute, entries).Msg("Read cluster list: done")
 	log.Info().Msg(separator)
 	log.Info().Msg("Read previously reported issues for cluster list")
-	previouslyReported, err = storage.ReadLastNotifiedRecordForClusterList(clusters, notifConfig.Cooldown)
+	previouslyReported[types.NotificationBackendTarget], err = storage.ReadLastNotifiedRecordForClusterList(clusters, notifConfig.Cooldown, types.NotificationBackendTarget)
 	if err != nil {
 		ReadReportedErrors.Inc()
 		log.Err(err).Msg(operationFailedMessage)

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -888,7 +888,7 @@ func TestProcessClustersAllIssuesAlreadyNotifiedCooldownNotPassed(t *testing.T) 
 		},
 	)
 
-	previouslyReported[types.ClusterOrgKey{OrgID: types.OrgID(1), ClusterName: "first_cluster"}] = types.NotificationRecord{
+	previouslyReported[types.NotificationBackendTarget][types.ClusterOrgKey{OrgID: types.OrgID(1), ClusterName: "first_cluster"}] = types.NotificationRecord{
 		OrgID:              1,
 		AccountNumber:      4,
 		ClusterName:        "first_cluster",
@@ -900,7 +900,7 @@ func TestProcessClustersAllIssuesAlreadyNotifiedCooldownNotPassed(t *testing.T) 
 		ErrorLog:           "",
 	}
 
-	previouslyReported[types.ClusterOrgKey{OrgID: types.OrgID(2), ClusterName: "second_cluster"}] = types.NotificationRecord{
+	previouslyReported[types.NotificationBackendTarget][types.ClusterOrgKey{OrgID: types.OrgID(2), ClusterName: "second_cluster"}] = types.NotificationRecord{
 		OrgID:              2,
 		AccountNumber:      4,
 		ClusterName:        "second_cluster",
@@ -918,7 +918,10 @@ func TestProcessClustersAllIssuesAlreadyNotifiedCooldownNotPassed(t *testing.T) 
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"message\":\"No new issues to notify for cluster second_cluster\"}\n", "Notification already sent for second_cluster's report, but corresponding log not found.")
 
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
-	previouslyReported = make(types.NotifiedRecordsPerCluster)
+	previouslyReported = types.NotifiedRecordsPerClusterByTarget{
+		types.NotificationBackendTarget: types.NotifiedRecordsPerCluster{},
+		types.ServiceLogTarget:          types.NotifiedRecordsPerCluster{},
+	}
 }
 
 func TestProcessClustersNewIssuesNotPreviouslyNotified(t *testing.T) {
@@ -1049,7 +1052,7 @@ func TestProcessClustersNewIssuesNotPreviouslyNotified(t *testing.T) {
 	originalNotifier := notifier
 	notifier = &producerMock
 
-	previouslyReported[types.ClusterOrgKey{OrgID: types.OrgID(3), ClusterName: "a cluster"}] = types.NotificationRecord{
+	previouslyReported[types.NotificationBackendTarget][types.ClusterOrgKey{OrgID: types.OrgID(3), ClusterName: "a cluster"}] = types.NotificationRecord{
 		OrgID:              3,
 		AccountNumber:      4,
 		ClusterName:        "a cluster",
@@ -1070,7 +1073,10 @@ func TestProcessClustersNewIssuesNotPreviouslyNotified(t *testing.T) {
 
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
 	notifier = originalNotifier
-	previouslyReported = make(types.NotifiedRecordsPerCluster)
+	previouslyReported = types.NotifiedRecordsPerClusterByTarget{
+		types.NotificationBackendTarget: types.NotifiedRecordsPerCluster{},
+		types.ServiceLogTarget:          types.NotifiedRecordsPerCluster{},
+	}
 }
 
 //---------------------------------------------------------------------------------------

--- a/differ/export_test.go
+++ b/differ/export_test.go
@@ -33,3 +33,7 @@ import (
 func PushMetrics(metricsConf conf.MetricsConfiguration) {
 	pushMetrics(metricsConf)
 }
+
+func InClauseFromStringSlice(slice []string) string {
+	return inClauseFromStringSlice(slice)
+}

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -14,18 +14,80 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package differ
+package differ_test
 
 import (
-	"github.com/stretchr/testify/assert"
+	"database/sql"
+	"fmt"
+	"regexp"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RedHatInsights/ccx-notification-service/differ"
+	"github.com/RedHatInsights/ccx-notification-service/types"
+	"github.com/stretchr/testify/assert"
 )
 
-// Test the checkArgs function when flag for --show-version is set
-func TestInClauseFromSlice(t *testing.T) {
-	stringSlice := make([]string, 0)
-	assert.Equal(t, "", inClauseFromStringSlice(stringSlice))
+func TestReadLastNotifiedRecordForClusterList(t *testing.T) {
+	var (
+		now            = time.Now()
+		clusters       = "'first cluster','second cluster'"
+		orgs           = "'1','2'"
+		clusterEntries = []types.ClusterEntry{
+			{
+				OrgID:         1,
+				AccountNumber: 1,
+				ClusterName:   "first cluster",
+				KafkaOffset:   1,
+				UpdatedAt:     types.Timestamp(now),
+			},
+			{
+				OrgID:         2,
+				AccountNumber: 2,
+				ClusterName:   "second cluster",
+				KafkaOffset:   1,
+				UpdatedAt:     types.Timestamp(now),
+			},
+		}
+		timeOffset = "1 day"
+	)
 
-	stringSlice = []string{"first item", "second item"}
-	assert.Equal(t, "'first item','second item'", inClauseFromStringSlice(stringSlice))
+	db, mock := newMock(t)
+	defer func() { _ = db.Close() }()
+
+	sut := differ.NewFromConnection(db, types.DBDriverPostgres)
+
+	expectedQuery := fmt.Sprintf(`
+	SELECT org_id, cluster, report, notified_at 
+	FROM ( 
+		SELECT DISTINCT ON (cluster) * 
+		FROM reported
+		WHERE event_type_id = %v AND state = 1 AND org_id IN (%v) AND cluster IN (%v)
+		ORDER BY cluster, notified_at DESC) t 
+	WHERE notified_at > NOW() - $1::INTERVAL;
+	`, types.NotificationBackendTarget, orgs, clusters)
+
+	rows := sqlmock.NewRows(
+		[]string{"org_id", "cluster", "report", "notified_at"}).
+		AddRow(1, "first cluster", "test", now).
+		AddRow(1, "first cluster", "test", now)
+
+	mock.ExpectQuery(regexp.QuoteMeta(expectedQuery)).
+		WithArgs(timeOffset).
+		WillReturnRows(rows)
+
+	records, err := sut.ReadLastNotifiedRecordForClusterList(
+		clusterEntries, timeOffset, types.NotificationBackendTarget)
+	assert.NoError(t, err, "error running ReadLastNotifiedRecordForClusterList")
+	fmt.Println(records)
+}
+
+func newMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	return db, mock
 }

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -91,3 +91,12 @@ func newMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 
 	return db, mock
 }
+
+// Test the checkArgs function when flag for --show-version is set
+func TestInClauseFromSlice(t *testing.T) {
+	stringSlice := make([]string, 0)
+	assert.Equal(t, "", differ.InClauseFromStringSlice(stringSlice))
+
+	stringSlice = []string{"first item", "second item"}
+	assert.Equal(t, "'first item','second item'", differ.InClauseFromStringSlice(stringSlice))
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/DATA-DOG/go-sqlmock v1.4.1 // indirect
 	github.com/RedHatInsights/insights-operator-utils v1.23.9
 	github.com/RedHatInsights/insights-results-types v1.3.12
 	github.com/Shopify/sarama v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
+github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -203,13 +203,13 @@ func (_m *Storage) ReadClusterList() ([]types.ClusterEntry, error) {
 	return r0, r1
 }
 
-// ReadLastNotifiedRecordForClusterList provides a mock function with given fields: clusterEntries, timeOffset
-func (_m *Storage) ReadLastNotifiedRecordForClusterList(clusterEntries []types.ClusterEntry, timeOffset string) (types.NotifiedRecordsPerCluster, error) {
-	ret := _m.Called(clusterEntries, timeOffset)
+// ReadLastNotifiedRecordForClusterList provides a mock function with given fields: clusterEntries, timeOffset, eventTarget
+func (_m *Storage) ReadLastNotifiedRecordForClusterList(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) (types.NotifiedRecordsPerCluster, error) {
+	ret := _m.Called(clusterEntries, timeOffset, eventTarget)
 
 	var r0 types.NotifiedRecordsPerCluster
-	if rf, ok := ret.Get(0).(func([]types.ClusterEntry, string) types.NotifiedRecordsPerCluster); ok {
-		r0 = rf(clusterEntries, timeOffset)
+	if rf, ok := ret.Get(0).(func([]types.ClusterEntry, string, types.EventTarget) types.NotifiedRecordsPerCluster); ok {
+		r0 = rf(clusterEntries, timeOffset, eventTarget)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.NotifiedRecordsPerCluster)
@@ -217,8 +217,8 @@ func (_m *Storage) ReadLastNotifiedRecordForClusterList(clusterEntries []types.C
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([]types.ClusterEntry, string) error); ok {
-		r1 = rf(clusterEntries, timeOffset)
+	if rf, ok := ret.Get(1).(func([]types.ClusterEntry, string, types.EventTarget) error); ok {
+		r1 = rf(clusterEntries, timeOffset, eventTarget)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
# Description

I'm splitting https://github.com/RedHatInsights/ccx-notification-service/pull/243 into smaller pieces.

These changes uses the `types.NotificationBackendTarget` type in order to `ReadLastNotifiedRecordForClusterList` but just for the notification backend. It's a first step before listing the last notified records for service log.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Unit tests + BDD tests.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
