### PR TITLE
Ability to filter clusters by using allow list and block list

### DIFF
--- a/differ/cluster_filter.go
+++ b/differ/cluster_filter.go
@@ -1,0 +1,109 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+// Generated documentation is available at:
+// https://pkg.go.dev/github.com/RedHatInsights/ccx-notification-service/differ
+//
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/ccx-notification-service/packages/differ/cluster_filter.html
+
+import (
+	"github.com/RedHatInsights/ccx-notification-service/conf"
+	"github.com/RedHatInsights/ccx-notification-service/types"
+
+	"github.com/RedHatInsights/insights-operator-utils/collections"
+)
+
+// ClusterFilterStatistic is a structure containing elementary statistic about
+// clusters being filtered by filterClusterList function. It can be used for
+// logging and debugging purposes.
+type ClusterFilterStatistic struct {
+	Input    int
+	Allowed  int
+	Blocked  int
+	Filtered int
+}
+
+// filterClusterList function filters clusters according to given allow list
+// and block list
+func filterClusterList(clusters []types.ClusterEntry, configuration conf.ProcessingConfiguration) ([]types.ClusterEntry, ClusterFilterStatistic) {
+	// initialize structure with statistic
+	stat := ClusterFilterStatistic{
+		Input:    0,
+		Allowed:  0,
+		Blocked:  0,
+		Filtered: 0,
+	}
+
+	// optimization phase - don't process/filter clusters if filtering is
+	// completely disabled (this includes both allowed clusters filter and
+	// blocked clusters filter)
+	if !configuration.FilterAllowedClusters && !configuration.FilterBlockedClusters {
+		// just update the statistic
+		stat.Input = len(clusters)
+		stat.Filtered = len(clusters)
+
+		// and return original cluster list
+		return clusters, stat
+	}
+
+	// list of filtered clusters
+	filtered := []types.ClusterEntry{}
+
+	for _, cluster := range clusters {
+		clusterName := string(cluster.ClusterName)
+
+		// update statistic
+		stat.Input++
+
+		// cluster might be explicitly allowed if "filter
+		// allowed clusters" command line option is enabled
+		if configuration.FilterAllowedClusters {
+			// if cluster is in list of allowed clusters
+			// -> put it into the output list
+			// -> skip rest of the loop
+			if collections.StringInSlice(clusterName, configuration.AllowedClusters) {
+				stat.Allowed++
+				stat.Filtered++
+				filtered = append(filtered, cluster)
+			}
+			// don't do anything else with the cluster
+			continue
+		}
+
+		// cluster might be blocked if "filter blocked clusters"
+		// configuration option is enabled
+		if configuration.FilterBlockedClusters {
+			// if cluster is in list of blocked clusters
+			// -> ignore it
+			// -> skip rest of the loop
+			if collections.StringInSlice(clusterName, configuration.BlockedClusters) {
+				stat.Blocked++
+				// don't do anything else with the cluster
+				continue
+			}
+			// not blocked
+			// -> put it into the output list
+			stat.Filtered++
+			filtered = append(filtered, cluster)
+		}
+	}
+
+	// return filtered list of clusters
+	return filtered, stat
+}

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -412,3 +412,37 @@ func TestFilterAllowTwoClustersAllUnknown(t *testing.T) {
 	assert.Equal(t, 0, stat.Blocked)
 	assert.Equal(t, 0, stat.Filtered)
 }
+
+// TestFilterAllowAndBlock test checks filtering if both filters are
+// enabled and allow list and block list contain some clusters.
+func TestFilterAllowAndBlock(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: true,
+		AllowedClusters: []string{
+			string(cluster1.ClusterName),
+			string(cluster2.ClusterName)},
+		BlockedClusters: []string{
+			string(cluster3.ClusterName),
+			string(cluster4.ClusterName)}}
+
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 2, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 2, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster1, filtered[0])
+	assert.Equal(t, cluster2, filtered[1])
+}

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -267,3 +267,148 @@ func TestFilterBlockTwoClustersAllUnknown(t *testing.T) {
 	assert.Equal(t, cluster3, filtered[2])
 	assert.Equal(t, cluster4, filtered[3])
 }
+
+// TestFilterAllowNoClusters test checks filtering if filters are
+// enabled. In this case list of allowed clusters is empty.
+func TestFilterAllowNoClusters(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters:       []string{}}
+
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 0)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 0, stat.Filtered)
+}
+
+// TestFilterAllowOneCluster test checks filtering if filters are
+// enabled. In this case list of allowed clusters contains one known
+// cluster.
+func TestFilterAllowOneCluster(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters: []string{
+			string(cluster1.ClusterName)}}
+
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 1, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 1, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster1, filtered[0])
+}
+
+// TestFilterAllowTwoClusters test checks filtering if filters are
+// enabled. In this case list of allowed clusters contains two known
+// clusters.
+func TestFilterAllowTwoClusters(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters: []string{
+			string(cluster1.ClusterName),
+			string(cluster2.ClusterName)}}
+
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 2, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 2, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster1, filtered[0])
+	assert.Equal(t, cluster2, filtered[1])
+}
+
+// TestFilterAllowTwoClustersOneUnknown test checks filtering if filters
+// are enabled. In this case allow list contains two clusters, one known
+// and one unknown.
+func TestFilterAllowTwoClustersOneUnknown(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters: []string{
+			string(cluster1.ClusterName),
+			"ffffffff-ffff-ffff-0123456789ab"}}
+
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 1, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 1, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster1, filtered[0])
+}
+
+// TestFilterAllowTwoClustersAllUnknown test checks filtering if filters
+// are enabled. In this case allow list contains two unknown clusters.
+func TestFilterAllowTwoClustersAllUnknown(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters: []string{
+			"ffffffff-ffff-ffff-0123456789ab",
+			"ffffffff-0000-0000-ffffffffffff"},
+	}
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 0)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 0, stat.Filtered)
+}

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -137,3 +137,133 @@ func TestFilterNoFilters(t *testing.T) {
 	assert.Equal(t, cluster3, filtered[2])
 	assert.Equal(t, cluster4, filtered[3])
 }
+
+// TestFilterBlockOneCluster test checks filtering if filters are
+// enabled. In this case block list contains one cluster.
+func TestFilterBlockOneCluster(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+		BlockedClusters: []string{
+			string(cluster1.ClusterName)},
+	}
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 3)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 1, stat.Blocked)
+	assert.Equal(t, 3, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster2, filtered[0])
+	assert.Equal(t, cluster3, filtered[1])
+	assert.Equal(t, cluster4, filtered[2])
+}
+
+// TestFilterBlockTwoClusters test checks filtering if filters are
+// enabled. In this case block list contains two clusters, both of them
+// are known.
+func TestFilterBlockTwoClusters(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+		BlockedClusters: []string{
+			string(cluster1.ClusterName),
+			string(cluster4.ClusterName)},
+	}
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 2, stat.Blocked)
+	assert.Equal(t, 2, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster2, filtered[0])
+	assert.Equal(t, cluster3, filtered[1])
+}
+
+// TestFilterBlockTwoClustersOneUnknown test checks filtering if filters
+// are enabled. In this case block list contains two clusters, one of
+// them is unknown.
+func TestFilterBlockTwoClustersOneUnknown(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+		BlockedClusters: []string{
+			string(cluster1.ClusterName),
+			"ffffffff-0000-0000-ffffffffffff"},
+	}
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 3)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 1, stat.Blocked)
+	assert.Equal(t, 3, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster2, filtered[0])
+	assert.Equal(t, cluster3, filtered[1])
+	assert.Equal(t, cluster4, filtered[2])
+}
+
+// TestFilterBlockTwoClustersAllUnknown test checks filtering if filters
+// are enabled. In this case block list contains two clusters, both
+// unknown.
+func TestFilterBlockTwoClustersAllUnknown(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+		BlockedClusters: []string{
+			"ffffffff-ffff-ffff-0123456789ab",
+			"ffffffff-0000-0000-ffffffffffff"},
+	}
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 4)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 4, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster1, filtered[0])
+	assert.Equal(t, cluster2, filtered[1])
+	assert.Equal(t, cluster3, filtered[2])
+	assert.Equal(t, cluster4, filtered[3])
+}

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -62,8 +62,10 @@ var (
 	}
 )
 
-// TestFilterNullClusterList test checks the filtering for null cluster list
+// TestFilterNullClusterList test checks the filtering for null cluster list.
+// In this case empty list of clusters is provided at input.
 func TestFilterNullClusterList(t *testing.T) {
+	// configuration to be used during filtering
 	config := conf.ProcessingConfiguration{
 		FilterAllowedClusters: false,
 		FilterBlockedClusters: false,
@@ -83,8 +85,10 @@ func TestFilterNullClusterList(t *testing.T) {
 	assert.Equal(t, 0, stat.Filtered)
 }
 
-// TestFilterEmptyClusterList test checks the filtering for null cluster list
+// TestFilterEmptyClusterList test checks the filtering for null cluster list.
+// In this case empty list of clusters is provided at input.
 func TestFilterEmptyClusterList(t *testing.T) {
+	// configuration to be used during filtering
 	config := conf.ProcessingConfiguration{
 		FilterAllowedClusters: false,
 		FilterBlockedClusters: false,
@@ -102,4 +106,34 @@ func TestFilterEmptyClusterList(t *testing.T) {
 	assert.Equal(t, 0, stat.Allowed)
 	assert.Equal(t, 0, stat.Blocked)
 	assert.Equal(t, 0, stat.Filtered)
+}
+
+// TestFilterNoFilters test checks filtering if filters are disabled.
+// In this test case, list with three clusters is provided at input.
+func TestFilterNoFilters(t *testing.T) {
+	// configuration used during filtering
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: false,
+	}
+	var clusters []types.ClusterEntry
+
+	// list of clusters at input
+	clusters = append(clusters, cluster1, cluster2, cluster3, cluster4)
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Len(t, filtered, 4)
+	assert.Equal(t, 4, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 4, stat.Filtered)
+
+	// check the cluster list
+	assert.Equal(t, cluster1, filtered[0])
+	assert.Equal(t, cluster2, filtered[1])
+	assert.Equal(t, cluster3, filtered[2])
+	assert.Equal(t, cluster4, filtered[3])
 }

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/ccx-notification-writer/packages/differ/cluster_filter_test.html
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RedHatInsights/ccx-notification-service/conf"
+	"github.com/RedHatInsights/ccx-notification-service/types"
+)
+
+// cluster entries to be used by unit tests
+var (
+	cluster1 = types.ClusterEntry{
+		OrgID:         1,
+		AccountNumber: 2,
+		ClusterName:   "aaaaaaaa-0000-0000-0000-00000000000",
+		KafkaOffset:   0,
+	}
+	cluster2 = types.ClusterEntry{
+		OrgID:         1,
+		AccountNumber: 2,
+		ClusterName:   "bbbbbbbb-0000-0000-0000-00000000000",
+		KafkaOffset:   0,
+	}
+	cluster3 = types.ClusterEntry{
+		OrgID:         1,
+		AccountNumber: 2,
+		ClusterName:   "cccccccc-0000-0000-0000-00000000000",
+		KafkaOffset:   0,
+	}
+	cluster4 = types.ClusterEntry{
+		OrgID:         1,
+		AccountNumber: 2,
+		ClusterName:   "dddddddd-0000-0000-0000-00000000000",
+		KafkaOffset:   0,
+	}
+	cluster5 = types.ClusterEntry{
+		OrgID:         1,
+		AccountNumber: 2,
+		ClusterName:   "eeeeeeee-0000-0000-0000-00000000000",
+		KafkaOffset:   0,
+	}
+)

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -54,12 +54,6 @@ var (
 		ClusterName:   "dddddddd-0000-0000-0000-00000000000",
 		KafkaOffset:   0,
 	}
-	cluster5 = types.ClusterEntry{
-		OrgID:         1,
-		AccountNumber: 2,
-		ClusterName:   "eeeeeeee-0000-0000-0000-00000000000",
-		KafkaOffset:   0,
-	}
 )
 
 // TestFilterNullClusterList test checks the filtering for null cluster list.

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -61,3 +61,45 @@ var (
 		KafkaOffset:   0,
 	}
 )
+
+// TestFilterNullClusterList test checks the filtering for null cluster list
+func TestFilterNullClusterList(t *testing.T) {
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: false,
+	}
+
+	// null value
+	var clusters []types.ClusterEntry
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Empty(t, filtered)
+	assert.Equal(t, 0, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 0, stat.Filtered)
+}
+
+// TestFilterEmptyClusterList test checks the filtering for null cluster list
+func TestFilterEmptyClusterList(t *testing.T) {
+	config := conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: false,
+	}
+
+	// empty cluster list
+	clusters := []types.ClusterEntry{}
+
+	// start filter
+	filtered, stat := filterClusterList(clusters, config)
+
+	// check filter output
+	assert.Empty(t, filtered)
+	assert.Equal(t, 0, stat.Input)
+	assert.Equal(t, 0, stat.Allowed)
+	assert.Equal(t, 0, stat.Blocked)
+	assert.Equal(t, 0, stat.Filtered)
+}

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -284,6 +284,8 @@ func showConfiguration(config conf.ConfigStruct) {
 	log.Info().
 		Bool("Filter allowed clusters", processingConfig.FilterAllowedClusters).
 		Strs("List of allowed clusters", processingConfig.AllowedClusters).
+		Bool("Filter blocked clusters", processingConfig.FilterBlockedClusters).
+		Strs("List of blocked clusters", processingConfig.BlockedClusters).
 		Msg("Processing configuration")
 }
 
@@ -1057,6 +1059,16 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 		log.Err(err).Msg(operationFailedMessage)
 		os.Exit(ExitStatusStorageError)
 	}
+
+	// filter clusters according to allow list and block list
+	clusters, statistic := filterClusterList(clusters, conf.GetProcessingConfiguration(config))
+	log.Info().
+		Int("On input", statistic.Input).
+		Int("Allowed", statistic.Allowed).
+		Int("Blocked", statistic.Blocked).
+		Int("Filtered", statistic.Filtered).
+		Msg("Filter cluster list")
+
 	entries := len(clusters)
 	if entries == 0 {
 		log.Info().Msg("Differ finished")


### PR DESCRIPTION
# Description

Ability to filter clusters by using allow list and block list. All cases are covered by unit tests.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps

Done on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
