### PR TITLE
initialize producers

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/RedHatInsights/ccx-notification-service/ocmclient"
+	"github.com/RedHatInsights/ccx-notification-service/producer/disabled"
 	"github.com/RedHatInsights/ccx-notification-service/producer/servicelog"
 
 	"github.com/RedHatInsights/ccx-notification-service/producer/kafka"
@@ -706,6 +707,7 @@ func setupKafkaProducer(config conf.ConfigStruct) {
 	// broker enable/disable is very important information, let's inform
 	// admins about the state
 	if !conf.GetKafkaBrokerConfiguration(config).Enabled {
+		kafkaNotifier = &disabled.Producer{}
 		log.Info().Msg("Broker config for Notification Service is disabled")
 		return
 	}
@@ -728,6 +730,7 @@ func setupServiceLogProducer(config conf.ConfigStruct) {
 	// admins about the state
 	serviceLogConfig := conf.GetServiceLogConfiguration(config)
 	if !serviceLogConfig.Enabled {
+		serviceLogNotifier = &disabled.Producer{}
 		log.Info().Msg("Service Log config for Notification Service is disabled")
 		return
 	}


### PR DESCRIPTION
# Description

In stage we found:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xe78fc6]
goroutine 1 [running]:
github.com/RedHatInsights/ccx-notification-service/differ.closeNotifier(0x0, 0x0, 0x3c, 0xc000248180)
/opt/app-root/src/differ/differ.go:940 +0x26
github.com/RedHatInsights/ccx-notification-service/differ.closeDiffer(0xc0002569f0)
/opt/app-root/src/differ/differ.go:1069 +0x165
github.com/RedHatInsights/ccx-notification-service/differ.startDiffer(0x1, 0xc000043248, 0x4, 0xc00003e4ad, 0x8, 0xc00037e540, 0x8, 0xc0002b2390, 0x14, 0xc0002862d0, ...)
/opt/app-root/src/differ/differ.go:1045 +0x947
github.com/RedHatInsights/ccx-notification-service/differ.Run()
/opt/app-root/src/differ/differ.go:1172 +0x7ef
main.main()
/opt/app-root/src/ccx_notification_service.go:38 +0x178
```

caused by the producers not being initialized.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

None

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
