### PR TITLE
Sanitize cooldown value to avoid panic

### DIFF
--- a/differ/storage.go
+++ b/differ/storage.go
@@ -544,7 +544,7 @@ func (storage DBStorage) ReadLastNotifiedRecordForClusterList(
 	var err error
 	var rows *sql.Rows
 
-	if len(timeOffset) == 0 || strings.Split(timeOffset, " ")[0] == "0" {
+	if len(strings.TrimSpace(timeOffset)) == 0 || strings.Split(timeOffset, " ")[0] == "0" {
 		query := strings.Join([]string{selectQuery, whereClause, orderByClause, ";"}, " ")
 		rows, err = storage.connection.Query(query)
 	} else {

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -56,6 +56,7 @@ func TestReadLastNotifiedRecordForClusterList(t *testing.T) {
 		}
 		timeOffset           = "1 day"
 		timeOffsetNotSet     = ""
+		timeOffsetEmptySpace = "   "
 		timeOffsetSetToZero  = "0"
 		timeOffsetSetToZeroX = "0 hours"
 	)
@@ -114,6 +115,10 @@ func TestReadLastNotifiedRecordForClusterList(t *testing.T) {
 		clusterEntries, timeOffsetSetToZeroX, types.NotificationBackendTarget)
 	assert.NoError(t, err, "unexpected query")
 
+	mock.ExpectQuery(regexp.QuoteMeta(expectedQuery)).WillReturnRows(rows)
+	_, err = sut.ReadLastNotifiedRecordForClusterList(
+		clusterEntries, timeOffsetEmptySpace, types.NotificationBackendTarget)
+	assert.NoError(t, err, "unexpected query")
 }
 
 func newMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {


### PR DESCRIPTION
# Description

Fix for https://github.com/RedHatInsights/ccx-notification-service/pull/371#pullrequestreview-1159844086.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Updated UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
