### PR TITLE
Make sure `server.Close()` is called even when error occurs

### DIFF
--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -1504,7 +1504,8 @@ func TestProduceEntriesToServiceLog(t *testing.T) {
 	var deserialized types.Report
 	err := json.Unmarshal([]byte(testdata.ClusterReport3Rules), &deserialized)
 	if err != nil {
-		log.Fatal().Msg(err.Error())
+		log.Error().Msg(err.Error())
+		return
 	}
 	reports := deserialized.Reports
 


### PR DESCRIPTION
# Description

Make sure `server.Close()` is called even when error occurs

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
