### PR TITLE
Call getAllContentFromMap only once

### DIFF
--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -1494,6 +1494,8 @@ func TestProduceEntriesToServiceLog(t *testing.T) {
 		"rule3":                   testdata.RuleContent3,
 	}
 
+	rules := getAllContentFromMap(ruleContent)
+
 	cluster := types.ClusterEntry{
 		OrgID:         1,
 		AccountNumber: 1,
@@ -1526,7 +1528,7 @@ func TestProduceEntriesToServiceLog(t *testing.T) {
 	originalNotifier := serviceLogNotifier
 	serviceLogNotifier = &producerMock
 
-	messages, err := produceEntriesToServiceLog(&config, cluster, ruleContent, reports)
+	messages, err := produceEntriesToServiceLog(&config, cluster, rules, ruleContent, reports)
 	producerMock.AssertNumberOfCalls(t, "ProduceMessage", 2)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, messages)

--- a/differ/renderer.go
+++ b/differ/renderer.go
@@ -40,7 +40,7 @@ func renderReportsForCluster(
 	config conf.DependenciesConfiguration,
 	clusterName types.ClusterName,
 	reports []types.ReportItem,
-	ruleContent types.RulesMap) ([]types.RenderedReport, error) {
+	ruleContent types.Rules) ([]types.RenderedReport, error) {
 
 	req, err := createTemplateRendererRequest(ruleContent, reports, clusterName, config.TemplateRendererURL)
 	if err != nil {
@@ -78,15 +78,13 @@ func getAllContentFromMap(ruleContent types.RulesMap) []utypes.RuleContent {
 }
 
 func createTemplateRendererRequest(
-	ruleContent types.RulesMap,
+	rules types.Rules,
 	reports []types.ReportItem,
 	clusterName types.ClusterName,
 	rendererURL string) (*http.Request, error) {
 
-	content := getAllContentFromMap(ruleContent)
-
 	requestBody := types.TemplateRendererRequestBody{
-		Content: content,
+		Content: rules,
 		ReportData: types.ReportData{
 			Reports: map[types.ClusterName]types.Report{
 				clusterName: {Reports: reports},

--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -99,6 +99,8 @@ func TestRenderReportsForCluster(t *testing.T) {
 		},
 	}
 
+	rules := getAllContentFromMap(ruleContent)
+
 	reports := []types.ReportItem{
 		types.ReportItem{
 			Type:     "rule",
@@ -114,7 +116,7 @@ func TestRenderReportsForCluster(t *testing.T) {
 		},
 	}
 
-	rendereredReports, err := renderReportsForCluster(config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", reports, ruleContent)
+	rendereredReports, err := renderReportsForCluster(config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", reports, rules)
 	v, _ := json.Marshal(rendereredReports)
 	log.Info().Msg(string(v))
 	assert.NoError(t, err)

--- a/types/types.go
+++ b/types/types.go
@@ -116,6 +116,9 @@ type States struct {
 	ErrorState      StateID
 }
 
+// Rules is a slice of RuleContent objects
+type Rules []types.RuleContent
+
 // RulesMap contains a map of RuleContent objects accesible indexed by rule names
 type RulesMap map[string]types.RuleContent
 
@@ -279,8 +282,8 @@ type ReportData struct {
 
 // TemplateRendererRequestBody is a structure to be sent in request body to content template renderer
 type TemplateRendererRequestBody struct {
-	Content    []types.RuleContent `json:"content"`
-	ReportData ReportData          `json:"report_data"`
+	Content    Rules      `json:"content"`
+	ReportData ReportData `json:"report_data"`
 }
 
 // ServiceLogEntry is a structure to be sent to Service Log


### PR DESCRIPTION
# Description

`getAllContentFromMap` is currently called every time we want to render the reports for a given cluster, so we are doing this slice creation thousands of times.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Updated UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
