### PR TITLE
Don't pass the whole 700 bytes `config` struct to Kafka interface constructor

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -749,7 +749,7 @@ func setupKafkaProducer(config conf.ConfigStruct) {
 	}
 	log.Info().Msg("Broker config for Notification Service is enabled")
 
-	kafkaProducer, err := kafka.New(config)
+	kafkaProducer, err := kafka.New(&config)
 	if err != nil {
 		ProducerSetupErrors.Inc()
 		log.Error().

--- a/producer/kafka/kafka_producer.go
+++ b/producer/kafka/kafka_producer.go
@@ -41,8 +41,8 @@ type Producer struct {
 }
 
 // New constructs new implementation of Producer interface
-func New(config conf.ConfigStruct) (*Producer, error) {
-	kafkaConfig := conf.GetKafkaBrokerConfiguration(&config)
+func New(config *conf.ConfigStruct) (*Producer, error) {
+	kafkaConfig := conf.GetKafkaBrokerConfiguration(config)
 
 	saramaConfig, err := saramaConfigFromBrokerConfig(kafkaConfig)
 	if err != nil {
@@ -51,7 +51,7 @@ func New(config conf.ConfigStruct) (*Producer, error) {
 
 	producer, err := sarama.NewSyncProducer([]string{kafkaConfig.Address}, saramaConfig)
 	if err != nil {
-		log.Error().Err(err).Msgf("unable to start a Kafka producer with broker address %s", config.Kafka.Address)
+		log.Error().Err(err).Msgf("unable to start a Kafka producer with broker address %s", kafkaConfig.Address)
 		return nil, err
 	}
 

--- a/producer/kafka/kafka_producer_test.go
+++ b/producer/kafka/kafka_producer_test.go
@@ -50,7 +50,7 @@ func init() {
 // This test assumes there is no local kafka instance currently running
 func TestNewProducerBadBroker(t *testing.T) {
 	const expectedErr = "kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"
-	_, err := New(conf.ConfigStruct{
+	_, err := New(&conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
 			Address: "",
 			Topic:   "whatever",
@@ -59,7 +59,7 @@ func TestNewProducerBadBroker(t *testing.T) {
 		}})
 	assert.EqualError(t, err, expectedErr)
 
-	_, err = New(conf.ConfigStruct{
+	_, err = New(&conf.ConfigStruct{
 		Kafka: brokerCfg,
 	})
 	assert.EqualError(t, err, expectedErr)
@@ -96,7 +96,7 @@ func TestProducerNew(t *testing.T) {
 	}
 	mockBroker.SetHandlerByMap(handlerMap)
 
-	prod, err := New(conf.ConfigStruct{
+	prod, err := New(&conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
 			Address: mockBroker.Addr(),
 			Topic:   brokerCfg.Topic,


### PR DESCRIPTION
# Description

Don't pass the whole 700 bytes `config` struct to Kafka interface constructor

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
