### PR TITLE
Add benchmark for findRenderedReport

### DIFF
--- a/differ/differ_benchmark_test.go
+++ b/differ/differ_benchmark_test.go
@@ -43,7 +43,10 @@ func BenchmarkFindRenderedReport(b *testing.B) {
 	ruleName := types.RuleName("rule_4")
 	errorKey := types.ErrorKey("RULE_4")
 	for i := 0; i < b.N; i++ {
-		findRenderedReport(reports, ruleName, errorKey)
+		_, err := findRenderedReport(reports, ruleName, errorKey)
+		if err != nil {
+			b.Fatal("Given key could not be found in benchmark reports")
+		}
 		b.StopTimer()
 		b.StartTimer()
 	}

--- a/differ/differ_benchmark_test.go
+++ b/differ/differ_benchmark_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"github.com/RedHatInsights/ccx-notification-service/types"
+	"testing"
+)
+
+func BenchmarkFindRenderedReport(b *testing.B) {
+	reports := []types.RenderedReport{
+		types.RenderedReport{
+			RuleID:   "rule_1",
+			ErrorKey: "RULE_1",
+		},
+		types.RenderedReport{
+			RuleID:   "rule_2",
+			ErrorKey: "RULE_2",
+		},
+		types.RenderedReport{
+			RuleID:   "rule_3",
+			ErrorKey: "RULE_3",
+		},
+		types.RenderedReport{
+			RuleID:   "rule_4",
+			ErrorKey: "RULE_4",
+		},
+	}
+	ruleName := types.RuleName("rule_4")
+	errorKey := types.ErrorKey("RULE_4")
+	for i := 0; i < b.N; i++ {
+		findRenderedReport(reports, ruleName, errorKey)
+		b.StopTimer()
+		b.StartTimer()
+	}
+}

--- a/differ/differ_benchmark_test.go
+++ b/differ/differ_benchmark_test.go
@@ -47,7 +47,5 @@ func BenchmarkFindRenderedReport(b *testing.B) {
 		if err != nil {
 			b.Fatal("Given key could not be found in benchmark reports")
 		}
-		b.StopTimer()
-		b.StartTimer()
 	}
 }


### PR DESCRIPTION
# Description

Added benchamark for findRenderedReport in order to measure its performance.

## Type of change

- Benchmarks (no changes in the code)

## Testing steps

Run benchmarks.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
