### PR TITLE
Update grafana dashboards to show metrics in each subsystem

### DIFF
--- a/dashboards/grafana-dashboard-ccx-notification-services.configmap.yaml
+++ b/dashboards/grafana-dashboard-ccx-notification-services.configmap.yaml
@@ -11,17 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 apiVersion: v1
 data:
-  ccx_notification_service_dashboard.json: |
+  ccx_notification_service_dashboard.json: |-
     {
+      "__inputs": [
+        {
+          "name": "DS_APP-SRE-PROD-01-PROMETHEUS",
+          "label": "app-sre-prod-01-prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__elements": {},
       "__requires": [
         {
           "type": "grafana",
           "id": "grafana",
           "name": "Grafana",
-          "version": "8.2.1"
+          "version": "9.0.3"
         },
         {
           "type": "datasource",
@@ -40,7 +52,10 @@ data:
         "list": [
           {
             "builtIn": 1,
-            "datasource": "-- Grafana --",
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
@@ -58,16 +73,18 @@ data:
       "description": "Dashboard for CCX notification services (writer, db-cleaner and notification-service)",
       "editable": true,
       "fiscalYearStartMonth": 0,
-      "gnetId": null,
       "graphTooltip": 0,
       "id": null,
-      "iteration": 1635422102595,
+      "iteration": 1665125741860,
       "links": [],
       "liveNow": false,
       "panels": [
         {
           "collapsed": false,
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "tuHy3WB7z"
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -77,11 +94,23 @@ data:
           "id": 2,
           "panels": [],
           "repeat": "datasource",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "tuHy3WB7z"
+              },
+              "refId": "A"
+            }
+          ],
           "title": "CCX Notification Service",
           "type": "row"
         },
         {
-          "datasource": "${datasource}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -146,11 +175,16 @@ data:
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_fetch_content_errors{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -158,6 +192,10 @@ data:
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -166,6 +204,10 @@ data:
               "refId": "B"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_producer_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -174,6 +216,10 @@ data:
               "refId": "C"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_read_cluster_list_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -182,6 +228,10 @@ data:
               "refId": "D"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -190,6 +240,10 @@ data:
               "refId": "E"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_storage_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -198,6 +252,10 @@ data:
               "refId": "G"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_fetch_content_errors{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -205,6 +263,10 @@ data:
               "refId": "H"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -213,6 +275,10 @@ data:
               "refId": "I"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_producer_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -221,6 +287,10 @@ data:
               "refId": "J"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_read_cluster_list_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -229,6 +299,10 @@ data:
               "refId": "K"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -237,6 +311,10 @@ data:
               "refId": "L"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_storage_setup_errors{namespace=\"$namespace\"}[1h]))",
               "hide": false,
@@ -249,7 +327,10 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": "${datasource}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+          },
           "description": "Metrics related with notifications",
           "fieldConfig": {
             "defaults": {
@@ -315,11 +396,16 @@ data:
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_notification_sent{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -327,6 +413,10 @@ data:
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_notification_sent{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -338,7 +428,10 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": "${datasource}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -403,11 +496,16 @@ data:
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_report_with_high_impact{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -415,6 +513,10 @@ data:
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_report_with_high_impact{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -426,7 +528,10 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": "${datasource}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+          },
           "description": "Notifications not sent due to an error",
           "fieldConfig": {
             "defaults": {
@@ -492,11 +597,16 @@ data:
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_error_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -504,6 +614,10 @@ data:
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_error_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -515,7 +629,10 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": "${datasource}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+          },
           "description": "The new reports for given cluster contain issues that were already notified",
           "fieldConfig": {
             "defaults": {
@@ -606,11 +723,16 @@ data:
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_same_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -618,6 +740,10 @@ data:
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+              },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_same_state{namespace=\"$namespace\"}[1h]))",
               "interval": "",
@@ -630,7 +756,7 @@ data:
         }
       ],
       "refresh": "",
-      "schemaVersion": 31,
+      "schemaVersion": 36,
       "style": "dark",
       "tags": [],
       "templating": {
@@ -641,8 +767,6 @@ data:
               "text": "app-sre-prod-01-prometheus",
               "value": "app-sre-prod-01-prometheus"
             },
-            "description": null,
-            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "datasource",
@@ -657,14 +781,11 @@ data:
             "type": "datasource"
           },
           {
-            "allValue": null,
             "current": {
               "selected": true,
               "text": "app-sre-observability-production",
               "value": "app-sre-observability-production"
             },
-            "description": null,
-            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "namespace",
@@ -697,12 +818,10 @@ data:
       "timezone": "",
       "title": "CCX Notification Services",
       "uid": "ERzLEqdnk",
-      "version": 9
+      "version": 6,
+      "weekStart": ""
     }
 kind: ConfigMap
 metadata:
-  name: grafana-dashboard-ccx-notification-service
-  labels:
-    grafana_dashboard: "true"
-  annotations:
-    grafana-folder: /grafana-dashboard-definitions/Insights
+  creationTimestamp: null
+  name: grafana-dashboard-ccx-notification-services


### PR DESCRIPTION
# Description

Update Grafana dashboard to take into account the existing subsystems (notification_backend and service_log).

This new content is exported from the App-SRE [Grafana playground](https://grafana.stage.devshift.net/d/ERzLEqdnk/ccx-notification-services?orgId=1&var-datasource=app-sre-prod-01-prometheus&var-namespace=app-sre-observability-production)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
