### PR TITLE
Avoid NPE when Clowder config is not completed

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -339,15 +339,18 @@ func updateConfigFromClowder(configuration *ConfigStruct) {
 
 			// SSL config
 			if broker.Authtype != nil {
-				configuration.Kafka.SaslUsername = *broker.Sasl.Username
-				configuration.Kafka.SaslPassword = *broker.Sasl.Password
-				configuration.Kafka.SaslMechanism = *broker.Sasl.SaslMechanism
-				configuration.Kafka.SecurityProtocol = *broker.Sasl.SecurityProtocol
-				if caPath, err := clowder.LoadedConfig.KafkaCa(broker); err == nil {
-					configuration.Kafka.CertPath = caPath
+				fmt.Println("kafka is configured to use authentication")
+				if broker.Sasl != nil {
+					configuration.Kafka.SaslUsername = *broker.Sasl.Username
+					configuration.Kafka.SaslPassword = *broker.Sasl.Password
+					configuration.Kafka.SaslMechanism = *broker.Sasl.SaslMechanism
+					configuration.Kafka.SecurityProtocol = *broker.Sasl.SecurityProtocol
+					if caPath, err := clowder.LoadedConfig.KafkaCa(broker); err == nil {
+						configuration.Kafka.CertPath = caPath
+					}
+				} else {
+					fmt.Println(noSaslConfig)
 				}
-			} else {
-				fmt.Println(noSaslConfig)
 			}
 
 		} else {


### PR DESCRIPTION
# Description

Avoid NPE when Clowder config is not completed

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Done on CI, but partially ATM.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
