### PR TITLE
Fix datasource, update description, and show not_sent_same_state view by default

### DIFF
--- a/dashboards/grafana-dashboard-ccx-notification-services.configmap.yaml
+++ b/dashboards/grafana-dashboard-ccx-notification-services.configmap.yaml
@@ -11,16 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 apiVersion: v1
 data:
-  ccx_notification_service_dashboard.json: |-
+  ccx_notification_service_dashboard.json: |
     {
       "__inputs": [
         {
-          "name": "DS_APP-SRE-PROD-01-PROMETHEUS",
-          "label": "app-sre-prod-01-prometheus",
+          "name": "DS_APP-SRE-STAGE-01-PROMETHEUS",
+          "label": "app-sre-stage-01-prometheus",
           "description": "",
           "type": "datasource",
           "pluginId": "prometheus",
@@ -70,12 +69,12 @@ data:
           }
         ]
       },
-      "description": "Dashboard for CCX notification services (writer, db-cleaner and notification-service)",
+      "description": "Dashboard for CCX notification services (to-notification-backend and to-service-log)",
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
       "id": null,
-      "iteration": 1665125741860,
+      "iteration": 1665136813891,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -93,7 +92,6 @@ data:
           },
           "id": 2,
           "panels": [],
-          "repeat": "datasource",
           "targets": [
             {
               "datasource": {
@@ -103,13 +101,13 @@ data:
               "refId": "A"
             }
           ],
-          "title": "CCX Notification Service",
+          "title": "CCX Notification Services",
           "type": "row"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+            "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -183,7 +181,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_fetch_content_errors{namespace=\"$namespace\"}[1h]))",
@@ -194,7 +192,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
@@ -206,7 +204,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_producer_setup_errors{namespace=\"$namespace\"}[1h]))",
@@ -218,7 +216,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_read_cluster_list_errors{namespace=\"$namespace\"}[1h]))",
@@ -230,7 +228,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
@@ -242,7 +240,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_storage_setup_errors{namespace=\"$namespace\"}[1h]))",
@@ -254,7 +252,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_fetch_content_errors{namespace=\"$namespace\"}[1h]))",
@@ -265,7 +263,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
@@ -277,7 +275,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_producer_setup_errors{namespace=\"$namespace\"}[1h]))",
@@ -289,7 +287,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_read_cluster_list_errors{namespace=\"$namespace\"}[1h]))",
@@ -301,7 +299,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_read_report_for_cluster_errors{namespace=\"$namespace\"}[1h]))",
@@ -313,7 +311,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_storage_setup_errors{namespace=\"$namespace\"}[1h]))",
@@ -329,7 +327,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+            "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
           },
           "description": "Metrics related with notifications",
           "fieldConfig": {
@@ -404,7 +402,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_notification_sent{namespace=\"$namespace\"}[1h]))",
@@ -415,7 +413,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_notification_sent{namespace=\"$namespace\"}[1h]))",
@@ -430,7 +428,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+            "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -504,23 +502,38 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
-              "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_notification_backend_report_with_high_impact{namespace=\"$namespace\"}[1h]))",
-              "interval": "",
-              "legendFormat": "Notification Backend",
-              "refId": "A"
+              "dimensions": {},
+              "editorMode": "code",
+              "expr": "sum(rate(ccx_notification_service_notification_backend_report_with_high_impact{namespace=\"$namespace\"}[15m]))",
+              "expression": "",
+              "id": "",
+              "label": "",
+              "legendFormat": "__auto",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "",
+              "metricQueryType": 0,
+              "namespace": "",
+              "period": "",
+              "queryMode": "Metrics",
+              "range": true,
+              "refId": "A",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Average"
             },
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
-              "exemplar": true,
-              "expr": "sum(rate(ccx_notification_service_service_log_report_with_high_impact{namespace=\"$namespace\"}[1h]))",
-              "interval": "",
-              "legendFormat": "Service Log",
+              "editorMode": "code",
+              "expr": "sum(rate(ccx_notification_service_service_log_report_with_high_impact{namespace=\"$namespace\"}[15m]))",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
               "refId": "B"
             }
           ],
@@ -530,7 +543,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+            "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
           },
           "description": "Notifications not sent due to an error",
           "fieldConfig": {
@@ -605,7 +618,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_error_state{namespace=\"$namespace\"}[1h]))",
@@ -616,7 +629,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_error_state{namespace=\"$namespace\"}[1h]))",
@@ -631,7 +644,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+            "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
           },
           "description": "The new reports for given cluster contain issues that were already notified",
           "fieldConfig": {
@@ -682,32 +695,7 @@ data:
                 ]
               }
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "sum(rate(ccx_notification_service_notification_not_sent_same_state{namespace=\"app-sre-observability-production\"}[1h]))"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -731,7 +719,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_notification_backend_notification_not_sent_same_state{namespace=\"$namespace\"}[1h]))",
@@ -742,7 +730,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APP-SRE-PROD-01-PROMETHEUS}"
+                "uid": "${DS_APP-SRE-STAGE-01-PROMETHEUS}"
               },
               "exemplar": true,
               "expr": "sum(rate(ccx_notification_service_service_log_notification_not_sent_same_state{namespace=\"$namespace\"}[1h]))",
@@ -763,9 +751,9 @@ data:
         "list": [
           {
             "current": {
-              "selected": false,
-              "text": "app-sre-prod-01-prometheus",
-              "value": "app-sre-prod-01-prometheus"
+              "selected": true,
+              "text": "app-sre-stage-01-prometheus",
+              "value": "app-sre-stage-01-prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -783,8 +771,8 @@ data:
           {
             "current": {
               "selected": true,
-              "text": "app-sre-observability-production",
-              "value": "app-sre-observability-production"
+              "text": "app-sre-observability-stage",
+              "value": "app-sre-observability-stage"
             },
             "hide": 0,
             "includeAll": false,
@@ -793,12 +781,12 @@ data:
             "name": "namespace",
             "options": [
               {
-                "selected": false,
+                "selected": true,
                 "text": "app-sre-observability-stage",
                 "value": "app-sre-observability-stage"
               },
               {
-                "selected": true,
+                "selected": false,
                 "text": "app-sre-observability-production",
                 "value": "app-sre-observability-production"
               }
@@ -811,14 +799,14 @@ data:
         ]
       },
       "time": {
-        "from": "now-12h",
+        "from": "now-1h",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "CCX Notification Services",
       "uid": "ERzLEqdnk",
-      "version": 6,
+      "version": 1,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
# Description

With this, the dashbaord now looks like it should when opened:

- The name is changed to `CCX Notification Services`
- The default datasource used is `app-sre-stage-01-prometheus` (since the graph is for stage by default)
- The range of data displayed is `now - 1 hour`
- All the dashboards views show data for service log and notification backend by default

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Will see how dashboard is rendered in stage

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
