### PR TITLE
Cluster name column benchmarks 2nd version - DELETE FROM benchmarks

### DIFF
--- a/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
+++ b/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
@@ -58,6 +58,11 @@ const (
 		 USING btree (notified_at DESC);
         `
 
+	// Select cluster names from reported table
+	SelectClusterNamesFromReportedV1Statement = `
+            SELECT cluster FROM reported_benchmark_1
+	`
+
 	// Insert one record into reported table
 	InsertIntoReportedV1Statement = `
             INSERT INTO reported_benchmark_1
@@ -90,6 +95,11 @@ const (
 	DropTableReportedBenchmarkByteArrayClusterID = `
 	        DROP TABLE IF EXISTS reported_benchmark_2;
         `
+	// Select cluster names from reported table
+	SelectClusterNamesFromReportedV2Statement = `
+            SELECT cluster FROM reported_benchmark_2
+	`
+
 	// Insert one record into reported table
 	InsertIntoReportedV2Statement = `
             INSERT INTO reported_benchmark_2
@@ -122,6 +132,11 @@ const (
 	DropTableReportedBenchmarkUUIDClusterID = `
 	        DROP TABLE IF EXISTS reported_benchmark_3;
         `
+	// Select cluster names from reported table
+	SelectClusterNamesFromReportedV3Statement = `
+            SELECT cluster FROM reported_benchmark_3
+	`
+
 	// Insert one record into reported table
 	InsertIntoReportedV3Statement = `
             INSERT INTO reported_benchmark_3

--- a/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
+++ b/docs/demos/uuid_column_in_db/demo/uuid_column_test.go
@@ -65,6 +65,12 @@ const (
             VALUES
             ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
+
+	// Delete one record from reported table
+	DeleteFromReportedV1Statement = `
+            DELETE FROM reported_benchmark_1 WHERE cluster=$1
+	`
+
 	CreateTableReportedBenchmarkByteArrayClusterID = `
 		CREATE TABLE IF NOT EXISTS reported_benchmark_2 (
 		    org_id            integer not null,
@@ -91,6 +97,12 @@ const (
             VALUES
             ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
+
+	// Delete one record from reported table
+	DeleteFromReportedV2Statement = `
+            DELETE FROM reported_benchmark_2 WHERE cluster=$1
+	`
+
 	CreateTableReportedBenchmarkUUIDClusterID = `
 		CREATE TABLE IF NOT EXISTS reported_benchmark_3 (
 		    org_id            integer not null,
@@ -116,6 +128,11 @@ const (
             (org_id, account_number, cluster, notification_type, state, report, updated_at, notified_at, error_log)
             VALUES
             ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`
+
+	// Delete one record from reported table
+	DeleteFromReportedV3Statement = `
+            DELETE FROM reported_benchmark_3 WHERE cluster=$1
 	`
 )
 


### PR DESCRIPTION
# Description

Cluster name column benchmarks 2nd version - `DELETE FROM` benchmarks

Fixes (partially) https://issues.redhat.com/browse/CCXDEV-9915

## Type of change

- Benchmarks (no changes in the code)

## Testing steps

Can be run from command line if needed.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
