### PR TITLE
Add labels and annotations to grafana dashboard

### DIFF
--- a/dashboards/grafana-dashboard-ccx-notification-services.configmap.yaml
+++ b/dashboards/grafana-dashboard-ccx-notification-services.configmap.yaml
@@ -825,3 +825,7 @@ kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: grafana-dashboard-ccx-notification-services
+  labels:
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/Insights


### PR DESCRIPTION
# Description

The labels and annotations are not automatically created when the `oc create configmap` command is run. Without these fields, the Grafana dashboard is not found (and therefore not shown).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Will See if dashboard shows in stage

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
