### PR TITLE
Mention ccx-notification-service account credentials in the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ The "end-to-end" data flow is described there (including Notification Writer ser
 1. Content of that table is consumed by `ccx-notification-service` periodically.
 1. Newest results from `new_reports` table is compared with results stored in `reported` table.
 1. If changes (new issues) has been found, notification message is sent into Kafka topic named `platform.notifications.ingress`. The expected format of the message can be found [here](https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/send-notification.html#_kafka).
-1. New issues is also sent to Service Log via REST API
+1. New issues is also sent to Service Log via REST API. To use the Service Log API, the `ccx-notification-service` uses the credentials stored in [vault](https://vault.devshift.net/ui/vault/secrets/insights/show/secrets/insights-prod/ccx-data-pipeline-prod/ccx-notification-service-auth).
 1. The newest result is stored into `reported` table to be used in the next `ccx-notification-service` iteration.
 
 ### Remarks


### PR DESCRIPTION
# Description

Mention the need to use the ccx-notification-service account in the end to end data flow docs.

## Type of change

- Documentation update

