### PR TITLE
Pass `record` by reference

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -70,7 +70,7 @@ func getNotificationType(notificationTypes []types.NotificationType, value strin
 	return -1
 }
 
-func getNotificationResolution(issue types.ReportItem, record types.NotificationRecord) (resolution bool) {
+func getNotificationResolution(issue types.ReportItem, record *types.NotificationRecord) (resolution bool) {
 	// it is not a brand new cluster -> check if issue was included in older report
 	var oldReport types.Report
 	err := json.Unmarshal([]byte(record.Report), &oldReport)
@@ -95,7 +95,7 @@ func shouldNotify(cluster types.ClusterEntry, issue types.ReportItem, eventTarge
 		return true
 	}
 
-	return getNotificationResolution(issue, reported)
+	return getNotificationResolution(issue, &reported)
 }
 
 func updateNotificationRecordSameState(storage Storage, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp, eventTarget types.EventTarget) {


### PR DESCRIPTION
# Description

Pass `record` by reference. It's size is 121 bytes, reference is 4/8 bytes only.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
