### PR TITLE
Basic benchmarks for filtering solution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,15 @@ build-test: gen-mocks ## Build native binary with unit tests and benchmarks
 profiler: ${BINARY} ## Run the unit tests with profiler enabled
 	./profile.sh
 
+benchmark.txt:	benchmark
+
+benchmark: ${BINARY} ## Run benchmarks
+	go test -bench=. -run ^$ -v `go list ./... | grep -v tests | tr '\n' ' '` | tee benchmark.txt
+	# go test -bench=. -run=^$ | tee benchmark.txt
+
+benchmark.csv:	benchmark.txt ## Export benchmark results into CSV
+	awk '/Benchmark/{count ++; gsub(/BenchmarkTest/,""); printf("%d,%s,%s,%s\n",count,$$1,$$2,$$3)}' $< > $@
+
 cover: test ## Generate HTML pages with code coverage
 	@go tool cover -html=coverage.out
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ run                  Build the project and executes the binary
 test                 Run the unit tests
 build-test           Build native binary with unit tests and benchmarks
 profiler             Run the unit tests with profiler enabled
+benchmark            Run benchmarks
 cover                Generate HTML pages with code coverage
 coverage             Display code coverage on terminal
 bdd_tests            Run BDD tests (needs real dependencies)

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -64,3 +64,115 @@ var (
 			string(cluster2.ClusterName)},
 	}
 )
+
+// Benchmark for null cluster list at input when both filters are disabled.
+func BenchmarkNoFiltersNullListOfClustersFiltersDisabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersDisabled
+
+	// null value
+	var clusters []types.ClusterEntry
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Benchmark for null cluster list at input when allow filter is enabled.
+func BenchmarkNoFiltersNullListOfClustersAllowFilterEnabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationAllowFilterEnabled
+
+	// null value
+	var clusters []types.ClusterEntry
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Benchmark for null cluster list at input when block filter is enabled.
+func BenchmarkNoFiltersNullListOfClustersBlockFilterEnabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationBlockFilterEnabled
+
+	// null value
+	var clusters []types.ClusterEntry
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Benchmark for null cluster list at input when both filters are enabled.
+func BenchmarkNoFiltersNullListOfClustersFiltersEnabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersEnabled
+
+	// null value
+	var clusters []types.ClusterEntry
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Benchmark for empty cluster list at input when both filters are disabled.
+func BenchmarkNoFiltersEmptyListOfClustersFiltersDisabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersDisabled
+
+	// empty value
+	clusters := []types.ClusterEntry{}
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Benchmark for empty cluster list at input when allow filter is enabled.
+func BenchmarkNoFiltersEmptyListOfClustersAllowFilterEnabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationAllowFilterEnabled
+
+	// empty value
+	clusters := []types.ClusterEntry{}
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Benchmark for empty cluster list at input when block filter is enabled.
+func BenchmarkNoFiltersEmptyListOfClustersBlockFilterEnabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationBlockFilterEnabled
+
+	// empty value
+	clusters := []types.ClusterEntry{}
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Benchmark for empty cluster list at input when both filters are enabled.
+func BenchmarkNoFiltersEmptyListOfClustersFiltersEnabled(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersEnabled
+
+	// empty value
+	clusters := []types.ClusterEntry{}
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -49,20 +49,6 @@ var (
 		FilterAllowedClusters: true,
 		FilterBlockedClusters: true,
 	}
-
-	configurationOneClusterBlockList = conf.ProcessingConfiguration{
-		FilterAllowedClusters: false,
-		FilterBlockedClusters: true,
-		BlockedClusters: []string{
-			string(cluster2.ClusterName)},
-	}
-
-	configurationOneClusterAllowList = conf.ProcessingConfiguration{
-		FilterAllowedClusters: true,
-		FilterBlockedClusters: false,
-		AllowedClusters: []string{
-			string(cluster2.ClusterName)},
-	}
 )
 
 // Benchmark for null cluster list at input when both filters are disabled.

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -244,3 +244,59 @@ func BenchmarkNoFilters10000Clusters(b *testing.B) {
 		_, _ = filterClusterList(clusters, config)
 	}
 }
+
+// Check list processing for 10 clusters when block filter is enabled.
+func BenchmarkEmptyBlockListFilter10Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationBlockFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 100 clusters when block filter is enabled.
+func BenchmarkEmptyBlockListFilter100Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationBlockFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(100)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 1000 clusters when block filter is enabled.
+func BenchmarkEmptyBlockListFilter1000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationBlockFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(1000)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 10000 clusters when block filter is enabled.
+func BenchmarkEmptyBlockListFilter10000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationBlockFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10000)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+// Benchmarks for function filterClusterList.
+
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/ccx-notification-writer/packages/differ/cluster_filter_test.html
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/ccx-notification-service/conf"
+	"github.com/RedHatInsights/ccx-notification-service/types"
+)
+
+// configuration variants used during filtering
+var (
+	configurationFiltersDisabled = conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: false,
+	}
+
+	configurationAllowFilterEnabled = conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+	}
+
+	configurationBlockFilterEnabled = conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+	}
+
+	configurationFiltersEnabled = conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: true,
+	}
+
+	configurationOneClusterBlockList = conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+		BlockedClusters: []string{
+			string(cluster2.ClusterName)},
+	}
+
+	configurationOneClusterAllowList = conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters: []string{
+			string(cluster2.ClusterName)},
+	}
+)

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -176,3 +176,71 @@ func BenchmarkNoFiltersEmptyListOfClustersFiltersEnabled(b *testing.B) {
 		_, _ = filterClusterList(clusters, config)
 	}
 }
+
+// Helper function to prepare list of at least N clusters
+func prepareListOfNClusters(n int) []types.ClusterEntry {
+	var clusters []types.ClusterEntry
+
+	// add 5 clusters at once
+	for i := 0; i < n; i += 5 {
+		clusters = append(clusters, cluster1, cluster2, cluster3, cluster4, cluster5)
+	}
+
+	return clusters
+}
+
+// Check list processing for 10 clusters when both filters are disabled.
+func BenchmarkNoFilters10Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersDisabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 100 clusters when both filters are disabled.
+func BenchmarkNoFilters100Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersDisabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(100)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 1000 clusters when both filters are disabled.
+func BenchmarkNoFilters1000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersDisabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(1000)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 10000 clusters when both filters are disabled.
+func BenchmarkNoFilters10000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationFiltersDisabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10000)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -300,3 +300,59 @@ func BenchmarkEmptyBlockListFilter10000Clusters(b *testing.B) {
 		_, _ = filterClusterList(clusters, config)
 	}
 }
+
+// Check list processing for 10 clusters when allow filter is enabled.
+func BenchmarkEmptyAllowListFilter10Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationAllowFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 100 clusters when allow filter is enabled.
+func BenchmarkEmptyAllowListFilter100Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationAllowFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(100)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 1000 clusters when allow filter is enabled.
+func BenchmarkEmptyAllowListFilter1000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationAllowFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(1000)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}
+
+// Check list processing for 10000 clusters when allow filter is enabled.
+func BenchmarkEmptyAllowListFilter10000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationAllowFilterEnabled
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10000)
+
+	// run benchmark
+	for i := 0; i < b.N; i++ {
+		_, _ = filterClusterList(clusters, config)
+	}
+}

--- a/differ/cluster_filter_test.go
+++ b/differ/cluster_filter_test.go
@@ -54,6 +54,12 @@ var (
 		ClusterName:   "dddddddd-0000-0000-0000-00000000000",
 		KafkaOffset:   0,
 	}
+	cluster5 = types.ClusterEntry{
+		OrgID:         1,
+		AccountNumber: 2,
+		ClusterName:   "eeeeeeee-0000-0000-0000-00000000000",
+		KafkaOffset:   0,
+	}
 )
 
 // TestFilterNullClusterList test checks the filtering for null cluster list.


### PR DESCRIPTION
# Description

Basic benchmarks for filtering solution

Results seems to be ok-ish so far:

```
BenchmarkNoFiltersNullListOfClustersFiltersDisabled-8           470145574                2.706 ns/op
BenchmarkNoFiltersNullListOfClustersAllowFilterEnabled-8        393646858                3.238 ns/op
BenchmarkNoFiltersNullListOfClustersBlockFilterEnabled-8        372016285                3.314 ns/op
BenchmarkNoFiltersNullListOfClustersFiltersEnabled-8            392002869                3.094 ns/op
BenchmarkNoFiltersEmptyListOfClustersFiltersDisabled-8          448799083                2.717 ns/op
BenchmarkNoFiltersEmptyListOfClustersAllowFilterEnabled-8       370419956                3.116 ns/op
BenchmarkNoFiltersEmptyListOfClustersBlockFilterEnabled-8       352190559                3.842 ns/op
BenchmarkNoFiltersEmptyListOfClustersFiltersEnabled-8           382834504                3.271 ns/op
BenchmarkNoFilters10Clusters-8                                  428441546                2.820 ns/op
BenchmarkNoFilters100Clusters-8                                 449174948                2.898 ns/op
BenchmarkNoFilters1000Clusters-8                                391930606                2.940 ns/op
BenchmarkNoFilters10000Clusters-8                               421005040                2.765 ns/op
BenchmarkEmptyBlockListFilter10Clusters-8                        1983159               614.3 ns/op
BenchmarkEmptyBlockListFilter100Clusters-8                        301632              5426 ns/op
BenchmarkEmptyBlockListFilter1000Clusters-8                        41108             36764 ns/op
BenchmarkEmptyBlockListFilter10000Clusters-8                        1299            795937 ns/op
BenchmarkEmptyAllowListFilter10Clusters-8                       31769295                42.69 ns/op
BenchmarkEmptyAllowListFilter100Clusters-8                       3077632               377.6 ns/op
BenchmarkEmptyAllowListFilter1000Clusters-8                       331632              3855 ns/op
BenchmarkEmptyAllowListFilter10000Clusters-8                       30082             45474 ns/op
```

## Type of change

- Benchmarks (no changes in the code)
- Documentation update

## Testing steps

Basic checks done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
