### PR TITLE
Benchmarks: finalization

### DIFF
--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -423,3 +423,55 @@ func Benchmark1ClusterInAllowListFilter10000Clusters(b *testing.B) {
 	// start benchmark
 	runBenchmark(b, clusters, config)
 }
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 10 clusters
+func Benchmark10ClustersInBlockListFilter10Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 100 clusters
+func Benchmark10ClustersInBlockListFilter100Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(100)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 1000 clusters
+func Benchmark10ClustersInBlockListFilter1000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(1000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 10000 clusters
+func Benchmark10ClustersInBlockListFilter10000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -591,3 +591,55 @@ func Benchmark10ClustersInBlockListFilter10000Clusters(b *testing.B) {
 	// start benchmark
 	runBenchmark(b, clusters, config)
 }
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 10 clusters
+func Benchmark10ClustersInAllowListFilter10Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenAllowClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 100 clusters
+func Benchmark10ClustersInAllowListFilter100Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenAllowClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(100)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 1000
+func Benchmark10ClustersInAllowListFilter1000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenAllowClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(1000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check cluster list processing for filter with 10 known clusters and cluster
+// list with 10000
+func Benchmark10ClustersInAllowListFilter10000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenAllowClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -63,6 +63,122 @@ var (
 		AllowedClusters: []string{
 			string(cluster2.ClusterName)},
 	}
+
+	configurationTenBlockedClustersConfig = conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+		AllowedClusters: []string{
+			string(cluster1.ClusterName),
+			string(cluster2.ClusterName),
+			string(cluster3.ClusterName),
+			string(cluster4.ClusterName),
+			string(cluster5.ClusterName),
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+		},
+		BlockedClusters: []string{
+			string(cluster1.ClusterName),
+			string(cluster2.ClusterName),
+			string(cluster3.ClusterName),
+			string(cluster4.ClusterName),
+			string(cluster5.ClusterName),
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+		},
+	}
+
+	configurationTenAllowClustersConfig = conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters: []string{
+			string(cluster1.ClusterName),
+			string(cluster2.ClusterName),
+			string(cluster3.ClusterName),
+			string(cluster4.ClusterName),
+			string(cluster5.ClusterName),
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+		},
+		BlockedClusters: []string{
+			string(cluster1.ClusterName),
+			string(cluster2.ClusterName),
+			string(cluster3.ClusterName),
+			string(cluster4.ClusterName),
+			string(cluster5.ClusterName),
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+		},
+	}
+
+	configurationTenUnknownBlockedClustersConfig = conf.ProcessingConfiguration{
+		FilterAllowedClusters: false,
+		FilterBlockedClusters: true,
+		AllowedClusters: []string{
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+			"66666666-6666-6666-666666666666",
+			"77777777-7777-7777-777777777777",
+			"88888888-8888-8888-888888888888",
+			"99999999-9999-9999-999999999999",
+			"aaaaaaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		},
+		BlockedClusters: []string{
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+			"66666666-6666-6666-666666666666",
+			"77777777-7777-7777-777777777777",
+			"88888888-8888-8888-888888888888",
+			"99999999-9999-9999-999999999999",
+			"aaaaaaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		},
+	}
+
+	configurationTenUnknownAllowedClustersConfig = conf.ProcessingConfiguration{
+		FilterAllowedClusters: true,
+		FilterBlockedClusters: false,
+		AllowedClusters: []string{
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+			"66666666-6666-6666-666666666666",
+			"77777777-7777-7777-777777777777",
+			"88888888-8888-8888-888888888888",
+			"99999999-9999-9999-999999999999",
+			"aaaaaaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		},
+		BlockedClusters: []string{
+			"11111111-1111-1111-111111111111",
+			"22222222-2222-2222-222222222222",
+			"33333333-3333-3333-333333333333",
+			"44444444-4444-4444-444444444444",
+			"55555555-5555-5555-555555555555",
+			"66666666-6666-6666-666666666666",
+			"77777777-7777-7777-777777777777",
+			"88888888-8888-8888-888888888888",
+			"99999999-9999-9999-999999999999",
+			"aaaaaaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		},
+	}
 )
 
 // runBenchmark function run the benchmark with specified cluster list and filter configuration

--- a/differ/cluster_filter_benchmark_test.go
+++ b/differ/cluster_filter_benchmark_test.go
@@ -643,3 +643,99 @@ func Benchmark10ClustersInAllowListFilter10000Clusters(b *testing.B) {
 	// start benchmark
 	runBenchmark(b, clusters, config)
 }
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInBlockListFilter10Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInBlockListFilter100Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(100)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInBlockListFilter1000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(1000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInBlockListFilter10000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownBlockedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInAllowListFilter10Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownAllowedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInAllowListFilter100Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownAllowedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(100)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInAllowListFilter1000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownAllowedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(1000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}
+
+// Check filtering by unknown clusters
+func Benchmark10UnknownClustersInAllowListFilter10000Clusters(b *testing.B) {
+	// configuration used during filtering
+	config := configurationTenUnknownAllowedClustersConfig
+
+	// fill-in list of clusters at input
+	clusters := prepareListOfNClusters(10000)
+
+	// start benchmark
+	runBenchmark(b, clusters, config)
+}


### PR DESCRIPTION
# Description

Benchmarks: finalization
Results:

```
BenchmarkNoFiltersNullListOfClustersFiltersDisabled-8        	404038790	         2.665 ns/op
BenchmarkNoFiltersNullListOfClustersAllowFilterEnabled-8     	392989483	         3.263 ns/op
BenchmarkNoFiltersNullListOfClustersBlockFilterEnabled-8     	349367343	         3.374 ns/op
BenchmarkNoFiltersNullListOfClustersFiltersEnabled-8         	407307870	         3.574 ns/op
BenchmarkNoFiltersEmptyListOfClustersFiltersDisabled-8       	485534881	         2.742 ns/op
BenchmarkNoFiltersEmptyListOfClustersAllowFilterEnabled-8    	363322621	         3.269 ns/op
BenchmarkNoFiltersEmptyListOfClustersBlockFilterEnabled-8    	349120347	         4.002 ns/op
BenchmarkNoFiltersEmptyListOfClustersFiltersEnabled-8        	349924776	         3.542 ns/op
BenchmarkNoFilters10Clusters-8                               	395357468	         2.796 ns/op
BenchmarkNoFilters100Clusters-8                              	411285759	         2.939 ns/op
BenchmarkNoFilters1000Clusters-8                             	395058192	         2.947 ns/op
BenchmarkNoFilters10000Clusters-8                            	400232542	         2.995 ns/op
BenchmarkEmptyBlockListFilter10Clusters-8                    	 1939976	       797.3 ns/op
BenchmarkEmptyBlockListFilter100Clusters-8                   	  278226	      4380 ns/op
BenchmarkEmptyBlockListFilter1000Clusters-8                  	   39856	     30728 ns/op
BenchmarkEmptyBlockListFilter10000Clusters-8                 	    1398	    853100 ns/op
BenchmarkEmptyAllowListFilter10Clusters-8                    	26059803	        51.60 ns/op
BenchmarkEmptyAllowListFilter100Clusters-8                   	 2116345	       505.0 ns/op
BenchmarkEmptyAllowListFilter1000Clusters-8                  	  304929	      4358 ns/op
BenchmarkEmptyAllowListFilter10000Clusters-8                 	   25497	     47381 ns/op
Benchmark1ClusterInBlockListFilter10Clusters-8               	 2685213	       488.0 ns/op
Benchmark1ClusterInBlockListFilter100Clusters-8              	  252417	      4603 ns/op
Benchmark1ClusterInBlockListFilter1000Clusters-8             	   35893	     33174 ns/op
Benchmark1ClusterInBlockListFilter10000Clusters-8            	    1341	    937106 ns/op
Benchmark1ClusterInAllowListFilter10Clusters-8               	 5097436	       230.1 ns/op
Benchmark1ClusterInAllowListFilter100Clusters-8              	  645225	      1686 ns/op
Benchmark1ClusterInAllowListFilter1000Clusters-8             	   91665	     13251 ns/op
Benchmark1ClusterInAllowListFilter10000Clusters-8            	    7904	    198324 ns/op
Benchmark10ClustersInBlockListFilter10Clusters-8             	 9179296	       133.6 ns/op
Benchmark10ClustersInBlockListFilter100Clusters-8            	  975818	      1264 ns/op
Benchmark10ClustersInBlockListFilter1000Clusters-8           	   94380	     15110 ns/op
Benchmark10ClustersInBlockListFilter10000Clusters-8          	    8851	    122698 ns/op
Benchmark10ClustersInAllowListFilter10Clusters-8             	 1533654	       809.2 ns/op
Benchmark10ClustersInAllowListFilter100Clusters-8            	  225814	      5292 ns/op
Benchmark10ClustersInAllowListFilter1000Clusters-8           	   30426	     49404 ns/op
Benchmark10ClustersInAllowListFilter10000Clusters-8          	    1114	    973710 ns/op
Benchmark10UnknownClustersInBlockListFilter10Clusters-8      	 1482894	       825.4 ns/op
Benchmark10UnknownClustersInBlockListFilter100Clusters-8     	  214237	      6705 ns/op
Benchmark10UnknownClustersInBlockListFilter1000Clusters-8    	   25125	     45168 ns/op
Benchmark10UnknownClustersInBlockListFilter10000Clusters-8   	    1029	   1042584 ns/op
Benchmark10UnknownClustersInAllowListFilter10Clusters-8      	 8434470	       157.0 ns/op
Benchmark10UnknownClustersInAllowListFilter100Clusters-8     	  993639	      1493 ns/op
Benchmark10UnknownClustersInAllowListFilter1000Clusters-8    	   95181	     13169 ns/op
Benchmark10UnknownClustersInAllowListFilter10000Clusters-8   	   10000	    129601 ns/op
```

## Type of change

- Benchmarks (no changes in the code)

## Testing steps

Can be run locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
