### PR TITLE
Add configuration of token URL in OCMClient

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -162,6 +162,7 @@ type ServiceLogConfiguration struct {
 	Enabled             bool          `mapstructure:"enabled" toml:"enabled"`
 	ClientID            string        `mapstructure:"client_id" toml:"client_id"`
 	ClientSecret        string        `mapstructure:"client_secret" toml:"client_secret"`
+	TokenURL            string        `mapstructure:"token_url" toml:"token_url"`
 	URL                 string        `mapstructure:"url" toml:"url"`
 	Timeout             time.Duration `mapstructure:"timeout" toml:"timeout"`
 	LikelihoodThreshold int           `mapstructure:"likelihood_threshold" toml:"likelihood_threshold"`

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -139,6 +139,7 @@ func TestLoadServiceLogConfiguration(t *testing.T) {
 	assert.Equal(t, 3, serviceLogCfg.TotalRiskThreshold)
 	assert.Equal(t, "test-id", serviceLogCfg.ClientID)
 	assert.Equal(t, "test-secret", serviceLogCfg.ClientSecret)
+	assert.Equal(t, "token url", serviceLogCfg.TokenURL)
 	assert.Equal(t, "localhost:8000/api/service_logs/v1/cluster_logs/", serviceLogCfg.URL)
 	assert.Equal(t, expectedTimeout, serviceLogCfg.Timeout)
 }

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -14,8 +14,10 @@ total_risk_threshold = 3
 event_filter = "totalRisk >= totalRiskThreshold"
 
 [service_log]
+client_id = "a-service-id"
+client_secret = "a-secret"
+token_url = ""
 enabled = false
-offline_token = ""
 token_refreshment_url = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 url = "localhost:8000/api/service_logs/v1/cluster_logs/"
 timeout = "15s"

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -18,7 +18,6 @@ client_id = "a-service-id"
 client_secret = "a-secret"
 token_url = ""
 enabled = false
-token_refreshment_url = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 url = "localhost:8000/api/service_logs/v1/cluster_logs/"
 timeout = "15s"
 likelihood_threshold = 0

--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,7 @@ event_filter = "totalRisk >= totalRiskThreshold"
 [service_log]
 client_id = "a-service-id"
 client_secret = "a-secret"
+token_url = ""
 enabled = false
 url = "https://api.openshift.com/api/service_logs/v1/cluster_logs/"
 timeout = "15s"

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -754,7 +754,8 @@ func setupServiceLogProducer(config conf.ConfigStruct) {
 	}
 	log.Info().Msg("Service Log config for Notification Service is enabled")
 
-	conn, err := ocmclient.NewOCMClient(serviceLogConfig.ClientID, serviceLogConfig.ClientSecret, serviceLogConfig.URL)
+	conn, err := ocmclient.NewOCMClient(serviceLogConfig.ClientID, serviceLogConfig.ClientSecret,
+		serviceLogConfig.URL, serviceLogConfig.TokenURL)
 	if err != nil {
 		log.Error().Err(err).Msg("got error while setting up the connection to OCM API gateway")
 		return

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,6 @@ event_filter = "totalRisk > totalRiskThreshold"
 - `client_id` is a client ID used for access token retrieval
 - `client_secret` is a client secret used for access token retrieval
 - `token_url` is a token refreshment API endpoint (optional, otherwise set to default one)
-- `token_refreshment_url` is a URL of OpenID Connect API for retrieval of new online token
 - `timeout` is a time used as a timeout when sending requests to Service Log API
 - `likelihood_threshold`,`impact_threshold`, `severity_threshold` and `total_risk_threshold` are values which can be used in `event_filter` for filtering messages sent to Service Log
 - `event_filter` is a condition string used to determine which messages will be sent to Service Log

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,8 +58,9 @@ Service Log configuration is in section `[service-log]` in config file
 ```
 [service_log]
 enabled = false
-offline_token = ""
-token_refreshment_url = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+client_id = "CLIENT_ID"
+client_secret = "CLIENT_SECRET"
+token_url = ""
 url = "https://api.openshift.com/api/service_logs/v1/cluster_logs/"
 timeout = "15s"
 likelihood_threshold = 0
@@ -70,7 +71,9 @@ event_filter = "totalRisk > totalRiskThreshold"
 ```
 
 - `enabled` determines whether the notifications service sends messages to Service Log
-- `offline_token` is an offline token used to retrieve online token via OpenID Connect
+- `client_id` is a client ID used for access token retrieval
+- `client_secret` is a client secret used for access token retrieval
+- `token_url` is a token refreshment API endpoint (optional, otherwise set to default one)
 - `token_refreshment_url` is a URL of OpenID Connect API for retrieval of new online token
 - `timeout` is a time used as a timeout when sending requests to Service Log API
 - `likelihood_threshold`,`impact_threshold`, `severity_threshold` and `total_risk_threshold` are values which can be used in `event_filter` for filtering messages sent to Service Log

--- a/ocmclient/ocmclient.go
+++ b/ocmclient/ocmclient.go
@@ -33,14 +33,17 @@ type OCMClient interface {
 }
 
 // NewOCMClient creates a client that can comunicate with the OCM API
-func NewOCMClient(clientID, clientSecret, url string) (OCMClient, error) {
-	return NewOCMClientWithTransport(clientID, clientSecret, url, nil)
+func NewOCMClient(clientID, clientSecret, url string, tokenURL string) (OCMClient, error) {
+	return NewOCMClientWithTransport(clientID, clientSecret, url, tokenURL, nil)
 }
 
 // NewOCMClientWithTransport creates a client that can comunicate with the OCM API, enabling to use a transport wrapper
-func NewOCMClientWithTransport(clientID, clientSecret, url string, transport http.RoundTripper) (OCMClient, error) {
+func NewOCMClientWithTransport(clientID, clientSecret, url string, tokenURL string, transport http.RoundTripper) (OCMClient, error) {
 	log.Info().Msg("creating client for the Openshift Cluster Manager (OCM) API...")
 	builder := gateway.NewConnectionBuilder().URL(url)
+	if tokenURL != "" {
+		builder = builder.TokenURL(tokenURL)
+	}
 
 	if transport != nil {
 		builder.TransportWrapper(func(http.RoundTripper) http.RoundTripper { return transport })

--- a/ocmclient/ocmclient_test.go
+++ b/ocmclient/ocmclient_test.go
@@ -31,7 +31,8 @@ func TestClientCreationError(t *testing.T) {
 	clientID := ""
 	clientSecret := ""
 	url := ""
-	_, err := ocmclient.NewOCMClient(clientID, clientSecret, url)
+	tokenURL := ""
+	_, err := ocmclient.NewOCMClient(clientID, clientSecret, url, tokenURL)
 	assert.NotEqual(t, nil, err)
 }
 
@@ -40,6 +41,7 @@ func TestClientCreationWithTransportError(t *testing.T) {
 	clientID := ""
 	clientSecret := ""
 	url := ""
-	_, err := ocmclient.NewOCMClientWithTransport(clientID, clientSecret, url, nil)
+	tokenURL := ""
+	_, err := ocmclient.NewOCMClientWithTransport(clientID, clientSecret, url, tokenURL, nil)
 	assert.NotEqual(t, nil, err)
 }

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -13,6 +13,7 @@ event_filter = "totalRisk >= totalRiskThreshold"
 enabled = false
 client_id = "test-id"
 client_secret = "test-secret"
+token_url = "token url"
 url = "localhost:8000/api/service_logs/v1/cluster_logs/"
 timeout = "15s"
 likelihood_threshold = 0


### PR DESCRIPTION
# Description

Add optional configuration of token refreshment URL used by OCM client. Right now OCM client uses default one, which is fine, but for BDD tests it would be useful to have a option to configure URL of a mock.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
