### PR TITLE
Add url to reason not description

### DIFF
--- a/differ/renderer.go
+++ b/differ/renderer.go
@@ -111,5 +111,5 @@ func createTemplateRendererRequest(
 func addDetailedInfoURLToRenderedReport(report *types.RenderedReport, infoURL *string) {
 	replacer := strings.NewReplacer("{module}", string(report.RuleID), "{error_key}", string(report.ErrorKey))
 	detailedInfoURL := replacer.Replace(*infoURL)
-	report.Description += "\n\n[More details](" + detailedInfoURL + ")."
+	report.Reason += "\n\n[More details](" + detailedInfoURL + ")."
 }

--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -102,13 +102,13 @@ func TestRenderReportsForCluster(t *testing.T) {
 	rules := getAllContentFromMap(ruleContent)
 
 	reports := []types.ReportItem{
-		types.ReportItem{
+		{
 			Type:     "rule",
 			Module:   "rule_1.report",
 			ErrorKey: "RULE_1",
 			Details:  json.RawMessage("{}"),
 		},
-		types.ReportItem{
+		{
 			Type:     "rule",
 			Module:   "rule_2.report",
 			ErrorKey: "RULE_2",
@@ -239,5 +239,5 @@ func TestAddDetailedInfoURLToRenderedReport(t *testing.T) {
 	}
 
 	addDetailedInfoURLToRenderedReport(&renderedReport, &detailsURI)
-	assert.Equal(t, renderedReport.Description, "this is just a test issue with a bunch of words in it\n\n[More details](theUri/a.rule.id|THE_ERROR_KEY).")
+	assert.Equal(t, renderedReport.Reason, "there is no real reason\n\n[More details](theUri/a.rule.id|THE_ERROR_KEY).")
 }


### PR DESCRIPTION
# Description

Service log's description is gathered from the `report.Reason`, not `report.Description`. It's a bit misleading.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Unit tests.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
