### PR TITLE
Don't pass whole `configuration` structure to function `GetCleanerConfiguration`

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -323,7 +323,7 @@ func GetMetricsConfiguration(configuration *ConfigStruct) MetricsConfiguration {
 }
 
 // GetCleanerConfiguration returns cleaner configuration
-func GetCleanerConfiguration(configuration ConfigStruct) CleanerConfiguration {
+func GetCleanerConfiguration(configuration *ConfigStruct) CleanerConfiguration {
 	return configuration.Cleaner
 }
 

--- a/conf/config_benchmark_test.go
+++ b/conf/config_benchmark_test.go
@@ -57,6 +57,24 @@ func mustLoadBenchmarkConfiguration(b *testing.B) conf.ConfigStruct {
 	return configuration
 }
 
+// BenchmarkGetCleanerConfiguration measures the speed of
+// GetCleanerConfiguration function from the conf module.
+func BenchmarkGetCleanerConfiguration(b *testing.B) {
+	configuration := mustLoadBenchmarkConfiguration(b)
+
+	for i := 0; i < b.N; i++ {
+		// call benchmarked function
+		m := conf.GetCleanerConfiguration(&configuration)
+
+		b.StopTimer()
+		if m.MaxAge != "90 days" {
+			b.Fatal("Wrong configuration: max_age = '" + m.MaxAge + "'")
+		}
+		b.StartTimer()
+	}
+
+}
+
 // BenchmarkGetNotificationsConfiguration measures the speed of
 // GetNotificationsConfiguration function from the conf module.
 func BenchmarkGetNotificationsConfiguration(b *testing.B) {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -320,7 +320,7 @@ func TestLoadCleanerConfiguration(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	configuration := conf.GetCleanerConfiguration(config)
+	configuration := conf.GetCleanerConfiguration(&config)
 
 	assert.Equal(t, "90 days", configuration.MaxAge)
 }

--- a/tests/benchmark.toml
+++ b/tests/benchmark.toml
@@ -1,3 +1,7 @@
+[logging]
+debug = true
+log_level = ""
+
 [kafka_broker]
 address = "localhost:9092"
 topic = "test_notification_topic"
@@ -16,6 +20,16 @@ total_risk_threshold = 3
 event_filter = "totalRisk > totalRiskThreshold"
 rule_details_uri = "https://console.redhat.com/openshift/insights/advisor/recommendations/{module}|{error_key}"
 
+[storage]
+db_driver = "sqlite3"
+sqlite_datasource = ":memory:"
+pg_username = "user"
+pg_password = "password"
+pg_host = "localhost"
+pg_port = 5432
+pg_db_name = "aggregator"
+pg_params = ""
+
 [dependencies]
 content_server = "localhost:8082" #provide in deployment env or as secret
 content_endpoint = "/api/v1/content" #provide in deployment env or as secret
@@ -29,16 +43,6 @@ rule_details_uri = "https://console.redhat.com/openshift/details/{cluster_id}/in
 # valid units are SQL epoch time units: months days hours minutes seconds"
 cooldown = "24 hours"
 
-[storage]
-db_driver = "sqlite3"
-sqlite_datasource = ":memory:"
-pg_username = "user"
-pg_password = "password"
-pg_host = "localhost"
-pg_port = 5432
-pg_db_name = "aggregator"
-pg_params = ""
-
 [metrics]
 job_name = "ccx_notification_service"
 # The metrics in Prometheus will be $namespace_$subsystem_$name
@@ -50,9 +54,9 @@ retries = 3
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 retry_after = "60s"
 
-[logging]
-debug = true
-log_level = ""
+[cleaner]
+# valid units are SQL epoch time units: months days hours minutes seconds"
+max_age = "90 days"
 
 [cloudwatch]
 


### PR DESCRIPTION
# Description

Don't pass whole `configuration` structure to function `GetCleanerConfiguration`

## Type of change

- Refactor (refactoring code, removing useless files)
- Benchmarks (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
