### PR TITLE
Change service log configuration to include info for token refreshment

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -152,7 +152,8 @@ type KafkaConfiguration struct {
 // ServiceLogConfiguration represents configuration of ServiceLog REST API
 type ServiceLogConfiguration struct {
 	Enabled             bool          `mapstructure:"enabled" toml:"enabled"`
-	AccessToken         string        `mapstructure:"access_token" toml:"access_token"`
+	OfflineToken        string        `mapstructure:"offline_token" toml:"offline_token"`
+	TokenRefreshmentURL string        `mapstructure:"token_refreshment_url" toml:"token_refreshment_url"`
 	URL                 string        `mapstructure:"url" toml:"url"`
 	Timeout             time.Duration `mapstructure:"timeout" toml:"timeout"`
 	LikelihoodThreshold int           `mapstructure:"likelihood_threshold" toml:"likelihood_threshold"`

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -124,7 +124,8 @@ func TestLoadServiceLogConfiguration(t *testing.T) {
 
 	assert.False(t, serviceLogCfg.Enabled)
 	assert.Equal(t, 3, serviceLogCfg.TotalRiskThreshold)
-	assert.Equal(t, "test", serviceLogCfg.AccessToken)
+	assert.Equal(t, "test", serviceLogCfg.OfflineToken)
+	assert.Equal(t, "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token", serviceLogCfg.TokenRefreshmentURL)
 	assert.Equal(t, "localhost:8000/api/service_logs/v1/cluster_logs/", serviceLogCfg.URL)
 	assert.Equal(t, expectedTimeout, serviceLogCfg.Timeout)
 }

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -15,7 +15,8 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
-access_token = ""
+offline_token = ""
+token_refreshment_url = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 url = "localhost:8000/api/service_logs/v1/cluster_logs/"
 timeout = "15s"
 likelihood_threshold = 0

--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,8 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
-access_token = ""
+offline_token = ""
+token_refreshment_url = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 url = "https://api.openshift.com/api/service_logs/v1/cluster_logs/"
 timeout = "15s"
 likelihood_threshold = 0

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -117,8 +117,10 @@ objects:
             value: 'false'
           - name: CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ENABLED
             value: 'false'  # TODO: Enable
-          - name: CCX_NOTIFICATION_SERVICE__SERVICE_LOG__ACCESS_TOKEN
-            value: ${SERVICE_LOG__ACCESS_TOKEN}
+          - name: CCX_NOTIFICATION_SERVICE__SERVICE_LOG__OFFLINE_TOKEN
+            value: ${SERVICE_LOG__OFFLINE_TOKEN}
+          - name: CCX_NOTIFICATION_SERVICE__SERVICE_LOG__TOKEN_REFRESHMENT_URL
+            value: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
           - name: CCX_NOTIFICATION_SERVICE__SERVICE_LOG__URL
             value: ${SERVICE_LOG__URL}
           - name: CCX_NOTIFICATION_SERVICE__SERVICE_LOG__TIMEOUT
@@ -242,7 +244,7 @@ parameters:
   name: CLEANUP_MAX_AGE
   value: '8 days'
 # Service Log
-- description: Access token to publish to Service Log
-  name: SERVICE_LOG__ACCESS_TOKEN
+- description: Offline token for retrieving access tokens to publish to Service Log
+  name: SERVICE_LOG__OFFLINE_TOKEN
 - description: URL of the Service Log API
   name: SERVICE_LOG__URL

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -11,7 +11,8 @@ event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
 enabled = false
-access_token = "test"
+offline_token = "test"
+token_refreshment_url = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 url = "localhost:8000/api/service_logs/v1/cluster_logs/"
 timeout = "15s"
 likelihood_threshold = 0


### PR DESCRIPTION
# Description

Access token for acessing Service Log API needs to be periodically refreshed, therefore access token is replaced with offline token and URL to token refreshment API.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Run unit tests.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
