### PR TITLE
INSERT benchmarks for various cluster name representation

### DIFF
--- a/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
+++ b/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
@@ -282,35 +282,35 @@ func insertIntoReportedV2(b *testing.B, connection *sql.DB, insertStatement *str
 	}
 }
 
-func performInsertBenchmark(b *testing.B, createTableStatement, dropTableStatement string, report *string) {
+// function to insert record into table v3 is the same as function to insert
+// record into table v1
+var insertIntoReportedV3 = insertIntoReportedV1
+
+func performInsertBenchmark(b *testing.B,
+	createTableStatement, dropTableStatement, insertStatement string,
+	insertFunction InsertFunction,
+	report *string,
+	dropTables bool) {
+
 	// connect to database
 	b.StopTimer()
 	connectionInfo := readConnectionInfoFromEnvVars(b)
-	// log.Print(connectionInfo)
 	connection := connectToDatabase(b, &connectionInfo)
-	// log.Print(connection)
 
 	// create table used by benchmark
-	_, err := connection.Exec(createTableStatement)
-	if err != nil {
-		b.Error("Create table error", err)
-		return
-	}
+	mustExecuteStatement(b, connection, createTableStatement)
 
 	// perform benchmark
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		insertIntoReportedV1(b, connection, i, report)
+		insertFunction(b, connection, &insertStatement, i, report)
 	}
 	b.StopTimer()
 
 	// drop table used by benchmark
-	_, err = connection.Exec(dropTableStatement)
-	if err != nil {
-		b.Error("Drop table error", err)
-		return
+	if dropTables {
+		mustExecuteStatement(b, connection, dropTableStatement)
 	}
-	b.StartTimer()
 }
 
 func BenchmarkInsertUUIDAsVarchar(b *testing.B) {

--- a/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
+++ b/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
@@ -105,6 +105,12 @@ const (
         `
 )
 
+// Tests configuration
+const (
+	// Should tables used by benchmarks be dropped at the end?
+	DropTables = false
+)
+
 // ConnectionInfo structure stores all values needed to connect to PSQL
 type ConnectionInfo struct {
 	username string

--- a/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
+++ b/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
@@ -313,31 +313,50 @@ func performInsertBenchmark(b *testing.B,
 	}
 }
 
-func BenchmarkInsertUUIDAsVarchar(b *testing.B) {
+func BenchmarkInsertClusterAsVarchar(b *testing.B) {
 	report := ""
-	performInsertBenchmark(b, CreateTableReportedBenchmarkVarcharClusterID, DropTableReportedBenchmarkVarcharClusterID, &report)
+	performInsertBenchmark(b,
+		CreateTableReportedBenchmarkVarcharClusterID,
+		DropTableReportedBenchmarkVarcharClusterID,
+		InsertIntoReportedV1Statement,
+		insertIntoReportedV1,
+		&report, DropTables)
 }
 
-func BenchmarkInsertUUIDAsBytea(b *testing.B) {
+func BenchmarkInsertClusterAsBytea(b *testing.B) {
+	report := ""
+	performInsertBenchmark(b,
+		CreateTableReportedBenchmarkByteArrayClusterID,
+		DropTableReportedBenchmarkByteArrayClusterID,
+		InsertIntoReportedV2Statement,
+		insertIntoReportedV2,
+		&report, DropTables)
 }
 
-func BenchmarkInsertUUIDAsUUID(b *testing.B) {
+func BenchmarkInsertClusterAsUUID(b *testing.B) {
+	report := ""
+	performInsertBenchmark(b,
+		CreateTableReportedBenchmarkUUIDClusterID,
+		DropTableReportedBenchmarkUUIDClusterID,
+		InsertIntoReportedV3Statement,
+		insertIntoReportedV3,
+		&report, DropTables)
 }
 
-func BenchmarkDeleteUUIDAsVarchar(b *testing.B) {
+func BenchmarkDeleteClusterAsVarchar(b *testing.B) {
 }
 
-func BenchmarkDeleteUUIDAsBytea(b *testing.B) {
+func BenchmarkDeleteClusterAsBytea(b *testing.B) {
 }
 
-func BenchmarkDeleteUUIDAsUUID(b *testing.B) {
+func BenchmarkDeleteClusterAsUUID(b *testing.B) {
 }
 
-func BenchmarkSelectUUIDAsVarchar(b *testing.B) {
+func BenchmarkSelectClusterAsVarchar(b *testing.B) {
 }
 
-func BenchmarkSelectUUIDAsBytea(b *testing.B) {
+func BenchmarkSelectClusterAsBytea(b *testing.B) {
 }
 
-func BenchmarkSelectUUIDAsUUID(b *testing.B) {
+func BenchmarkSelectClusterAsUUID(b *testing.B) {
 }

--- a/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
+++ b/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
@@ -42,7 +42,7 @@ const (
 		    updated_at        timestamp not null,
 		    notified_at       timestamp not null,
 		    error_log         varchar,
-		                
+
 		    PRIMARY KEY (org_id, cluster, notified_at)
 		);
 		`
@@ -65,6 +65,44 @@ const (
             VALUES
             ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
+	CreateTableReportedBenchmarkByteArrayClusterID = `
+		CREATE TABLE IF NOT EXISTS reported_benchmark_2 (
+		    org_id            integer not null,
+		    account_number    integer not null,
+		    cluster           bytea not null,
+		    notification_type integer not null,
+		    state             integer not null,
+		    report            varchar not null,
+		    updated_at        timestamp not null,
+		    notified_at       timestamp not null,
+		    error_log         varchar,
+
+		    PRIMARY KEY (org_id, cluster, notified_at)
+		);
+		`
+
+	DropTableReportedBenchmarkByteArrayClusterID = `
+	        DROP TABLE IF EXISTS reported_benchmark_2;
+        `
+	CreateTableReportedBenchmarkUUIDClusterID = `
+		CREATE TABLE IF NOT EXISTS reported_benchmark_3 (
+		    org_id            integer not null,
+		    account_number    integer not null,
+		    cluster           uuid not null,
+		    notification_type integer not null,
+		    state             integer not null,
+		    report            varchar not null,
+		    updated_at        timestamp not null,
+		    notified_at       timestamp not null,
+		    error_log         varchar,
+
+		    PRIMARY KEY (org_id, cluster, notified_at)
+		);
+		`
+
+	DropTableReportedBenchmarkUUIDClusterID = `
+	        DROP TABLE IF EXISTS reported_benchmark_3;
+        `
 )
 
 // ConnectionInfo structure stores all values needed to connect to PSQL

--- a/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
+++ b/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
@@ -84,6 +84,13 @@ const (
 	DropTableReportedBenchmarkByteArrayClusterID = `
 	        DROP TABLE IF EXISTS reported_benchmark_2;
         `
+	// Insert one record into reported table
+	InsertIntoReportedV2Statement = `
+            INSERT INTO reported_benchmark_2
+            (org_id, account_number, cluster, notification_type, state, report, updated_at, notified_at, error_log)
+            VALUES
+            ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`
 	CreateTableReportedBenchmarkUUIDClusterID = `
 		CREATE TABLE IF NOT EXISTS reported_benchmark_3 (
 		    org_id            integer not null,
@@ -103,6 +110,13 @@ const (
 	DropTableReportedBenchmarkUUIDClusterID = `
 	        DROP TABLE IF EXISTS reported_benchmark_3;
         `
+	// Insert one record into reported table
+	InsertIntoReportedV3Statement = `
+            INSERT INTO reported_benchmark_3
+            (org_id, account_number, cluster, notification_type, state, report, updated_at, notified_at, error_log)
+            VALUES
+            ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`
 )
 
 // Tests configuration


### PR DESCRIPTION
# Description

`INSERT` benchmarks for various `cluster name` representation

Fixes (partially) INSERT benchmarks for various `cluster name` representation

## Type of change

- Benchmarks (no changes in the code)

## Testing steps

Can be run from command line (given DB connection string is correct).

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
