### PR TITLE
Add functions for processing content templates

### DIFF
--- a/config-devel.toml
+++ b/config-devel.toml
@@ -38,6 +38,8 @@ log_sql_queries = true
 [dependencies]
 content_server = "localhost:8082"
 content_endpoint = "/api/v1/content"
+template_renderer_server = "localhost:8083"
+template_renderer_endpoint = "/rendered_reports"
 
 [notifications]
 insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"

--- a/config.toml
+++ b/config.toml
@@ -43,6 +43,8 @@ log_sql_queries = true
 [dependencies]
 content_server = "localhost:8082" #provide in deployment env or as secret
 content_endpoint = "/api/v1/content" #provide in deployment env or as secret
+template_renderer_server = "localhost:8083" #provide in deployment env or as secret
+template_renderer_endpoint = "/rendered_reports" #provide in deployment env or as secret
 
 [notifications]
 insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -149,6 +149,10 @@ objects:
             value: http://ccx-insights-content-service:${CONTENT_SERVICE_PORT}/api/v1/
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_ENDPOINT
             value: content
+          - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_SERVER
+            value: ${TEMPLATE_RENDERER_SERVER}
+          - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_ENDPOINT
+            value: rendered_reports
           - name: CCX_NOTIFICATION_SERVICE__NOTIFICATIONS__INSIGHTS_ADVISOR_URL
             value: "https://${PLATFORM_UI_HOSTNAME}/openshift/insights/advisor/clusters/{cluster_id}"
           - name: CCX_NOTIFICATION_SERVICE__NOTIFICATIONS__CLUSTER_DETAILS_URI
@@ -243,6 +247,8 @@ parameters:
 - description: Maximum age for reports cleanup on startup
   name: CLEANUP_MAX_AGE
   value: '8 days'
+- description: Domain name and port of the content template renderer API
+  name: TEMPLATE_RENDERER_SERVER
 # Service Log
 - description: Offline token for retrieving access tokens to publish to Service Log
   name: SERVICE_LOG__OFFLINE_TOKEN

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -86,7 +86,7 @@ func captureStdout(f func()) string {
 	return buf.String()
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 func TestToJSONEscapedStringValidJSON(t *testing.T) {
 	type testStruct struct {
 		Name         string
@@ -123,7 +123,7 @@ func TestToJSONEscapedStringInvalidJSON(t *testing.T) {
 	assert.Equal(t, expectedEscapedJSONString, toJSONEscapedString(tested))
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 func TestGenerateInstantReportNotificationMessage(t *testing.T) {
 	clusterURI := "the_cluster_uri_in_ocm_for_{cluster_id}"
 	accountID := "a_stringified_account_id"
@@ -173,7 +173,7 @@ func TestAppendEventsToExistingInstantReportNotificationMsg(t *testing.T) {
 	assert.Equal(t, notificationMsg.Events[1].Metadata, types.EventMetadata{}, "All notification messages should have empty metadata")
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 func TestUpdateDigestNotificationCounters(t *testing.T) {
 	digest := types.Digest{}
 	expectedDigest := types.Digest{}
@@ -231,7 +231,7 @@ func TestGenerateWeeklyDigestNotificationMessage(t *testing.T) {
 	assert.Equal(t, expectedEvent, notificationMsg.Events[0])
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 func TestShowVersion(t *testing.T) {
 	assert.Contains(t, captureStdout(showVersion), versionMessage, "showVersion function is not displaying the expected content")
 }
@@ -302,7 +302,7 @@ func TestShowConfiguration(t *testing.T) {
 	assert.Contains(t, output, metricsGateway)
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 func TestTotalRiskCalculation(t *testing.T) {
 	type testStruct struct {
 		impact       int
@@ -332,7 +332,7 @@ func TestModuleNameToRuleNameValidRuleName(t *testing.T) {
 	assert.Equal(t, ruleName, moduleToRuleName(moduleName))
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 func TestSetupNotificationProducerInvalidBrokerConf(t *testing.T) {
 	if os.Getenv("SETUP_PRODUCER") == "1" {
 		testConfig := conf.ConfigStruct{
@@ -422,7 +422,7 @@ func TestSetupNotificationProducerDisabledBrokerConfig(t *testing.T) {
 	assert.NoError(t, notifier.Close(), "error closing producer")
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 // TestProcessClustersNoReportForClusterEntry tests that when no report is found for
 // a given cluster entry, the processing is not stopped
 func TestProcessClustersNoReportForClusterEntry(t *testing.T) {
@@ -1316,7 +1316,7 @@ func TestProcessClustersNewIssuesNotPreviouslyNotified(t *testing.T) {
 	}
 }
 
-//---------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------
 func TestProcessClustersWeeklyDigest(t *testing.T) {
 	buf := new(bytes.Buffer)
 	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)

--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -1,0 +1,122 @@
+// Copyright 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import (
+	"encoding/json"
+	"github.com/RedHatInsights/ccx-notification-service/conf"
+	"github.com/RedHatInsights/ccx-notification-service/types"
+	utypes "github.com/RedHatInsights/insights-results-types"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRenderReportsForCluster(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"clusters":["e1a379e4-9ac5-4353-8f82-ad066a734f18"],"reports":{"e1a379e4-9ac5-4353-8f82-ad066a734f18":[{"rule_id":"rule_1","error_key":"RULE_1","resolution":"rule 1 resolution","reason":"rule 1 reason","description":"rule 1 error key description"},{"rule_id":"rule_2","error_key":"RULE_2","resolution":"rule 2 resolution","reason":"","description":"rule 2 error key description"}]}}`))
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+	}))
+	defer server.Close()
+
+	config := conf.DependenciesConfiguration{
+		TemplateRendererServer:   server.URL,
+		TemplateRendererEndpoint: "",
+		TemplateRendererURL:      server.URL,
+	}
+
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
+		"RULE_1": {
+			Metadata: utypes.ErrorKeyMetadata{
+				Description: "rule 1 error key description",
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 3,
+				},
+				Likelihood: 2,
+			},
+			Reason:    "rule 1 reason",
+			HasReason: true,
+		},
+		"RULE_2": {
+			Metadata: utypes.ErrorKeyMetadata{
+				Description: "rule 2 error key description",
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 2,
+				},
+				Likelihood: 3,
+			},
+			HasReason: false,
+		},
+	}
+	ruleContent := types.RulesMap{
+		"rule_1": {
+			Plugin: utypes.RulePluginInfo{
+				PythonModule: "rule_1",
+			},
+			Summary:    "rule 1 summary",
+			Reason:     "rule 1 reason",
+			Resolution: "rule 1 resolution",
+			MoreInfo:   "rule 1 more info",
+			ErrorKeys:  errorKeys,
+			HasReason:  true,
+		},
+		"rule_2": {
+			Plugin: utypes.RulePluginInfo{
+				PythonModule: "rule_2",
+			},
+			Summary:    "rule 2 summary",
+			Reason:     "",
+			Resolution: "rule 2 resolution",
+			MoreInfo:   "rule 2 more info",
+			ErrorKeys:  errorKeys,
+			HasReason:  false,
+		},
+	}
+
+	reports := []types.ReportItem{
+		types.ReportItem{
+			Type:     "rule",
+			Module:   "rule_1.report",
+			ErrorKey: "RULE_1",
+			Details:  json.RawMessage("{}"),
+		},
+		types.ReportItem{
+			Type:     "rule",
+			Module:   "rule_2.report",
+			ErrorKey: "RULE_2",
+			Details:  json.RawMessage("{}"),
+		},
+	}
+
+	rendereredReports, err := renderReportsForCluster(config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", reports, ruleContent)
+	v, _ := json.Marshal(rendereredReports)
+	log.Info().Msg(string(v))
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(rendereredReports))
+	assert.Contains(t, rendereredReports, types.RenderedReport{
+		RuleID:      "rule_1",
+		ErrorKey:    "RULE_1",
+		Resolution:  "rule 1 resolution",
+		Reason:      "rule 1 reason",
+		Description: "rule 1 error key description",
+	})
+}

--- a/types/types.go
+++ b/types/types.go
@@ -256,6 +256,33 @@ type NotifiedRecordsPerCluster map[ClusterOrgKey]NotificationRecord
 // NotifiedRecordsPerClusterByTarget let us split the notified records by their target (CCXDEV-8767)
 type NotifiedRecordsPerClusterByTarget map[EventTarget]NotifiedRecordsPerCluster
 
+// RenderedReport contains all rendered text fields for specific cluster report
+type RenderedReport struct {
+	RuleID      RuleID   `json:"rule_id"`
+	ErrorKey    ErrorKey `json:"error_key"`
+	Resolution  string   `json:"resolution"`
+	Reason      string   `json:"reason"`
+	Description string   `json:"description"`
+}
+
+// TemplateRendererOutput is an output structure from content template renderer
+type TemplateRendererOutput struct {
+	Clusters []ClusterName                    `json:"clusters"`
+	Reports  map[ClusterName][]RenderedReport `json:"reports"`
+}
+
+// ReportData is part of the request to content template renderer containing report data
+type ReportData struct {
+	Clusters []ClusterName          `json:"clusters"`
+	Reports  map[ClusterName]Report `json:"reports"`
+}
+
+// TemplateRendererRequestBody is a structure to be sent in request body to content template renderer
+type TemplateRendererRequestBody struct {
+	Content    []types.RuleContent `json:"content"`
+	ReportData ReportData          `json:"report_data"`
+}
+
 // ServiceLogEntry is a structure to be sent to Service Log
 type ServiceLogEntry struct {
 	ClusterUUID string `json:"cluster_uuid"`


### PR DESCRIPTION
# Description

Adds a `differ/renderer.go` file containing functionality for renderering content templates by sending requests to `content-template-renderer` service. This functionality is necessary for Service Log integration

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Functionality is not yet integrated with the rest of the code, but has been successfully used locally with modified `differ/differ.go` and additional test has been created for `renderer.go`.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
