### PR TITLE
Do not query previously reported rows if cooldown is set to 0

### DIFF
--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -67,13 +67,13 @@ func TestReadLastNotifiedRecordForClusterList(t *testing.T) {
 	sut := differ.NewFromConnection(db, types.DBDriverPostgres)
 
 	expectedQuery := fmt.Sprintf(`
-	SELECT org_id, cluster, report, notified_at 
-	FROM ( 
-		SELECT DISTINCT ON (cluster) * 
+	SELECT org_id, cluster, report, notified_at
+	FROM (
+		SELECT DISTINCT ON (cluster) *
 		FROM reported
 		WHERE event_type_id = %v AND state = 1 AND org_id IN (%v) AND cluster IN (%v)
-		ORDER BY cluster, notified_at DESC) t 
-	WHERE notified_at > NOW() - $1::INTERVAL;
+		ORDER BY cluster, notified_at DESC) t
+	WHERE notified_at > NOW() - $1::INTERVAL ;
 	`, types.NotificationBackendTarget, orgs, clusters)
 
 	rows := sqlmock.NewRows(
@@ -92,9 +92,9 @@ func TestReadLastNotifiedRecordForClusterList(t *testing.T) {
 
 	// If timeOffset is 0 or empty string, the WHERE clause is not included
 	expectedQuery = fmt.Sprintf(`
-	SELECT org_id, cluster, report, notified_at 
-	FROM ( 
-		SELECT DISTINCT ON (cluster) * 
+	SELECT org_id, cluster, report, notified_at
+	FROM (
+		SELECT DISTINCT ON (cluster) *
 		FROM reported
 		WHERE event_type_id = %v AND state = 1 AND org_id IN (%v) AND cluster IN (%v)
 		ORDER BY cluster, notified_at DESC) t ;


### PR DESCRIPTION
# Description

If the cooldown is set to 0, we can avoid doing the SELECT query, which we know to be slow due to the filtering.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)

## Testing steps

UTs updated, BDDs

## Checklist
* [x] `make before_commit` passes
* [] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
