### PR TITLE
Fix security protocol value propagation from clowder

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -307,7 +307,7 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 			c.Kafka.SaslUsername = *broker.Sasl.Username
 			c.Kafka.SaslPassword = *broker.Sasl.Password
 			c.Kafka.SaslMechanism = *broker.Sasl.SaslMechanism
-
+			c.Kafka.SecurityProtocol = *broker.Sasl.SecurityProtocol
 			if caPath, err := clowder.LoadedConfig.KafkaCa(broker); err == nil {
 				c.Kafka.CertPath = caPath
 			}


### PR DESCRIPTION
# Description

Security protocol value from Clowder is not being propagated to our configuration struct.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
