### PR TITLE
Don't pass whole `configuration` structure to function `GetNotificationsConfiguration`

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -313,7 +313,7 @@ func GetDependenciesConfiguration(configuration *ConfigStruct) DependenciesConfi
 }
 
 // GetNotificationsConfiguration returns configuration related with notification content
-func GetNotificationsConfiguration(configuration ConfigStruct) NotificationsConfiguration {
+func GetNotificationsConfiguration(configuration *ConfigStruct) NotificationsConfiguration {
 	return configuration.Notifications
 }
 

--- a/conf/config_benchmark_test.go
+++ b/conf/config_benchmark_test.go
@@ -57,6 +57,33 @@ func mustLoadBenchmarkConfiguration(b *testing.B) conf.ConfigStruct {
 	return configuration
 }
 
+// BenchmarkGetNotificationsConfiguration measures the speed of
+// GetNotificationsConfiguration function from the conf module.
+func BenchmarkGetNotificationsConfiguration(b *testing.B) {
+	configuration := mustLoadBenchmarkConfiguration(b)
+
+	for i := 0; i < b.N; i++ {
+		// call benchmarked function
+		m := conf.GetNotificationsConfiguration(&configuration)
+
+		b.StopTimer()
+		if m.InsightsAdvisorURL != "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}" {
+			b.Fatal("Wrong configuration: insights_advisor_url = '" + m.InsightsAdvisorURL + "'")
+		}
+		if m.ClusterDetailsURI != "https://console.redhat.com/openshift/details/{cluster_id}#insights" {
+			b.Fatal("Wrong configuration: cluster_details_uri = '" + m.ClusterDetailsURI + "'")
+		}
+		if m.RuleDetailsURI != "https://console.redhat.com/openshift/details/{cluster_id}/insights/{module}/{error_key}" {
+			b.Fatal("Wrong configuration: rule_details_uri = '" + m.RuleDetailsURI + "'")
+		}
+		if m.Cooldown != "24 hours" {
+			b.Fatal("Wrong configuration: cooldown = '" + m.Cooldown + "'")
+		}
+		b.StartTimer()
+	}
+
+}
+
 // BenchmarkGetDependenciesConfiguration measures the speed of
 // GetDependenciesConfiguration function from the conf module.
 func BenchmarkGetDependenciesConfiguration(b *testing.B) {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -279,7 +279,7 @@ func TestLoadNotificationsConfiguration(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	configuration := conf.GetNotificationsConfiguration(config)
+	configuration := conf.GetNotificationsConfiguration(&config)
 
 	assert.Equal(t, "url_to_specific_rule", configuration.RuleDetailsURI)
 	assert.Equal(t, "url_to_advisor", configuration.InsightsAdvisorURL)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -269,7 +269,7 @@ func showConfiguration(config conf.ConfigStruct) {
 		Bool("Pretty colored debug logging", loggingConfig.Debug).
 		Msg("Logging configuration")
 
-	notificationConfig := conf.GetNotificationsConfiguration(config)
+	notificationConfig := conf.GetNotificationsConfiguration(&config)
 	log.Info().
 		Str("Insights Advisor URL", notificationConfig.InsightsAdvisorURL).
 		Str("Cluster details URI", notificationConfig.ClusterDetailsURI).
@@ -1034,7 +1034,7 @@ func retrievePreviouslyReportedForEventTarget(storage *DBStorage, cooldown strin
 }
 
 func retrievePreviouslyReportedReports(config conf.ConfigStruct, storage *DBStorage, clusters []types.ClusterEntry) {
-	cooldown := conf.GetNotificationsConfiguration(config).Cooldown
+	cooldown := conf.GetNotificationsConfiguration(&config).Cooldown
 	if conf.GetKafkaBrokerConfiguration(&config).Enabled {
 		retrievePreviouslyReportedForEventTarget(storage, cooldown, clusters, types.NotificationBackendTarget)
 	}
@@ -1065,7 +1065,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	log.Info().Msg(separator)
 	log.Info().Msg("Read cluster list")
 
-	notifConfig := conf.GetNotificationsConfiguration(config)
+	notifConfig := conf.GetNotificationsConfiguration(&config)
 
 	setupNotificationURLs(notifConfig)
 	setupFiltersAndThresholds(config)

--- a/tests/benchmark.toml
+++ b/tests/benchmark.toml
@@ -22,6 +22,13 @@ content_endpoint = "/api/v1/content" #provide in deployment env or as secret
 template_renderer_server = "localhost:8083" #provide in deployment env or as secret
 template_renderer_endpoint = "/v1/rendered_reports" #provide in deployment env or as secret
 
+[notifications]
+insights_advisor_url = "https://console.redhat.com/openshift/insights/advisor/clusters/{cluster_id}"
+cluster_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}#insights"
+rule_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}/insights/{module}/{error_key}"
+# valid units are SQL epoch time units: months days hours minutes seconds"
+cooldown = "24 hours"
+
 [storage]
 db_driver = "sqlite3"
 sqlite_datasource = ":memory:"


### PR DESCRIPTION
# Description

Don't pass whole `configuration` structure to function `GetNotificationsConfiguration`

## Type of change

- Refactor (refactoring code, removing useless files)
- Benchmarks (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
