### PR TITLE
Add v1 prefix to template renderer endpoint

### DIFF
--- a/config-devel.toml
+++ b/config-devel.toml
@@ -41,7 +41,7 @@ log_sql_queries = true
 content_server = "localhost:8082"
 content_endpoint = "/api/v1/content"
 template_renderer_server = "localhost:8083"
-template_renderer_endpoint = "/rendered_reports"
+template_renderer_endpoint = "/v1/rendered_reports"
 
 [notifications]
 insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"

--- a/config.toml
+++ b/config.toml
@@ -46,7 +46,7 @@ log_sql_queries = true
 content_server = "localhost:8082" #provide in deployment env or as secret
 content_endpoint = "/api/v1/content" #provide in deployment env or as secret
 template_renderer_server = "localhost:8083" #provide in deployment env or as secret
-template_renderer_endpoint = "/rendered_reports" #provide in deployment env or as secret
+template_renderer_endpoint = "/v1/rendered_reports" #provide in deployment env or as secret
 
 [notifications]
 insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -163,7 +163,7 @@ objects:
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_SERVER
             value: ${TEMPLATE_RENDERER_SERVER}
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__TEMPLATE_RENDERER_ENDPOINT
-            value: rendered_reports
+            value: "v1/rendered_reports"
           - name: CCX_NOTIFICATION_SERVICE__NOTIFICATIONS__INSIGHTS_ADVISOR_URL
             value: "https://${PLATFORM_UI_HOSTNAME}/openshift/insights/advisor/clusters/{cluster_id}"
           - name: CCX_NOTIFICATION_SERVICE__NOTIFICATIONS__CLUSTER_DETAILS_URI


### PR DESCRIPTION
# Description

Change endpoint of template renderer to include v1 prefix. Applicable after merge of [this PR](https://github.com/RedHatInsights/insights-content-template-renderer/pull/14).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
