### PR TITLE
Add Clowder topics mapping support in configuration load

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # CCX Processing team members are the default owners of the repository
-* @tisnik @Bee-lee @JoseLSegura @dpensi @matysek @epapbak @JiriPapousek
+* @tisnik @Bee-lee @joselsegura @dpensi @matysek @epapbak @JiriPapousek

--- a/conf/config.go
+++ b/conf/config.go
@@ -321,6 +321,8 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 				if caPath, err := clowder.LoadedConfig.KafkaCa(broker); err == nil {
 					c.Kafka.CertPath = caPath
 				}
+			} else {
+				fmt.Println(noSaslConfig)
 			}
 
 		} else {
@@ -328,7 +330,7 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 		}
 
 		if err := updateTopicsMapping(c); err != nil {
-			fmt.Printf(mappingTopicsError)
+			fmt.Println(mappingTopicsError)
 		}
 	}
 

--- a/conf/config.go
+++ b/conf/config.go
@@ -69,6 +69,15 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	noKafkaConfig      = "No Kafka configuration available in Clowder, using default one"
+	noBrokerConfig     = "warning: no broker configurations found in clowder config"
+	noSaslConfig       = "warning: SASL configuration is missing"
+	noTopicMapping     = "warning: no kafka mapping found for topic %s"
+	mappingTopicsError = "warning: an error occurred when applying new topics"
+	noStorage          = "warning: no storage section in Clowder config"
+)
+
 // ConfigStruct is a structure holding the whole notification service
 // configuration
 type ConfigStruct struct {
@@ -292,25 +301,34 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 
 	fmt.Println("Clowder is enabled")
 	if clowder.LoadedConfig.Kafka == nil {
-		fmt.Println("No Kafka configuration available in Clowder, using default one")
+		fmt.Println(noKafkaConfig)
 	} else {
-		broker := clowder.LoadedConfig.Kafka.Brokers[0]
-		// port can be empty in clowder, so taking it into account
-		if broker.Port != nil {
-			c.Kafka.Address = fmt.Sprintf("%s:%d", broker.Hostname, *broker.Port)
+		if len(clowder.LoadedConfig.Kafka.Brokers) > 0 {
+			broker := clowder.LoadedConfig.Kafka.Brokers[0]
+			// port can be empty in clowder, so taking it into account
+			if broker.Port != nil {
+				c.Kafka.Address = fmt.Sprintf("%s:%d", broker.Hostname, *broker.Port)
+			} else {
+				c.Kafka.Address = broker.Hostname
+			}
+
+			// SSL config
+			if broker.Authtype != nil {
+				c.Kafka.SaslUsername = *broker.Sasl.Username
+				c.Kafka.SaslPassword = *broker.Sasl.Password
+				c.Kafka.SaslMechanism = *broker.Sasl.SaslMechanism
+				c.Kafka.SecurityProtocol = *broker.Sasl.SecurityProtocol
+				if caPath, err := clowder.LoadedConfig.KafkaCa(broker); err == nil {
+					c.Kafka.CertPath = caPath
+				}
+			}
+
 		} else {
-			c.Kafka.Address = broker.Hostname
+			fmt.Println(noBrokerConfig)
 		}
 
-		// SSL config
-		if broker.Authtype != nil {
-			c.Kafka.SaslUsername = *broker.Sasl.Username
-			c.Kafka.SaslPassword = *broker.Sasl.Password
-			c.Kafka.SaslMechanism = *broker.Sasl.SaslMechanism
-			c.Kafka.SecurityProtocol = *broker.Sasl.SecurityProtocol
-			if caPath, err := clowder.LoadedConfig.KafkaCa(broker); err == nil {
-				c.Kafka.CertPath = caPath
-			}
+		if err := updateTopicsMapping(c); err != nil {
+			fmt.Printf(mappingTopicsError)
 		}
 	}
 
@@ -321,6 +339,19 @@ func updateConfigFromClowder(c *ConfigStruct) error {
 		c.Storage.PGPort = clowder.LoadedConfig.Database.Port
 		c.Storage.PGUsername = clowder.LoadedConfig.Database.Username
 		c.Storage.PGPassword = clowder.LoadedConfig.Database.Password
+	} else {
+		fmt.Println(noStorage)
+	}
+
+	return nil
+}
+
+func updateTopicsMapping(c *ConfigStruct) error {
+	// Updating topics from clowder mapping if available
+	if topicCfg, ok := clowder.KafkaTopics[c.Kafka.Topic]; ok {
+		c.Kafka.Topic = topicCfg.Name
+	} else {
+		fmt.Printf(noTopicMapping, c.Kafka.Topic)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Add support for Clowder topics mapping in order to update the topic configuration of the job.

Fixes [#CCXDEV-9200](https://issues.redhat.com/browse/CCXDEV-9200)

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Unit tests, local tests

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
