### PR TITLE
[CCXDEV-9220] Don't update reported table if producer is disabled

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -97,29 +97,29 @@ func shouldNotify(cluster types.ClusterEntry, issue types.ReportItem, eventTarge
 	return getNotificationResolution(issue, reported)
 }
 
-func updateNotificationRecordSameState(storage Storage, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp) {
+func updateNotificationRecordSameState(storage Storage, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp, eventTarget types.EventTarget) {
 	log.Info().Msgf("No new issues to notify for cluster %s", cluster.ClusterName)
 	NotificationNotSentSameState.Inc()
 	// store notification info about not sending the notification
-	err := storage.WriteNotificationRecordForCluster(cluster, notificationTypes.Instant, states.SameState, report, notifiedAt, "")
+	err := storage.WriteNotificationRecordForCluster(cluster, notificationTypes.Instant, states.SameState, report, notifiedAt, "", eventTarget)
 	if err != nil {
 		writeNotificationRecordFailed(err)
 	}
 }
 
-func updateNotificationRecordSentState(storage Storage, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp) {
+func updateNotificationRecordSentState(storage Storage, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp, eventTarget types.EventTarget) {
 	log.Info().Msgf("New issues notified for cluster %s", string(cluster.ClusterName))
 	NotificationSent.Inc()
-	err := storage.WriteNotificationRecordForCluster(cluster, notificationTypes.Instant, states.SentState, report, notifiedAt, "")
+	err := storage.WriteNotificationRecordForCluster(cluster, notificationTypes.Instant, states.SentState, report, notifiedAt, "", eventTarget)
 	if err != nil {
 		writeNotificationRecordFailed(err)
 	}
 }
 
-func updateNotificationRecordErrorState(storage Storage, err error, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp) {
+func updateNotificationRecordErrorState(storage Storage, err error, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp, eventTarget types.EventTarget) {
 	log.Info().Msgf("New issues couldn't be notified for cluster %s", string(cluster.ClusterName))
 	NotificationNotSentErrorState.Inc()
-	err = storage.WriteNotificationRecordForCluster(cluster, notificationTypes.Instant, states.ErrorState, report, notifiedAt, err.Error())
+	err = storage.WriteNotificationRecordForCluster(cluster, notificationTypes.Instant, states.ErrorState, report, notifiedAt, err.Error(), eventTarget)
 	if err != nil {
 		writeNotificationRecordFailed(err)
 	}

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/RedHatInsights/ccx-notification-service/producer/kafka"
-	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	"io"
 	"os"
 	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/RedHatInsights/ccx-notification-service/producer/kafka"
+	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 
 	utypes "github.com/RedHatInsights/insights-results-types"
 
@@ -507,8 +508,9 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 		mock.AnythingOfType("types.StateID"),
 		mock.AnythingOfType("types.ClusterReport"),
 		mock.AnythingOfType("types.Timestamp"),
-		mock.AnythingOfType("string")).Return(
-		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string) error {
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).Return(
+		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string, eventTarget types.EventTarget) error {
 			return nil
 		},
 	)
@@ -664,8 +666,9 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 		mock.AnythingOfType("types.StateID"),
 		mock.AnythingOfType("types.ClusterReport"),
 		mock.AnythingOfType("types.Timestamp"),
-		mock.AnythingOfType("string")).Return(
-		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string) error {
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).Return(
+		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string, eventTarget types.EventTarget) error {
 			return nil
 		},
 	)
@@ -802,8 +805,9 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 		mock.AnythingOfType("types.StateID"),
 		mock.AnythingOfType("types.ClusterReport"),
 		mock.AnythingOfType("types.Timestamp"),
-		mock.AnythingOfType("string")).Return(
-		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string) error {
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).Return(
+		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string, eventTarget types.EventTarget) error {
 			return nil
 		},
 	)
@@ -886,8 +890,9 @@ func TestProcessClustersAllIssuesAlreadyNotifiedCooldownNotPassed(t *testing.T) 
 		mock.AnythingOfType("types.StateID"),
 		mock.AnythingOfType("types.ClusterReport"),
 		mock.AnythingOfType("types.Timestamp"),
-		mock.AnythingOfType("string")).Return(
-		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string) error {
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).Return(
+		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string, eventTarget types.EventTarget) error {
 			return nil
 		},
 	)
@@ -1032,8 +1037,9 @@ func TestProcessClustersNewIssuesNotPreviouslyNotified(t *testing.T) {
 		mock.AnythingOfType("types.StateID"),
 		mock.AnythingOfType("types.ClusterReport"),
 		mock.AnythingOfType("types.Timestamp"),
-		mock.AnythingOfType("string")).Return(
-		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string) error {
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("types.EventTarget")).Return(
+		func(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string, eventTarget types.EventTarget) error {
 			return nil
 		},
 	)

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -75,7 +75,8 @@ type Storage interface {
 		stateID types.StateID,
 		report types.ClusterReport,
 		notifiedAt types.Timestamp,
-		errorLog string) error
+		errorLog string,
+		eventTarget types.EventTarget) error
 	WriteNotificationRecordImpl(
 		orgID types.OrgID,
 		accountNumber types.AccountNumber,
@@ -528,13 +529,13 @@ func (storage DBStorage) WriteNotificationRecordForCluster(
 	stateID types.StateID,
 	report types.ClusterReport,
 	notifiedAt types.Timestamp,
-	errorLog string) error {
+	errorLog string,
+	eventTarget types.EventTarget) error {
 
-	// TODO: Accept event target too!!!!!
 	return storage.WriteNotificationRecordImpl(clusterEntry.OrgID,
 		clusterEntry.AccountNumber, clusterEntry.ClusterName,
 		notificationTypeID, stateID, report, clusterEntry.UpdatedAt,
-		notifiedAt, errorLog, types.NotificationBackendTarget)
+		notifiedAt, errorLog, eventTarget)
 }
 
 // ReadLastNotifiedRecordForClusterList method returns the last notification

--- a/producer/disabled/disabled_producer.go
+++ b/producer/disabled/disabled_producer.go
@@ -24,7 +24,7 @@ type Producer struct {
 
 // ProduceMessage doesn't publish any message.
 func (producer *Producer) ProduceMessage(msg types.ProducerMessage) (int32, int64, error) {
-	return 0, 0, nil
+	return 0, -1, nil
 }
 
 // Close return nil

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -356,13 +356,13 @@ func (_m *Storage) WriteNotificationRecord(notificationRecord types.Notification
 	return r0
 }
 
-// WriteNotificationRecordForCluster provides a mock function with given fields: clusterEntry, notificationTypeID, stateID, report, notifiedAt, errorLog
-func (_m *Storage) WriteNotificationRecordForCluster(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string) error {
-	ret := _m.Called(clusterEntry, notificationTypeID, stateID, report, notifiedAt, errorLog)
+// WriteNotificationRecordForCluster provides a mock function with given fields: clusterEntry, notificationTypeID, stateID, report, notifiedAt, errorLog, eventTarget
+func (_m *Storage) WriteNotificationRecordForCluster(clusterEntry types.ClusterEntry, notificationTypeID types.NotificationTypeID, stateID types.StateID, report types.ClusterReport, notifiedAt types.Timestamp, errorLog string, eventTarget types.EventTarget) error {
+	ret := _m.Called(clusterEntry, notificationTypeID, stateID, report, notifiedAt, errorLog, eventTarget)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(types.ClusterEntry, types.NotificationTypeID, types.StateID, types.ClusterReport, types.Timestamp, string) error); ok {
-		r0 = rf(clusterEntry, notificationTypeID, stateID, report, notifiedAt, errorLog)
+	if rf, ok := ret.Get(0).(func(types.ClusterEntry, types.NotificationTypeID, types.StateID, types.ClusterReport, types.Timestamp, string, types.EventTarget) error); ok {
+		r0 = rf(clusterEntry, notificationTypeID, stateID, report, notifiedAt, errorLog, eventTarget)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
# Description

More info in [Slack](https://coreos.slack.com/archives/C01A4DTTZN1/p1662387128250149).

Basically, when the notification-service encounters an issue that has to be notified it [updates the DB with sent state](https://github.com/RedHatInsights/ccx-notification-service/blob/68b58b8f4f8d28e1ef8e7712fccdadb0c78e67e3/differ/differ.go#L392), although it doesn't publish anything.

I added some changes in the code to:

* Use a new parameter in the function updateNotificationRecordSentState(storage, cluster, report, notifiedAt) being the eventTarget in order to update the DB accordingly
* Use updateNotificationRecordSentState just if the producer is enabled. I did this by checking the returned offset and setting the offset for the disabled producer to `-1`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

I updated the BDD tests: https://github.com/RedHatInsights/insights-behavioral-spec/pull/124

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
