### PR TITLE
Do not exit cluster entry processing if report not read

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -307,7 +307,7 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 		if err != nil {
 			ReadReportForClusterErrors.Inc()
 			log.Err(err).Msg(operationFailedMessage)
-			os.Exit(ExitStatusStorageError)
+			continue
 		}
 
 		var deserialized types.Report
@@ -315,7 +315,7 @@ func processReportsByCluster(ruleContent types.RulesMap, storage Storage, cluste
 		if err != nil {
 			DeserializeReportErrors.Inc()
 			log.Err(err).Msg("Deserialization error - Couldn't create report object")
-			os.Exit(ExitStatusStorageError)
+			continue
 		}
 
 		if len(deserialized.Reports) == 0 {


### PR DESCRIPTION
# Description

While processing cluster entries, it can happen that we try to read a report that is empty or cannot be deserialised into the [Report structure](https://github.com/RedHatInsights/ccx-notification-service/blob/master/types/types.go#L148). When that happens, we should simply skip that entry and process the next one instead of exiting.

Fixes CCXDEV-9230

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

- Running existing UTs
- test with local DB using new report with empty value in report column (creating BDD for this)
- test with local DB using new report with some fields but no reports  (creating BDD for this)

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
