### PR TITLE
Don't pass whole `configuration` to `GetMetricsConfiguration` function

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -318,7 +318,7 @@ func GetNotificationsConfiguration(configuration ConfigStruct) NotificationsConf
 }
 
 // GetMetricsConfiguration returns metrics configuration
-func GetMetricsConfiguration(configuration ConfigStruct) MetricsConfiguration {
+func GetMetricsConfiguration(configuration *ConfigStruct) MetricsConfiguration {
 	return configuration.Metrics
 }
 

--- a/conf/config_benchmark_test.go
+++ b/conf/config_benchmark_test.go
@@ -134,3 +134,24 @@ func BenchmarkGetServiceLogConfiguration(b *testing.B) {
 	}
 
 }
+
+// BenchmarkGetMetricsConfiguration measures the speed of
+// GetMetricsConfiguration function from the conf module.
+func BenchmarkGetMetricsConfiguration(b *testing.B) {
+	configuration := mustLoadBenchmarkConfiguration(b)
+
+	for i := 0; i < b.N; i++ {
+		// call benchmarked function
+		m := conf.GetMetricsConfiguration(&configuration)
+
+		b.StopTimer()
+		if m.Namespace != "ccx_notification_service" {
+			b.Fatal("Wrong configuration: namespace = '" + m.Namespace + "'")
+		}
+		if m.Subsystem != "to_notification_backend" {
+			b.Fatal("Wrong configuration: subsystem = '" + m.Subsystem + "'")
+		}
+		b.StartTimer()
+	}
+
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -305,7 +305,7 @@ func TestLoadMetricsConfiguration(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	configuration := conf.GetMetricsConfiguration(config)
+	configuration := conf.GetMetricsConfiguration(&config)
 
 	assert.Equal(t, "ccx_notification_service_namespace", configuration.Namespace)
 	assert.Equal(t, ":9091", configuration.GatewayURL)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -277,7 +277,7 @@ func showConfiguration(config conf.ConfigStruct) {
 		Str("Cooldown", notificationConfig.Cooldown).
 		Msg("Notifications configuration")
 
-	metricsConfig := conf.GetMetricsConfiguration(config)
+	metricsConfig := conf.GetMetricsConfiguration(&config)
 
 	// Authentication token and metrics groups values are omitted on
 	// purpose
@@ -1052,7 +1052,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	}
 
 	assertNotificationDestination(config)
-	registerMetrics(conf.GetMetricsConfiguration(config))
+	registerMetrics(conf.GetMetricsConfiguration(&config))
 	log.Info().Msg(separator)
 	log.Info().Msg("Getting rule content and impacts from content service")
 
@@ -1111,7 +1111,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	log.Info().Int(clustersAttribute, entries).Msg("Process Clusters Entries: done")
 	closeDiffer(storage)
 	log.Info().Msg("Differ finished. Pushing metrics to the configured prometheus gateway.")
-	pushMetrics(conf.GetMetricsConfiguration(config))
+	pushMetrics(conf.GetMetricsConfiguration(&config))
 	log.Info().Msg(separator)
 }
 

--- a/tests/benchmark.toml
+++ b/tests/benchmark.toml
@@ -29,6 +29,17 @@ pg_port = 5432
 pg_db_name = "aggregator"
 pg_params = ""
 
+[metrics]
+job_name = "ccx_notification_service"
+# The metrics in Prometheus will be $namespace_$subsystem_$name
+namespace = "ccx_notification_service"
+subsystem = "to_notification_backend"
+gateway_url = "localhost:9091"
+gateway_auth_token = ""
+retries = 3
+# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+retry_after = "60s"
+
 [logging]
 debug = true
 log_level = ""


### PR DESCRIPTION
# Description

Don't pass whole `configuration` to `GetMetricsConfiguration` function

## Type of change

- Refactor (refactoring code, removing useless files)
- Benchmarks (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
