### PR TITLE
Don't pass whole `configuration` structure to `GetDependenciesConfiguration` function

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -308,7 +308,7 @@ func GetServiceLogConfiguration(configuration *ConfigStruct) ServiceLogConfigura
 }
 
 // GetDependenciesConfiguration returns dependencies configuration
-func GetDependenciesConfiguration(configuration ConfigStruct) DependenciesConfiguration {
+func GetDependenciesConfiguration(configuration *ConfigStruct) DependenciesConfiguration {
 	return configuration.Dependencies
 }
 

--- a/conf/config_benchmark_test.go
+++ b/conf/config_benchmark_test.go
@@ -57,6 +57,27 @@ func mustLoadBenchmarkConfiguration(b *testing.B) conf.ConfigStruct {
 	return configuration
 }
 
+// BenchmarkGetDependenciesConfiguration measures the speed of
+// GetDependenciesConfiguration function from the conf module.
+func BenchmarkGetDependenciesConfiguration(b *testing.B) {
+	configuration := mustLoadBenchmarkConfiguration(b)
+
+	for i := 0; i < b.N; i++ {
+		// call benchmarked function
+		m := conf.GetDependenciesConfiguration(&configuration)
+
+		b.StopTimer()
+		if m.ContentServiceServer != "localhost:8082" {
+			b.Fatal("Wrong configuration: content service server = '" + m.ContentServiceServer + "'")
+		}
+		if m.ContentServiceEndpoint != "/api/v1/content" {
+			b.Fatal("Wrong configuration: content service endpoint = '" + m.ContentServiceEndpoint + "'")
+		}
+		b.StartTimer()
+	}
+
+}
+
 // BenchmarkGetStorageConfiguration measures the speed of
 // GetStorageConfiguration function from the conf module.
 func BenchmarkGetStorageConfiguration(b *testing.B) {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -266,7 +266,7 @@ func TestLoadDependenciesConfiguration(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	depsCfg := conf.GetDependenciesConfiguration(config)
+	depsCfg := conf.GetDependenciesConfiguration(&config)
 
 	assert.Equal(t, ":8081", depsCfg.ContentServiceEndpoint)
 }

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -255,7 +255,7 @@ func showConfiguration(config conf.ConfigStruct) {
 		Str("Parameters", storageConfig.PGParams).
 		Msg("Storage configuration")
 
-	dependenciesConfig := conf.GetDependenciesConfiguration(config)
+	dependenciesConfig := conf.GetDependenciesConfiguration(&config)
 	log.Info().
 		Str("Content server", dependenciesConfig.ContentServiceServer).
 		Str("Content endpoint", dependenciesConfig.ContentServiceEndpoint).
@@ -382,7 +382,7 @@ func createServiceLogEntry(report types.RenderedReport, cluster types.ClusterEnt
 func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.ClusterEntry,
 	rules types.Rules, ruleContent types.RulesMap, reports []types.ReportItem) (totalMessages int, err error) {
 	renderedReports, err := renderReportsForCluster(
-		conf.GetDependenciesConfiguration(*configuration), cluster.ClusterName,
+		conf.GetDependenciesConfiguration(configuration), cluster.ClusterName,
 		reports, rules)
 	if err != nil {
 		log.Err(err).
@@ -1056,7 +1056,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	log.Info().Msg(separator)
 	log.Info().Msg("Getting rule content and impacts from content service")
 
-	ruleContent, err := fetchAllRulesContent(conf.GetDependenciesConfiguration(config))
+	ruleContent, err := fetchAllRulesContent(conf.GetDependenciesConfiguration(&config))
 	if err != nil {
 		FetchContentErrors.Inc()
 		os.Exit(ExitStatusFetchContentError)

--- a/tests/benchmark.toml
+++ b/tests/benchmark.toml
@@ -17,7 +17,10 @@ event_filter = "totalRisk > totalRiskThreshold"
 rule_details_uri = "https://console.redhat.com/openshift/insights/advisor/recommendations/{module}|{error_key}"
 
 [dependencies]
-content_endpoint = "localhost:8080"
+content_server = "localhost:8082" #provide in deployment env or as secret
+content_endpoint = "/api/v1/content" #provide in deployment env or as secret
+template_renderer_server = "localhost:8083" #provide in deployment env or as secret
+template_renderer_endpoint = "/v1/rendered_reports" #provide in deployment env or as secret
 
 [storage]
 db_driver = "sqlite3"


### PR DESCRIPTION
# Description

Don't pass whole `configuration` structure to `GetDependenciesConfiguration` function

## Type of change

- Refactor (refactoring code, removing useless files)
- Benchmarks (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
