### PR TITLE
Small logging improvements

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -686,6 +686,7 @@ func setupKafkaProducer(config conf.ConfigStruct) {
 		os.Exit(ExitStatusKafkaBrokerError)
 	}
 	kafkaNotifier = kafkaProducer
+	log.Info().Msg("Kafka producer ready")
 }
 
 func setupServiceLogProducer(config conf.ConfigStruct) {
@@ -996,7 +997,6 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	log.Info().Msg(separator)
 	log.Info().Msg("Preparing Kafka producer")
 	setupKafkaProducer(config)
-	log.Info().Msg("Kafka producer ready")
 	log.Info().Msg(separator)
 	log.Info().Msg("Preparing Service Log producer")
 	setupServiceLogProducer(config)

--- a/ocmclient/ocmclient.go
+++ b/ocmclient/ocmclient.go
@@ -60,7 +60,7 @@ func NewOCMClientWithTransport(clientID, clientSecret, url string, transport htt
 		return nil, err
 	}
 
-	log.Info().Str("url", conn.URL()).Msg("OCM client created successfully...")
+	log.Info().Str("url", conn.URL()).Msg("OCM client created successfully")
 
 	return &OCMGateway{
 		conn,

--- a/producer/servicelog/service_log_producer.go
+++ b/producer/servicelog/service_log_producer.go
@@ -74,13 +74,13 @@ func (producer *Producer) ProduceMessage(msg types.ProducerMessage) (partitionID
 	req, err := http.NewRequest(http.MethodPost, serviceLogURL, bytes.NewBuffer(msg))
 	req.Header.Add("Authorization", "Bearer "+producer.AccessToken)
 	if err != nil {
-		log.Error().Err(err).Msg("Got error while setting up HTTP request")
+		log.Error().Err(err).Msg("Error setting up HTTP request")
 		return -1, -1, err
 	}
 
 	response, err := client.Do(req)
 	if err != nil {
-		log.Error().Err(err).Msgf("Got error while making the HTTP request")
+		log.Error().Err(err).Msgf("Error making the HTTP request")
 		return -1, -1, err
 	}
 

--- a/producer/servicelog/service_log_producer.go
+++ b/producer/servicelog/service_log_producer.go
@@ -120,10 +120,12 @@ func (producer *Producer) Close() error {
 }
 
 func (producer *Producer) refreshToken() error {
+	log.Info().Msg("refreshing access token...")
 	accessToken, _, err := producer.OCMClient.GetTokens(producer.TokenRefreshmentDelay)
 	if err != nil {
 		return err
 	}
 	producer.AccessToken = accessToken
+	log.Info().Msg("access token refreshed successfully")
 	return nil
 }


### PR DESCRIPTION
# Description

- The 'Kafka producer ready' message was showing even when the Kafka producer is disabled. 
- Added info logs to indicate token refreshment is ongoing

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
