### PR TITLE
Service Log integration

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -275,13 +275,14 @@ func calculateTotalRisk(impact, likelihood int) int {
 // cluster_wide_proxy_auth_check
 func moduleToRuleName(module types.ModuleName) types.RuleName {
 	result := strings.TrimSuffix(string(module), ".report")
-	result = strings.TrimPrefix(result, "ccx_rules_ocp.")
-	result = strings.TrimPrefix(result, "external.")
-	result = strings.TrimPrefix(result, "rules.")
-	result = strings.TrimPrefix(result, "bug_rules.")
-	result = strings.TrimPrefix(result, "ocs.")
+	return ruleIDToRuleName(types.RuleID(result))
+}
 
-	return types.RuleName(result)
+// ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check
+// ->
+// cluster_wide_proxy_auth_check
+func ruleIDToRuleName(ruleID types.RuleID) types.RuleName {
+	return types.RuleName(string(ruleID)[strings.LastIndex(string(ruleID), ".")+1:])
 }
 
 func findRuleByNameAndErrorKey(
@@ -318,8 +319,8 @@ func evaluateFilterExpression(eventFilter string, thresholds EventThresholds, ev
 
 func findRenderedReport(reports []types.RenderedReport, ruleName types.RuleName, errorKey types.ErrorKey) (types.RenderedReport, error) {
 	for _, report := range reports {
-		reportRuleName := string(report.RuleID)[strings.LastIndex(string(report.RuleID), ".")+1:]
-		if reportRuleName == string(ruleName) && report.ErrorKey == errorKey {
+		reportRuleName := ruleIDToRuleName(report.RuleID)
+		if reportRuleName == ruleName && report.ErrorKey == errorKey {
 			return report, nil
 		}
 	}

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -25,6 +25,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"testing"
@@ -529,7 +531,7 @@ func TestProcessClustersNoReportForClusterEntry(t *testing.T) {
 	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "no rows in result set", "No report should be retrieved for the first cluster")
@@ -642,7 +644,7 @@ func TestProcessClustersInvalidReportFormatForClusterEntry(t *testing.T) {
 	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "cannot unmarshal object into Go struct field Report.reports of type []types.ReportItem", "The string retrieved is not a list of reports. It should not deserialize correctly")
@@ -745,7 +747,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskInferiorToThreshold(t *testing.
 		},
 	)
 
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "No new issues to notify for cluster first_cluster", "processClusters shouldn't generate any notification for 'first_cluster' with given data")
@@ -903,7 +905,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 		},
 	)
 
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "Report with high impact detected", "processClusters should create a notification for 'first_cluster' with given data")
@@ -1042,7 +1044,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 		},
 	)
 
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "{\"level\":\"warn\",\"type\":\"rule\",\"rule\":\"rule_1\",\"error key\":\"RULE_1\",\"likelihood\":4,\"impact\":4,\"totalRisk\":4,\"message\":\"Report with high impact detected\"}\n")
@@ -1150,7 +1152,7 @@ func TestProcessClustersAllIssuesAlreadyNotifiedCooldownNotPassed(t *testing.T) 
 		NotifiedAt:         types.Timestamp(testTimestamp.Add(-2)),
 		ErrorLog:           "",
 	}
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"message\":\"No new issues to notify for cluster first_cluster\"}\n", "Notification already sent for first_cluster's report, but corresponding log not found.")
@@ -1304,7 +1306,7 @@ func TestProcessClustersNewIssuesNotPreviouslyNotified(t *testing.T) {
 		ErrorLog:           "",
 	}
 
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "{\"level\":\"warn\",\"type\":\"rule\",\"rule\":\"rule_1\",\"error key\":\"RULE_1\",\"likelihood\":4,\"impact\":4,\"totalRisk\":4,\"message\":\"Report with high impact detected\"}\n")
@@ -1439,7 +1441,7 @@ func TestProcessClustersWeeklyDigest(t *testing.T) {
 	kafkaNotifier = &producerMock
 
 	notificationType = types.WeeklyDigest
-	processClusters(ruleContent, &storage, clusters)
+	processClusters(conf.ConfigStruct{}, ruleContent, &storage, clusters)
 
 	print(buf.String())
 
@@ -1450,4 +1452,119 @@ func TestProcessClustersWeeklyDigest(t *testing.T) {
 
 	zerolog.SetGlobalLevel(zerolog.WarnLevel)
 	kafkaNotifier = originalNotifier
+}
+
+// ---------------------------------------------------------------------------------------
+func TestProduceEntriesToServiceLog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rendered_reports" {
+			t.Errorf("Expected to request '/render_reports', got: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type: application/json header, got: %s", r.Header.Get("Accept"))
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"clusters":["first_cluster"],"reports":{"first_cluster":[{"rule_id":"ccx_rules_ocp.external.rules.rule_1","error_key":"RULE_1","resolution":"rule 1 resolution","reason":"This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long.","description":"This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long."},{"rule_id":"ccx_rules_ocp.external.rules.rule_2","error_key":"RULE_2","resolution":"rule 2 resolution","reason":"rule 2 reason","description":"rule 2 error key description"}]}}`))
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+	}))
+	defer server.Close()
+
+	config := conf.ConfigStruct{
+		ServiceLog: conf.ServiceLogConfiguration{
+			Enabled:            true,
+			TotalRiskThreshold: 1,
+			EventFilter:        "totalRisk > totalRiskThreshold",
+		},
+		Dependencies: conf.DependenciesConfiguration{
+			TemplateRendererServer:   server.URL,
+			TemplateRendererEndpoint: "/rendered_reports",
+			TemplateRendererURL:      server.URL + "/rendered_reports",
+		},
+	}
+	serviceLogEventThresholds.TotalRisk = 1
+	serviceLogEventFilter = "totalRisk > totalRiskThreshold"
+
+	errorKeys := map[string]utypes.RuleErrorKeyContent{
+		"RULE_1": {
+			Metadata: utypes.ErrorKeyMetadata{
+				Description: "This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long.",
+				Impact: utypes.Impact{
+					Name:   "impact_1",
+					Impact: 3,
+				},
+				Likelihood: 2,
+			},
+			Reason:    "rule 1 reason",
+			HasReason: true,
+		},
+		"RULE_2": {
+			Metadata: utypes.ErrorKeyMetadata{
+				Description: "rule 2 error key description",
+				Impact: utypes.Impact{
+					Name:   "impact_2",
+					Impact: 2,
+				},
+				Likelihood: 3,
+			},
+			HasReason: false,
+		},
+	}
+
+	ruleContent := types.RulesMap{
+		"rule_1": {
+			Summary:    "rule 1 summary",
+			Reason:     "This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long.",
+			Resolution: "rule 1 resolution",
+			MoreInfo:   "rule 1 more info",
+			ErrorKeys:  errorKeys,
+			HasReason:  true,
+		},
+		"rule_2": {
+			Summary:    "rule 2 summary",
+			Reason:     "rule 2 reason",
+			Resolution: "rule 2 resolution",
+			MoreInfo:   "rule 2 more info",
+			ErrorKeys:  errorKeys,
+			HasReason:  false,
+		},
+	}
+
+	cluster := types.ClusterEntry{
+		OrgID:         1,
+		AccountNumber: 1,
+		ClusterName:   "first_cluster",
+		KafkaOffset:   0,
+		UpdatedAt:     types.Timestamp(testTimestamp),
+	}
+
+	var deserialized types.Report
+	reportsJSON := types.ClusterReport("{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_1|RULE_1\",\"component\":\"ccx_rules_ocp.external.rules.rule_1.report\",\"type\":\"rule\",\"key\":\"RULE_1\",\"details\":\"some details\"},{\"rule_id\":\"rule_2|RULE_2\",\"component\":\"ccx_rules_ocp.external.rules.rule_2.report\",\"type\":\"rule\",\"key\":\"RULE_2\",\"details\":\"some details\"}]}")
+	err := json.Unmarshal([]byte(reportsJSON), &deserialized)
+	if err != nil {
+		log.Fatal().Msg(err.Error())
+	}
+	reports := deserialized.Reports
+
+	producerMock := mocks.Producer{}
+	producerMock.On("ProduceMessage", mock.AnythingOfType("types.ProducerMessage")).Return(
+		func(msg types.ProducerMessage) int32 {
+			return 0
+		},
+		func(msg types.ProducerMessage) int64 {
+			return 0
+		},
+		func(msg types.ProducerMessage) error {
+			return nil
+		},
+	)
+
+	originalNotifier := serviceLogNotifier
+	serviceLogNotifier = &producerMock
+
+	produceEntriesToServiceLog(config, cluster, ruleContent, reports)
+	producerMock.AssertNumberOfCalls(t, "ProduceMessage", 2)
+
+	serviceLogNotifier = originalNotifier
 }

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/RedHatInsights/ccx-notification-service/producer/kafka"
 	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 
 	utypes "github.com/RedHatInsights/insights-results-types"
 
@@ -1464,7 +1465,7 @@ func TestProduceEntriesToServiceLog(t *testing.T) {
 			t.Errorf("Expected Content-Type: application/json header, got: %s", r.Header.Get("Accept"))
 		}
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(`{"clusters":["first_cluster"],"reports":{"first_cluster":[{"rule_id":"ccx_rules_ocp.external.rules.rule_1","error_key":"RULE_1","resolution":"rule 1 resolution","reason":"This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long.","description":"This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long."},{"rule_id":"ccx_rules_ocp.external.rules.rule_2","error_key":"RULE_2","resolution":"rule 2 resolution","reason":"rule 2 reason","description":"rule 2 error key description"}]}}`))
+		_, err := w.Write([]byte(`{"clusters":["84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc"],"reports":{"84f7eedc-0dd8-49cd-9d4d-f6646df3a5bc":[{"rule_id":"node_installer_degraded","error_key":"ek1","resolution":"rule 1 resolution","reason":"This reason is more than 255 characters long. This reason is more than 255 characters long. This reason is more than 255 characters long. This reason is more than 255 characters long. This reason is more than 255 characters long. This reason is more than 255 characters long.","description":"This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long."},{"rule_id":"rule2","error_key":"ek2","resolution":"rule 2 resolution","reason":"rule 2 reason","description":"rule 2 error key description"}, {"rule_id":"rule3","error_key":"ek3","resolution":"rule 3 resolution","reason":"rule 3 reason","description":"rule 3 error key description"}]}}`))
 		if err != nil {
 			log.Fatal().Msg(err.Error())
 		}
@@ -1486,62 +1487,22 @@ func TestProduceEntriesToServiceLog(t *testing.T) {
 	serviceLogEventThresholds.TotalRisk = 1
 	serviceLogEventFilter = "totalRisk > totalRiskThreshold"
 
-	errorKeys := map[string]utypes.RuleErrorKeyContent{
-		"RULE_1": {
-			Metadata: utypes.ErrorKeyMetadata{
-				Description: "This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long.",
-				Impact: utypes.Impact{
-					Name:   "impact_1",
-					Impact: 3,
-				},
-				Likelihood: 2,
-			},
-			Reason:    "rule 1 reason",
-			HasReason: true,
-		},
-		"RULE_2": {
-			Metadata: utypes.ErrorKeyMetadata{
-				Description: "rule 2 error key description",
-				Impact: utypes.Impact{
-					Name:   "impact_2",
-					Impact: 2,
-				},
-				Likelihood: 3,
-			},
-			HasReason: false,
-		},
-	}
-
 	ruleContent := types.RulesMap{
-		"rule_1": {
-			Summary:    "rule 1 summary",
-			Reason:     "This reason is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long. This summary is more than 255 characters long.",
-			Resolution: "rule 1 resolution",
-			MoreInfo:   "rule 1 more info",
-			ErrorKeys:  errorKeys,
-			HasReason:  true,
-		},
-		"rule_2": {
-			Summary:    "rule 2 summary",
-			Reason:     "rule 2 reason",
-			Resolution: "rule 2 resolution",
-			MoreInfo:   "rule 2 more info",
-			ErrorKeys:  errorKeys,
-			HasReason:  false,
-		},
+		"node_installer_degraded": testdata.RuleContent1,
+		"rule2":                   testdata.RuleContent2,
+		"rule3":                   testdata.RuleContent3,
 	}
 
 	cluster := types.ClusterEntry{
 		OrgID:         1,
 		AccountNumber: 1,
-		ClusterName:   "first_cluster",
+		ClusterName:   types.ClusterName(testdata.ClusterName),
 		KafkaOffset:   0,
 		UpdatedAt:     types.Timestamp(testTimestamp),
 	}
 
 	var deserialized types.Report
-	reportsJSON := types.ClusterReport("{\"analysis_metadata\":{\"metadata\":\"some metadata\"},\"reports\":[{\"rule_id\":\"rule_1|RULE_1\",\"component\":\"ccx_rules_ocp.external.rules.rule_1.report\",\"type\":\"rule\",\"key\":\"RULE_1\",\"details\":\"some details\"},{\"rule_id\":\"rule_2|RULE_2\",\"component\":\"ccx_rules_ocp.external.rules.rule_2.report\",\"type\":\"rule\",\"key\":\"RULE_2\",\"details\":\"some details\"}]}")
-	err := json.Unmarshal([]byte(reportsJSON), &deserialized)
+	err := json.Unmarshal([]byte(testdata.ClusterReport3Rules), &deserialized)
 	if err != nil {
 		log.Fatal().Msg(err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/RedHatInsights/insights-operator-utils v1.24.1
+	github.com/RedHatInsights/insights-results-aggregator-data v1.3.3 // indirect
 	github.com/RedHatInsights/insights-results-types v1.3.12
 	github.com/Shopify/sarama v1.27.1
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect

--- a/types/types.go
+++ b/types/types.go
@@ -285,10 +285,10 @@ type TemplateRendererRequestBody struct {
 
 // ServiceLogEntry is a structure to be sent to Service Log
 type ServiceLogEntry struct {
-	ClusterUUID string `json:"cluster_uuid"`
-	Description string `json:"description"`
-	ServiceName string `json:"service_name"`
-	Summary     string `json:"summary"`
+	ClusterUUID ClusterName `json:"cluster_uuid"`
+	Description string      `json:"description"`
+	ServiceName string      `json:"service_name"`
+	Summary     string      `json:"summary"`
 }
 
 // AccessTokenOutput is a structure containing fresh access token


### PR DESCRIPTION
# Description

Include sending messages to service log as a part of `differ.go`. Before enabling this feature in configuration, content-template-renderer service needs to be deployed.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Tried changes locally, added new test.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
