### PR TITLE
[Dashboard] Increase the rate range so that SL metrics are shown

### DIFF
--- a/dashboards/grafana-dashboard-ccx-notification-service.configmap.yaml
+++ b/dashboards/grafana-dashboard-ccx-notification-service.configmap.yaml
@@ -152,14 +152,14 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_fetch_content_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_fetch_content_errors{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "[Notification Backend] Fetch content",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Notification Backend] Read reported",
@@ -167,7 +167,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_producer_setup_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_producer_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Notification Backend] Producer setup",
@@ -175,7 +175,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_read_cluster_list_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_read_cluster_list_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Notification Backend] Read cluster list",
@@ -183,7 +183,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Notification Backend] Read report for cluster",
@@ -191,7 +191,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_storage_setup_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_storage_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Notification Backend] Storage setup",
@@ -199,14 +199,14 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_fetch_content_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_fetch_content_errors{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "[Service Log] Fetch content",
               "refId": "H"
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Service Log] Read reported",
@@ -214,7 +214,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_producer_setup_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_producer_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Service Log] Producer setup",
@@ -222,7 +222,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_read_cluster_list_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_read_cluster_list_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Service Log] Read cluster list",
@@ -230,7 +230,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Service Log] Read report for cluster",
@@ -238,7 +238,7 @@ data:
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_storage_setup_errors{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_storage_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
               "interval": "",
               "legendFormat": "[Service Log] Storage setup",
@@ -321,14 +321,14 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_notification_sent{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_notification_sent{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Notification Backend",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_notification_sent{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_notification_sent{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Service Log",
               "refId": "B"
@@ -409,14 +409,14 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_report_with_high_impact{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_report_with_high_impact{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Notification Backend",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_report_with_high_impact{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_report_with_high_impact{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Service Log",
               "refId": "B"
@@ -498,14 +498,14 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_error_state{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_error_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Notification Backend",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_error_state{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_error_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Service Log",
               "refId": "B"
@@ -573,7 +573,7 @@ data:
                   "options": {
                     "mode": "exclude",
                     "names": [
-                      "sum(rate(ccx_notification_service_notification_not_sent_same_state{namespace=\"app-sre-observability-production\"}[15m]))"
+                      "sum(rate(ccx_notification_service_notification_not_sent_same_state{namespace=\"app-sre-observability-production\"}[1h]))"
                     ],
                     "prefix": "All except:",
                     "readOnly": true
@@ -612,14 +612,14 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_same_state{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_same_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Notification Backend",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_same_state{namespace=\"$namespace\"}[15m]))",
+              "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_same_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
               "legendFormat": "Service Log",
               "refId": "B"


### PR DESCRIPTION
# Description

This is needed because the SL job is taking more than 15 minutes to complete, so the rate (difference between time slides of 15 minutes) is always 0. Increasing it to 1h should be fine.

<details>
<summary>Before:</summary>
<br>

![image](https://user-images.githubusercontent.com/42124482/192992222-c2e4ecd4-bb75-4092-9317-3bdc5a949aab.png)

</details>

<details>
<summary>After:</summary>
<br>

![image](https://user-images.githubusercontent.com/42124482/192992075-d2b9d9fa-7d5e-482a-8673-d133e59b12fd.png)

</details>

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
