### PR TITLE
[CCXDEV-8785] Fix typo

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -113,7 +113,7 @@ objects:
               cpu: ${CPU_REQUEST}
               memory: ${MEMORY_REQUEST}
           env:
-          - name: CCX_NOTIFICATION_SERVICE__KAFKA__ENABLED
+          - name: CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ENABLED
             value: 'false'
           - name: CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED
             value: 'false'  # TODO: Enable

--- a/differ/slice_util.go
+++ b/differ/slice_util.go
@@ -1,0 +1,29 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import "strings"
+
+// inClauseFromStringSlice is a helper function to construct `in` clause for SQL
+// statement from a given slice of string items. If the slice is empty, an
+// empty string will be returned, making the in clause fail.
+func inClauseFromStringSlice(slice []string) string {
+	if len(slice) == 0 {
+		return ""
+	}
+	return "'" + strings.Join(slice, `','`) + `'`
+}

--- a/differ/slice_util_test.go
+++ b/differ/slice_util_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test the checkArgs function when flag for --show-version is set
+func TestInClauseFromSlice(t *testing.T) {
+	stringSlice := make([]string, 0)
+	assert.Equal(t, "", inClauseFromStringSlice(stringSlice))
+
+	stringSlice = []string{"first item", "second item"}
+	assert.Equal(t, "'first item','second item'", inClauseFromStringSlice(stringSlice))
+}

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -196,16 +196,6 @@ const (
 `
 )
 
-// inClauseFromStringSlice is a helper function to construct `in` clause for SQL
-// statement from a given slice of string items. If the slice is empty, an
-// empty string will be returned, making the in clause fail.
-func inClauseFromStringSlice(slice []string) string {
-	if len(slice) == 0 {
-		return ""
-	}
-	return "'" + strings.Join(slice, `','`) + `'`
-}
-
 // NewStorage function creates and initializes a new instance of Storage interface
 func NewStorage(configuration conf.StorageConfiguration) (*DBStorage, error) {
 	driverType, driverName, dataSource, err := initAndGetDriver(configuration)


### PR DESCRIPTION
# Description

Fix typo. Kafka wasn't disabled because the env variable was wrong.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
