### PR TITLE
Checks if all configuration getters are not mutators

### DIFF
--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -678,3 +678,23 @@ func TestLoadConfigurationKafkaTopicUpdatedFromClowder(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
 	assert.Equal(t, topicName, brokerCfg.Topic)
 }
+
+// TestGetStorageConfigurationIsImmutable checks if function
+// GetStorageConfiguration is not mutable
+func TestGetStorageConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetStorageConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetStorageConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -818,3 +818,23 @@ func TestGetNotificationsConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetNotificationsConfiguration must not be mutable")
 }
+
+// TestGetCleanerConfigurationIsImmutable checks if function
+// GetCleanerConfiguration is not mutable
+func TestGetCleanerConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetCleanerConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetCleanerConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -718,3 +718,23 @@ func TestGetLoggingConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetLoggingConfiguration must not be mutable")
 }
+
+// TestGetKafkaBrokerConfigurationIsImmutable checks if function
+// GetKafkaBrokerConfiguration is not mutable
+func TestGetKafkaBrokerConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetKafkaBrokerConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetKafkaBrokerConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -778,3 +778,23 @@ func TestGetServiceLogConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetServiceLogConfiguration must not be mutable")
 }
+
+// TestGetDependenciesConfigurationIsImmutable checks if function
+// GetDependenciesConfiguration is not mutable
+func TestGetDependenciesConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetDependenciesConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetDependenciesConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -698,3 +698,23 @@ func TestGetStorageConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetStorageConfiguration must not be mutable")
 }
+
+// TestGetLoggingConfigurationIsImmutable checks if function
+// GetLoggingConfiguration is not mutable
+func TestGetLoggingConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetLoggingConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetLoggingConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -838,3 +838,23 @@ func TestGetCleanerConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetCleanerConfiguration must not be mutable")
 }
+
+// TestGetProcessingConfigurationIsImmutable checks if function
+// GetProcessingConfiguration is not mutable
+func TestGetProcessingConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetProcessingConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetProcessingConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -758,3 +758,23 @@ func TestGetMetricsConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetMetricsConfiguration must not be mutable")
 }
+
+// TestGetServiceLogConfigurationIsImmutable checks if function
+// GetServiceLogConfiguration is not mutable
+func TestGetServiceLogConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetServiceLogConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetServiceLogConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -798,3 +798,23 @@ func TestGetDependenciesConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetDependenciesConfiguration must not be mutable")
 }
+
+// TestGetNotificationsConfigurationIsImmutable checks if function
+// GetNotificationsConfiguration is not mutable
+func TestGetNotificationsConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetNotificationsConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetNotificationsConfiguration must not be mutable")
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -738,3 +738,23 @@ func TestGetKafkaBrokerConfigurationIsImmutable(t *testing.T) {
 	// and compare original configuration with possibly mutated one
 	assert.Equal(t, config, origConfig, "GetKafkaBrokerConfiguration must not be mutable")
 }
+
+// TestGetMetricsConfigurationIsImmutable checks if function
+// GetMetricsConfiguration is not mutable
+func TestGetMetricsConfigurationIsImmutable(t *testing.T) {
+	envVar := "CCX_NOTIFICATION_SERVICE_CONFIG_FILE"
+	mustSetEnv(t, envVar, "tests/config2")
+
+	// load configuration with check if loading was ok
+	config, err := conf.LoadConfiguration(envVar, "")
+	assert.Nil(t, err, "Failed loading configuration file from env var!")
+
+	// clone the configuration
+	origConfig := config
+
+	// call the tested function
+	conf.GetMetricsConfiguration(&config)
+
+	// and compare original configuration with possibly mutated one
+	assert.Equal(t, config, origConfig, "GetMetricsConfiguration must not be mutable")
+}


### PR DESCRIPTION
# Description

Checks if all configuration getters are not mutators

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
