### PR TITLE
Pass configuration by reference into RenderReportsForCluster function

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -382,7 +382,7 @@ func createServiceLogEntry(report types.RenderedReport, cluster types.ClusterEnt
 func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.ClusterEntry,
 	rules types.Rules, ruleContent types.RulesMap, reports []types.ReportItem) (totalMessages int, err error) {
 	renderedReports, err := renderReportsForCluster(
-		conf.GetDependenciesConfiguration(*configuration), cluster.ClusterName,
+		&conf.GetDependenciesConfiguration(*configuration), cluster.ClusterName,
 		reports, rules)
 	if err != nil {
 		log.Err(err).

--- a/differ/renderer.go
+++ b/differ/renderer.go
@@ -38,7 +38,7 @@ import (
 )
 
 func renderReportsForCluster(
-	config conf.DependenciesConfiguration,
+	config *conf.DependenciesConfiguration,
 	clusterName types.ClusterName,
 	reports []types.ReportItem,
 	ruleContent types.Rules) ([]types.RenderedReport, error) {

--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -116,7 +116,7 @@ func TestRenderReportsForCluster(t *testing.T) {
 		},
 	}
 
-	rendereredReports, err := renderReportsForCluster(config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", reports, rules)
+	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", reports, rules)
 	v, _ := json.Marshal(rendereredReports)
 	log.Info().Msg(string(v))
 	assert.NoError(t, err)


### PR DESCRIPTION
# Description

Pass configuration by reference into `RenderReportsForCluster` function

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
