### PR TITLE
Speedup: don't copy whole `configuration` struct (500 bytes or more) every time

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -365,7 +365,7 @@ func createServiceLogEntry(report types.RenderedReport, cluster types.ClusterEnt
 func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.ClusterEntry,
 	ruleContent types.RulesMap, reports []types.ReportItem) (totalMessages int, err error) {
 	renderedReports, err := renderReportsForCluster(
-		conf.GetDependenciesConfiguration(configuration), cluster.ClusterName,
+		conf.GetDependenciesConfiguration(*configuration), cluster.ClusterName,
 		reports, ruleContent)
 	if err != nil {
 		log.Err(err).

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -365,7 +365,7 @@ func createServiceLogEntry(report types.RenderedReport, cluster types.ClusterEnt
 func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.ClusterEntry,
 	ruleContent types.RulesMap, reports []types.ReportItem) (totalMessages int, err error) {
 	renderedReports, err := renderReportsForCluster(
-		conf.GetDependenciesConfiguration(&configuration), cluster.ClusterName,
+		conf.GetDependenciesConfiguration(configuration), cluster.ClusterName,
 		reports, ruleContent)
 	if err != nil {
 		log.Err(err).
@@ -571,7 +571,7 @@ func processReportsByCluster(config conf.ConfigStruct, ruleContent types.RulesMa
 
 		if conf.GetServiceLogConfiguration(config).Enabled {
 			notifiedAt := types.Timestamp(time.Now())
-			newNotifiedIssues, err := produceEntriesToServiceLog(config, cluster, ruleContent, deserialized.Reports)
+			newNotifiedIssues, err := produceEntriesToServiceLog(&config, cluster, ruleContent, deserialized.Reports)
 			updateNotificationRecordState(storage, cluster, report, newNotifiedIssues, notifiedAt, types.ServiceLogTarget, err)
 			notifiedIssues += newNotifiedIssues
 		}

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -362,10 +362,10 @@ func createServiceLogEntry(report types.RenderedReport, cluster types.ClusterEnt
 	return logEntry
 }
 
-func produceEntriesToServiceLog(config conf.ConfigStruct, cluster types.ClusterEntry,
+func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.ClusterEntry,
 	ruleContent types.RulesMap, reports []types.ReportItem) (totalMessages int, err error) {
 	renderedReports, err := renderReportsForCluster(
-		conf.GetDependenciesConfiguration(config), cluster.ClusterName,
+		conf.GetDependenciesConfiguration(&configuration), cluster.ClusterName,
 		reports, ruleContent)
 	if err != nil {
 		log.Err(err).

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -1526,7 +1526,7 @@ func TestProduceEntriesToServiceLog(t *testing.T) {
 	originalNotifier := serviceLogNotifier
 	serviceLogNotifier = &producerMock
 
-	messages, err := produceEntriesToServiceLog(config, cluster, ruleContent, reports)
+	messages, err := produceEntriesToServiceLog(&config, cluster, ruleContent, reports)
 	producerMock.AssertNumberOfCalls(t, "ProduceMessage", 2)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, messages)


### PR DESCRIPTION
Speedup: don't copy whole `configuration` struct (500 bytes or more) every time

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
