### PR TITLE
Don't pass whole `configuration` to `GetStorageConfiguration function`, use reference instead

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -288,7 +288,7 @@ func createURL(server, endpoint string) (string, error) {
 }
 
 // GetStorageConfiguration returns storage configuration
-func GetStorageConfiguration(configuration ConfigStruct) StorageConfiguration {
+func GetStorageConfiguration(configuration *ConfigStruct) StorageConfiguration {
 	return configuration.Storage
 }
 

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -164,7 +164,7 @@ func TestLoadStorageConfiguration(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	storageCfg := conf.GetStorageConfiguration(config)
+	storageCfg := conf.GetStorageConfiguration(&config)
 
 	assert.Equal(t, "sqlite3", storageCfg.Driver)
 	assert.Equal(t, "user", storageCfg.PGUsername)
@@ -377,7 +377,7 @@ func TestLoadStorageConfigFromClowder(t *testing.T) {
 	cfg, err := conf.LoadConfiguration(envVar, "../tests/config1")
 	assert.NoError(t, err, "error loading configuration")
 
-	storageCfg := conf.GetStorageConfiguration(cfg)
+	storageCfg := conf.GetStorageConfiguration(&cfg)
 	assert.Equal(t, dbName, storageCfg.PGDBName)
 	assert.Equal(t, hostname, storageCfg.PGHost)
 	assert.Equal(t, port, storageCfg.PGPort)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -244,7 +244,7 @@ func showConfiguration(config conf.ConfigStruct) {
 		Str("OCM URL", serviceLogConfig.URL).
 		Msg("ServiceLog configuration")
 
-	storageConfig := conf.GetStorageConfiguration(config)
+	storageConfig := conf.GetStorageConfiguration(&config)
 	log.Info().
 		Str("Driver", storageConfig.Driver).
 		Str("DB Name", storageConfig.PGDBName).
@@ -1237,7 +1237,7 @@ func Run() {
 		Msg("Log level")
 
 	// prepare the storage
-	storageConfiguration := conf.GetStorageConfiguration(config)
+	storageConfiguration := conf.GetStorageConfiguration(&config)
 	storage, err := NewStorage(storageConfiguration)
 	if err != nil {
 		StorageSetupErrors.Inc()


### PR DESCRIPTION
# Description

Don't pass whole `configuration` to `GetStorageConfiguration function`, use reference instead

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
