### PR TITLE
Don't pass whole `configuration` structure to `GetProcessingConfiguration` function

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -328,7 +328,7 @@ func GetCleanerConfiguration(configuration *ConfigStruct) CleanerConfiguration {
 }
 
 // GetProcessingConfiguration returns processing configuration
-func GetProcessingConfiguration(configuration ConfigStruct) ProcessingConfiguration {
+func GetProcessingConfiguration(configuration *ConfigStruct) ProcessingConfiguration {
 	return configuration.Processing
 }
 

--- a/conf/config_benchmark_test.go
+++ b/conf/config_benchmark_test.go
@@ -57,6 +57,27 @@ func mustLoadBenchmarkConfiguration(b *testing.B) conf.ConfigStruct {
 	return configuration
 }
 
+// BenchmarkGetProcessingConfiguration measures the speed of
+// GetProcessingConfiguration function from the conf module.
+func BenchmarkGetProcessingConfiguration(b *testing.B) {
+	configuration := mustLoadBenchmarkConfiguration(b)
+
+	for i := 0; i < b.N; i++ {
+		// call benchmarked function
+		m := conf.GetProcessingConfiguration(&configuration)
+
+		b.StopTimer()
+		if !m.FilterAllowedClusters {
+			b.Fatal("Wrong configuration: filter_allowed_clusters is set to false")
+		}
+		if !m.FilterBlockedClusters {
+			b.Fatal("Wrong configuration: filter_blocked_clusters is set to false")
+		}
+		b.StartTimer()
+	}
+
+}
+
 // BenchmarkGetCleanerConfiguration measures the speed of
 // GetCleanerConfiguration function from the conf module.
 func BenchmarkGetCleanerConfiguration(b *testing.B) {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -186,7 +186,7 @@ func TestLoadProcessingConfiguration3AllowedClusters(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	processingCfg := conf.GetProcessingConfiguration(config)
+	processingCfg := conf.GetProcessingConfiguration(&config)
 
 	assert.True(t, processingCfg.FilterAllowedClusters)
 	assert.Len(t, processingCfg.AllowedClusters, 3)
@@ -205,7 +205,7 @@ func TestLoadProcessingConfigurationNoAllowedClusters(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	processingCfg := conf.GetProcessingConfiguration(config)
+	processingCfg := conf.GetProcessingConfiguration(&config)
 
 	assert.False(t, processingCfg.FilterAllowedClusters)
 	assert.Len(t, processingCfg.AllowedClusters, 0)
@@ -221,7 +221,7 @@ func TestLoadProcessingConfiguration3BlockedClusters(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	processingCfg := conf.GetProcessingConfiguration(config)
+	processingCfg := conf.GetProcessingConfiguration(&config)
 
 	assert.True(t, processingCfg.FilterBlockedClusters)
 	assert.Len(t, processingCfg.BlockedClusters, 3)
@@ -240,7 +240,7 @@ func TestLoadProcessingConfigurationNoBlockedClusters(t *testing.T) {
 	config, err := conf.LoadConfiguration(envVar, "")
 	assert.Nil(t, err, "Failed loading configuration file from env var!")
 
-	processingCfg := conf.GetProcessingConfiguration(config)
+	processingCfg := conf.GetProcessingConfiguration(&config)
 
 	assert.False(t, processingCfg.FilterBlockedClusters)
 	assert.Len(t, processingCfg.BlockedClusters, 0)

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -289,7 +289,7 @@ func showConfiguration(config conf.ConfigStruct) {
 		Str("Retry after", metricsConfig.RetryAfter.String()).
 		Msg("Metrics configuration")
 
-	processingConfig := conf.GetProcessingConfiguration(config)
+	processingConfig := conf.GetProcessingConfiguration(&config)
 	log.Info().
 		Bool("Filter allowed clusters", processingConfig.FilterAllowedClusters).
 		Strs("List of allowed clusters", processingConfig.AllowedClusters).
@@ -1080,7 +1080,7 @@ func startDiffer(config conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	}
 
 	// filter clusters according to allow list and block list
-	clusters, statistic := filterClusterList(clusters, conf.GetProcessingConfiguration(config))
+	clusters, statistic := filterClusterList(clusters, conf.GetProcessingConfiguration(&config))
 	log.Info().
 		Int("On input", statistic.Input).
 		Int("Allowed", statistic.Allowed).


### PR DESCRIPTION
# Description

Don't pass whole `configuration` structure to `GetProcessingConfiguration` function

## Type of change

- Refactor (refactoring code, removing useless files)
- Benchmarks (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
