### PR TITLE
Don't pass whole `configuration` to `GetLoggingConfiguration`

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -293,7 +293,7 @@ func GetStorageConfiguration(configuration *ConfigStruct) StorageConfiguration {
 }
 
 // GetLoggingConfiguration returns logging configuration
-func GetLoggingConfiguration(configuration ConfigStruct) LoggingConfiguration {
+func GetLoggingConfiguration(configuration *ConfigStruct) LoggingConfiguration {
 	return configuration.Logging
 }
 

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -253,7 +253,7 @@ func TestLoadLoggingConfiguration(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	loggingCfg := conf.GetLoggingConfiguration(config)
+	loggingCfg := conf.GetLoggingConfiguration(&config)
 
 	assert.Equal(t, true, loggingCfg.Debug)
 	assert.Equal(t, "", loggingCfg.LogLevel)

--- a/config_benchmark_test.go
+++ b/config_benchmark_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main_test
+
+// Benchmark for config module
+
+import (
+	"os"
+	"testing"
+
+	conf "github.com/RedHatInsights/ccx-notification-service/conf"
+)
+
+// Configuration-related constants
+const (
+	configFileEnvName = "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	configFileName    = "tests/benchmark"
+)
+
+// loadConfiguration function loads configuration prepared to be used by
+// benchmarks
+func loadConfiguration() (conf.ConfigStruct, error) {
+	os.Clearenv()
+
+	err := os.Setenv(configFileEnvName, configFileName)
+	if err != nil {
+		return conf.ConfigStruct{}, err
+	}
+
+	config, err := conf.LoadConfiguration(configFileEnvName, configFileName)
+	if err != nil {
+		return conf.ConfigStruct{}, err
+	}
+
+	return config, nil
+}
+
+func mustLoadBenchmarkConfiguration(b *testing.B) conf.ConfigStruct {
+	configuration, err := loadConfiguration()
+	if err != nil {
+		b.Fatal(err)
+	}
+	return configuration
+}
+
+// BenchmarkGetLoggingConfiguration measures the speed of
+// GetLoggingConfiguration function from the main module.
+func BenchmarkGetLoggingConfiguration(b *testing.B) {
+	configuration := mustLoadBenchmarkConfiguration(b)
+
+	for i := 0; i < b.N; i++ {
+		// call benchmarked function
+		m := conf.GetLoggingConfiguration(&configuration)
+
+		b.StopTimer()
+		if !m.Debug {
+			b.Fatal("Wrong configuration: debug is set to false")
+		}
+		if m.LogLevel != "" {
+			b.Fatal("Wrong configuration: loglevel = '" + m.LogLevel + "'")
+		}
+		b.StartTimer()
+	}
+
+}

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -263,7 +263,7 @@ func showConfiguration(config conf.ConfigStruct) {
 		Str("Template renderer endpoint", dependenciesConfig.TemplateRendererEndpoint).
 		Msg("Dependencies configuration")
 
-	loggingConfig := conf.GetLoggingConfiguration(config)
+	loggingConfig := conf.GetLoggingConfiguration(&config)
 	log.Info().
 		Str("Level", loggingConfig.LogLevel).
 		Bool("Pretty colored debug logging", loggingConfig.Debug).

--- a/tests/benchmark.toml
+++ b/tests/benchmark.toml
@@ -1,0 +1,28 @@
+[kafka_broker]
+address = "localhost:9092"
+topic = "test_notification_topic"
+
+[dependencies]
+content_endpoint = "localhost:8080"
+
+[storage]
+db_driver = "sqlite3"
+sqlite_datasource = ":memory:"
+pg_username = "user"
+pg_password = "password"
+pg_host = "localhost"
+pg_port = 5432
+pg_db_name = "aggregator"
+pg_params = ""
+
+[logging]
+debug = true
+log_level = ""
+
+[cloudwatch]
+
+[processing]
+filter_allowed_clusters = true
+allowed_clusters = ["aa", "bb", "cc"]
+filter_blocked_clusters = true
+blocked_clusters = ["bbbbbbbb-0000-0000-0000-000000000000", "bbbbbbbb-1111-1111-1111-111111111111", "bbbbbbbb-2222-2222-2222-222222222222"]


### PR DESCRIPTION
# Description

Don't pass whole `configuration` to `GetLoggingConfiguration`

## Type of change

- Refactor (refactoring code, removing useless files)
- Benchmarks (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
