### PR TITLE
Remove cleanup operation from service log

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -178,7 +178,7 @@ objects:
           command:
             - /bin/sh
             - -c
-            - ./ccx-notification-service --instant-reports --cleanup-on-startup --max-age '${CLEANUP_MAX_AGE}' --verbose
+            - ./ccx-notification-service --instant-reports --verbose
 
     kafkaTopics:
       - topicName: ${OUTGOING_TOPIC}


### PR DESCRIPTION
# Description

Removing the clean up operation from service log.

We have both service log and notification backend jobs stuck in stage because this operation is too heavy and blocking, so when one is deleting the other is blocked. 

This was detected because the crontab was set each 3 minutes (which is the schedule for stage - it was a typo). The jobs started at the same time and the DB got exhausted. Now the jobs run every 15 minutes each, but the service log one starting at minute 8, so this shouldn't happen again.

However, when prod is updated and the cronjobs restarted, the first run is at the same time, so this change is still necessary.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

None.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
