### PR TITLE
Notify moderate recommendations too with 1 week cooldown

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,13 +15,13 @@ timeout = "60s"
 likelihood_threshold = 0
 impact_threshold = 0
 severity_threshold = 0
-total_risk_threshold = 3
+total_risk_threshold = 2
 event_filter = "totalRisk >= totalRiskThreshold"
 tag_filter_enabled = false
 tags = []
 # valid units are SQL epoch time units: months days hours minutes seconds"
 # set to empty string "" or 0 to disable
-cooldown = "24 hours"
+cooldown = "1 week"
 
 [service_log]
 client_id = "a-service-id"
@@ -37,11 +37,11 @@ severity_threshold = 0
 total_risk_threshold = 0
 event_filter = "totalRisk >= totalRiskThreshold"
 rule_details_uri = "https://console.redhat.com/openshift/insights/advisor/recommendations/{module}|{error_key}"
-tag_filter_enabled = false
+tag_filter_enabled = true
 tags = ["osd_customer"]
 # valid units are SQL epoch time units: months days hours minutes seconds"
 # set to empty string "" or "0" to disable
-cooldown = "0"
+cooldown = "1 week"
 
 [storage]
 db_driver = "postgres"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -272,9 +272,9 @@ parameters:
 - name: PLATFORM_UI_HOSTNAME
 - name: CONTENT_SERVICE_PORT
 - name: NOTIFICATION_RESEND_COOLDOWN_NOTIFICATION_BACKEND
-  value: 24h
+  value: '1 week'
 - name: NOTIFICATION_RESEND_COOLDOWN_SERVICE_LOG
-  value: '0'
+  value: '1 week'
 - name: METRICS_NAMESPACE
   value: ccx_notification_service
 - name: METRICS_PUSH_RETRIES

--- a/docs/data_flow.md
+++ b/docs/data_flow.md
@@ -54,7 +54,9 @@ See steps 9 to 12 of the [data flow section](#data-flow)
 The cooldown mechanism can be configured by specifying the `cooldown` field under each integrated service's configuration.
 Currently, the `cooldown` field can be configured under the `kafka_broker` and `service_log` configurations in the [config.toml](../config.toml) file or by setting the `CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__COOLDOWN` and `CCX_NOTIFICATION_SERVICE__SERVICE_LOG__COOLDOWN` environment variables respectively.
 
-The value set is used directly within an SQL query, so the expected format is an integer followed by a valid SQL epoch time units (year[s] month[s] day[s] hour[s] minute[s] second[s])
+The value set is used directly within an SQL query, so the expected format is an integer followed by a valid SQL epoch time units (year[s] month[s] week[s] day[s] hour[s] minute[s] second[s])
+
+As of today, since we only keep 8 days of data in our database, the maximum cooldown that can be applied is 8 days.
 
 In case new services are supported in the future, the corresponding code would need to be added for it to support the cooldown mechanism.
 


### PR DESCRIPTION
# Description

- [notification-backend] include moderate issues (total risk = 2)
- [config] set cooldown time between notifications to 1 week instead of 24 hours
- [config] update `config.toml` to have same config as `clowdapp.yaml` file
- [documentation] mention maximum cooldown value in docs

With this change, we go from:
- sending ~11k events to ~45k with data similar to what we have in our production database. We can then expect the `reported` table to grow "faster", as each run of the cronjob will add more items than before this change.
    - customers that were already receiving notifications might receive more, or bigger ones
    - customers that were no receiving notifications might start receiving them if their clusters have unsolved moderate recommendations.
- the biggest execution time impact will be seen on the first run after the change is merged. After that, the 1 week cooldown will allow the cronjob to work with a more acceptable execution time impact on most executions (note that comparing to previously sent reports will happen 3 to 4 times more often though, so there will still be a performance impact)
Fixes CCXDEV-9817

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Configuration update

## Testing steps

Running the service with multiple sets of data

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
