### PR TITLE
[CCXDEV-9219] Differentiate the metrics between SL and NB targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ gen-mocks: ## Generates the mocks using mockery. Needs go >= 1.18
 	go install github.com/vektra/mockery/v2@latest  
 	mockery --all --output tests/mocks
 
-test: ${BINARY} gen-mocks ## Run the unit tests
+test: ${BINARY} ## Run the unit tests
 	./unit-tests.sh
 
 build-test: gen-mocks ## Build native binary with unit tests and benchmarks

--- a/conf/config.go
+++ b/conf/config.go
@@ -180,6 +180,7 @@ type NotificationsConfiguration struct {
 type MetricsConfiguration struct {
 	Job              string        `mapstructure:"job_name" toml:"job_name"`
 	Namespace        string        `mapstructure:"namespace" toml:"namespace"`
+	Subsystem        string        `mapstructure:"subsystem" toml:"subsystem"`
 	GatewayURL       string        `mapstructure:"gateway_url" toml:"gateway_url"`
 	GatewayAuthToken string        `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
 	Retries          int           `mapstructure:"retries" toml:"retries"`

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -51,6 +51,7 @@ cooldown = "1 minutes"
 [metrics]
 job_name = "ccx_notification_service"
 namespace = "ccx_notification_service"
+subsystem = "devel"
 gateway_url = "localhost:9091"
 gateway_auth_token = ""
 

--- a/config.toml
+++ b/config.toml
@@ -55,7 +55,9 @@ cooldown = "24 hours"
 
 [metrics]
 job_name = "ccx_notification_service"
+# The metrics in Prometheus will be $namespace_$subsystem_$name
 namespace = "ccx_notification_service"
+subsystem = "to_notification_backend"
 gateway_url = "localhost:9091"
 gateway_auth_token = ""
 retries = 3

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -80,6 +80,8 @@ objects:
             value: ccx_notification_service
           - name: CCX_NOTIFICATION_SERVICE__METRICS__NAMESPACE
             value: ${METRICS_NAMESPACE}
+          - name: CCX_NOTIFICATION_SERVICE__METRICS__SUBSYSTEM
+            value: notification_backend
           - name: CCX_NOTIFICATION_SERVICE__METRICS__GATEWAY_URL
             valueFrom:
               secretKeyRef:
@@ -165,6 +167,8 @@ objects:
             value: ccx_notification_service
           - name: CCX_NOTIFICATION_SERVICE__METRICS__NAMESPACE
             value: ${METRICS_NAMESPACE}
+          - name: CCX_NOTIFICATION_SERVICE__METRICS__SUBSYSTEM
+            value: service_log
           - name: CCX_NOTIFICATION_SERVICE__METRICS__GATEWAY_URL
             valueFrom:
               secretKeyRef:

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -774,7 +774,9 @@ func setupNotificationStates(storage *DBStorage) {
 func registerMetrics(metricsConfig conf.MetricsConfiguration) {
 	if metricsConfig.Namespace != "" {
 		log.Info().Str("namespace", metricsConfig.Namespace).Msg("Setting metrics namespace")
-		AddMetricsWithNamespace(metricsConfig.Namespace)
+		AddMetricsWithNamespaceAndSubsystem(
+			metricsConfig.Namespace,
+			metricsConfig.Subsystem)
 	}
 }
 

--- a/differ/metrics.go
+++ b/differ/metrics.go
@@ -26,12 +26,13 @@ package differ
 // https://redhatinsights.github.io/ccx-notification-service/packages/differ/metrics.html
 
 import (
+	"net/http"
+
 	"github.com/RedHatInsights/ccx-notification-service/conf"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/rs/zerolog/log"
-	"net/http"
 )
 
 // Metrics names
@@ -155,8 +156,8 @@ var NotificationSent = promauto.NewCounter(prometheus.CounterOpts{
 	Help: NotificationSentHelp,
 })
 
-// AddMetricsWithNamespace register the desired metrics using a given namespace
-func AddMetricsWithNamespace(namespace string) {
+// AddMetricsWithNamespaceAndSubsystem register the desired metrics using a given namespace
+func AddMetricsWithNamespaceAndSubsystem(namespace, subsystem string) {
 	// exposed metrics
 
 	// Unregister all metrics and registrer them again
@@ -174,6 +175,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// FetchContentErrors shows number of errors during fetch from content service
 	FetchContentErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      FetchContentErrorsName,
 		Help:      FetchContentErrorsHelp,
 	})
@@ -181,6 +183,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// ReadClusterListErrors shows number of errors when reading cluster list from new_reports table
 	ReadClusterListErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      ReadClusterListErrorsName,
 		Help:      ReadClusterListErrorsHelp,
 	})
@@ -188,6 +191,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// ProducerSetupErrors shows number of errors when setting up Kafka producer
 	ProducerSetupErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      ProducerSetupErrorsName,
 		Help:      ProducerSetupErrorsHelp,
 	})
@@ -195,6 +199,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// StorageSetupErrors shows number of errors when setting up storage
 	StorageSetupErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      StorageSetupErrorsName,
 		Help:      StorageSetupErrorsHelp,
 	})
@@ -202,6 +207,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// ReadReportForClusterErrors shows number of errors when getting latest report for a given cluster
 	ReadReportForClusterErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      ReadReportForClusterErrorsName,
 		Help:      ReadReportForClusterErrorsHelp,
 	})
@@ -209,6 +215,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// DeserializeReportErrors shows number of errors when deserializing a report retrieved from the new_reports table
 	DeserializeReportErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      DeserializeReportErrorsName,
 		Help:      DeserializeReportErrorsHelp,
 	})
@@ -216,6 +223,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// ReportWithHighImpact shows number of reports with total risk higher than the configured threshold
 	ReportWithHighImpact = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      ReportWithHighImpactName,
 		Help:      ReportWithHighImpactHelp,
 	})
@@ -223,6 +231,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// NotificationNotSentSameState shows number of notifications not sent because we parsed the same report
 	NotificationNotSentSameState = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      NotificationNotSentSameStateName,
 		Help:      NotificationNotSentSameStateHelp,
 	})
@@ -230,6 +239,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// NotificationNotSentErrorState shows number of notifications not sent because of a Kafka producer error
 	NotificationNotSentErrorState = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      NotificationNotSentErrorStateName,
 		Help:      NotificationNotSentErrorStateHelp,
 	})
@@ -237,6 +247,7 @@ func AddMetricsWithNamespace(namespace string) {
 	// NotificationSent shows number notifications sent to the configured Kafka topic
 	NotificationSent = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      NotificationSentName,
 		Help:      NotificationSentHelp,
 	})

--- a/differ/metrics_test.go
+++ b/differ/metrics_test.go
@@ -35,11 +35,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestAddMetricsWithNamespace function checks the basic behaviour of function
-// AddMetricsWithNamespace from `metrics.go`
-func TestAddMetricsWithNamespace(t *testing.T) {
+// TestAddMetricsWithNamespaceAndSubsystem function checks the basic behaviour of function
+// AddMetricsWithNamespaceAndSubsystem from `metrics.go`
+func TestAddMetricsWithNamespaceAndSubsystem(t *testing.T) {
 	// add all metrics into the namespace "foobar"
-	differ.AddMetricsWithNamespace("foobar")
+	differ.AddMetricsWithNamespaceAndSubsystem("foo", "bar")
 
 	// check the registration
 	assert.NotNil(t, differ.FetchContentErrors)


### PR DESCRIPTION
# Description

Differentiate the metrics between Service Log and Notification Backend targets by using prometheus metrics subsystems. This way we can differentiate between the two jobs.

If the subsystem is not set, the metric is just the `namespace + _ + name`, just as it's now.

Fixes #CCXDEV-9219

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Locally checked the push gateway requests.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
