### PR TITLE
Do not work if destination not set

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -33,7 +33,6 @@ import (
 	"github.com/RedHatInsights/ccx-notification-service/ocmclient"
 	"github.com/RedHatInsights/ccx-notification-service/producer/servicelog"
 
-	"github.com/RedHatInsights/ccx-notification-service/producer/disabled"
 	"github.com/RedHatInsights/ccx-notification-service/producer/kafka"
 
 	"github.com/rs/zerolog"
@@ -104,6 +103,7 @@ const (
 	serviceLogSendErrorMessage  = "Sending entry to service log failed for this report"
 	renderReportsFailedMessage  = "Rendering reports failed for this cluster"
 	ReportNotFoundError         = "report for rule ID %v and error key %v has not been found"
+	destinationNotSet           = "No known event destination configured. Aborting."
 )
 
 // Constants for notification message top level fields
@@ -544,6 +544,9 @@ func processReportsByCluster(config conf.ConfigStruct, ruleContent types.RulesMa
 			produceEntriesToServiceLog(config, cluster, ruleContent, deserialized.Reports)
 		}
 
+		if !conf.GetKafkaBrokerConfiguration(config).Enabled {
+			continue
+		}
 		newNotifiedIssues, err := produceEntriesToKafka(cluster, ruleContent, deserialized.Reports, storage, report)
 		if err != nil {
 			log.Err(err).
@@ -682,7 +685,6 @@ func setupKafkaProducer(config conf.ConfigStruct) {
 	// admins about the state
 	if !conf.GetKafkaBrokerConfiguration(config).Enabled {
 		log.Info().Msg("Broker config for Notification Service is disabled")
-		kafkaNotifier = &disabled.Producer{}
 		return
 	}
 	log.Info().Msg("Broker config for Notification Service is enabled")
@@ -705,7 +707,6 @@ func setupServiceLogProducer(config conf.ConfigStruct) {
 	serviceLogConfig := conf.GetServiceLogConfiguration(config)
 	if !serviceLogConfig.Enabled {
 		log.Info().Msg("Service Log config for Notification Service is disabled")
-		serviceLogNotifier = &disabled.Producer{}
 		return
 	}
 	log.Info().Msg("Service Log config for Notification Service is enabled")
@@ -951,6 +952,13 @@ func deleteOperationSpecified(cliFlags types.CliFlags) bool {
 		cliFlags.PerformOldReportsCleanup
 }
 
+func assertNotificationDestination(config conf.ConfigStruct) {
+	if !conf.GetKafkaBrokerConfiguration(config).Enabled && !conf.GetServiceLogConfiguration(config).Enabled {
+		log.Error().Msg(destinationNotSet)
+		os.Exit(ExitStatusConfiguration)
+	}
+}
+
 func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	log.Info().Msg("Differ started")
 	log.Info().Msg(separator)
@@ -959,8 +967,8 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 		showConfiguration(config)
 	}
 
+	assertNotificationDestination(config)
 	registerMetrics(conf.GetMetricsConfiguration(config))
-
 	log.Info().Msg(separator)
 	log.Info().Msg("Getting rule content and impacts from content service")
 

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -521,8 +521,10 @@ func (storage DBStorage) WriteNotificationRecordForCluster(
 }
 
 // ReadLastNotifiedRecordForClusterList method returns the last notification
-// with state = 'sent' for given org IDs and clusters.
-func (storage DBStorage) ReadLastNotifiedRecordForClusterList(clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget) (types.NotifiedRecordsPerCluster, error) {
+// with state = 'sent' for given event target, organization IDs and clusters.
+func (storage DBStorage) ReadLastNotifiedRecordForClusterList(
+	clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget,
+	) (types.NotifiedRecordsPerCluster, error) {
 	if len(clusterEntries) == 0 {
 		return types.NotifiedRecordsPerCluster{}, nil
 	}

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -524,7 +524,7 @@ func (storage DBStorage) WriteNotificationRecordForCluster(
 // with state = 'sent' for given event target, organization IDs and clusters.
 func (storage DBStorage) ReadLastNotifiedRecordForClusterList(
 	clusterEntries []types.ClusterEntry, timeOffset string, eventTarget types.EventTarget,
-	) (types.NotifiedRecordsPerCluster, error) {
+) (types.NotifiedRecordsPerCluster, error) {
 	if len(clusterEntries) == 0 {
 		return types.NotifiedRecordsPerCluster{}, nil
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -290,8 +290,3 @@ type ServiceLogEntry struct {
 	ServiceName string      `json:"service_name"`
 	Summary     string      `json:"summary"`
 }
-
-// AccessTokenOutput is a structure containing fresh access token
-type AccessTokenOutput struct {
-	AccessToken string `json:"access_token"`
-}


### PR DESCRIPTION
# Description

Avoid doing reports processing and other operations if not necessary:
- If no valid destination is configured, abort differ
- If Kafka broker is not enabled, do not enter in the `produceEntriesToKafka` function

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor
 
## Testing steps

- tested service locally
- Updated UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
