### PR TITLE
Exchange summary and description in log service entry

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -353,9 +353,9 @@ func findRenderedReport(reports []types.RenderedReport, ruleName types.RuleName,
 func createServiceLogEntry(report types.RenderedReport, cluster types.ClusterEntry) types.ServiceLogEntry {
 	logEntry := types.ServiceLogEntry{
 		ClusterUUID: cluster.ClusterName,
-		Description: report.Description,
+		Description: report.Reason,
 		ServiceName: serviceName,
-		Summary:     report.Reason,
+		Summary:     report.Description,
 	}
 
 	// It is necessary to truncate the fields because of Service Log limitations


### PR DESCRIPTION
# Description

summary field of the service log is limited to 255 characters - currently, notification service fills this field with rendered reason for given rule and report. In case the length of this text exceeds the limit, it is trimmed. 

This PR exchanges description and summary fields, since description appears to be shorter than 255 characters.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
