### PR TITLE
Refactor read last notified record for cluster list

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -266,6 +266,7 @@ func showConfiguration(config conf.ConfigStruct) {
 		Str("Insights Advisor URL", notificationConfig.InsightsAdvisorURL).
 		Str("Cluster details URI", notificationConfig.ClusterDetailsURI).
 		Str("Rule details URI", notificationConfig.RuleDetailsURI).
+		Str("Cooldown", notificationConfig.Cooldown).
 		Msg("Notifications configuration")
 
 	metricsConfig := conf.GetMetricsConfiguration(config)


### PR DESCRIPTION
# Description

Avoid applying the `where` clause if the cooldown is not configured or is set to 0.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

updated UTs.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
