### PR TITLE
Retry POST after 1 second cooldown when status 429 received

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -110,6 +110,7 @@ const (
 	renderReportsFailedMessage  = "Rendering reports failed for this cluster"
 	ReportNotFoundError         = "report for rule ID %v and error key %v has not been found"
 	destinationNotSet           = "No known event destination configured. Aborting."
+	AuthorizationHeader         = "Authorization"
 )
 
 // Constants for notification message top level fields

--- a/differ/metrics.go
+++ b/differ/metrics.go
@@ -79,7 +79,7 @@ type PushGatewayClient struct {
 func (pgc *PushGatewayClient) Do(request *http.Request) (*http.Response, error) {
 	if pgc.AuthToken != "" {
 		log.Debug().Msg("Adding authorization header to HTTP request")
-		request.Header.Set("Authorization", "Basic "+pgc.AuthToken)
+		request.Header.Set(AuthorizationHeader, "Basic "+pgc.AuthToken)
 	} else {
 		log.Debug().Msg("No authorization token provided. Making HTTP request without credentials.")
 	}


### PR DESCRIPTION
# Description

The Service Log API can sometimes return status 429 - Too Many Requests when receiving a grand number of events. This change handles that, and avoid recreating the HTTP request every time we need to retry it.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Stage will tell us

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
