### PR TITLE
Use `created_by` field in communication with ServiceLog

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -295,6 +295,7 @@ type ServiceLogEntry struct {
 	Description string      `json:"description"`
 	ServiceName string      `json:"service_name"`
 	Summary     string      `json:"summary"`
+	CreatedBy   string      `json:"created_by"`
 }
 
 // MakeSetOfTags helper function makes set of tags from given list of tags


### PR DESCRIPTION
# Description

Use `created_by` field in communication with ServiceLog

Fixes https://issues.redhat.com/browse/CCXDEV-9665

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
