### PR TITLE
Method to check if `read_errors` contains an error for given cluster and given timestamp

### DIFF
--- a/differ/storage.go
+++ b/differ/storage.go
@@ -34,6 +34,7 @@ package differ
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -89,6 +90,11 @@ type Storage interface {
 		notifiedAt types.Timestamp,
 		errorLog string,
 		eventType types.EventTarget) error
+	ReadErrorExists(
+		orgID types.OrgID,
+		clusterName types.ClusterName,
+		lastCheckedTime time.Time,
+	) (bool, error)
 	WriteReadError(
 		orgID types.OrgID,
 		clusterName types.ClusterName,
@@ -182,6 +188,10 @@ const (
 		  FROM reported
 		 WHERE updated_at < NOW() - $1::INTERVAL
 		 ORDER BY updated_at
+`
+
+	QueryRecordExistsInReadErrors = `
+		SELECT exists(SELECT 1 FROM read_errors WHERE org_id=$1 and cluster=$1 and updated_at=$3);
 `
 
 	InsertReadErrorsStatement = `
@@ -531,7 +541,44 @@ func (storage DBStorage) WriteNotificationRecordForCluster(
 		notifiedAt, errorLog, eventTarget)
 }
 
-// WriteReadError writes information about read error into table read_error.
+// ReadErrorExists method checks if read_errors table contains given
+// combination org_id+cluster_name+updated_at
+func (storage DBStorage) ReadErrorExists(
+	orgID types.OrgID,
+	clusterName types.ClusterName,
+	lastCheckedTime time.Time,
+) (bool, error) {
+	// perform query
+	rows, err := storage.connection.Query(QueryRecordExistsInReadErrors, orgID, clusterName, lastCheckedTime)
+
+	// check for any error during query
+	if err != nil {
+		return false, err
+	}
+
+	// be sure to close result set properly
+	defer func() {
+		err := rows.Close()
+		if err != nil {
+			log.Error().Err(err).Msg(unableToCloseDBRowsHandle)
+		}
+	}()
+
+	// only one record should returned
+	if rows.Next() {
+		var exists bool
+		err := rows.Scan(&exists)
+		if err != nil {
+			return false, err
+		}
+		return exists, nil
+	}
+
+	return false, errors.New("Unable to read from table read_errors")
+}
+
+// WriteReadError method writes information about read error into table
+// read_errors.
 func (storage DBStorage) WriteReadError(
 	orgID types.OrgID,
 	clusterName types.ClusterName,

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -191,7 +191,7 @@ const (
 `
 
 	QueryRecordExistsInReadErrors = `
-		SELECT exists(SELECT 1 FROM read_errors WHERE org_id=$1 and cluster=$1 and updated_at=$3);
+		SELECT exists(SELECT 1 FROM read_errors WHERE org_id=$1 and cluster=$2 and updated_at=$3);
 `
 
 	InsertReadErrorsStatement = `

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -216,6 +216,40 @@ func TestReadErrorExistPositiveResult(t *testing.T) {
 	checkAllExpectations(t, mock)
 }
 
+// TestReadErrorExistNegativeResult checks if Storage.ReadErrorExists returns
+// expected results (positive test).
+func TestReadErrorExistNegativeResult(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"exists"})
+	rows.AddRow(false)
+
+	// expected query performed by tested function
+	expectedQuery := "SELECT exists\\(SELECT 1 FROM read_errors WHERE org_id=\\$1 and cluster=\\$2 and updated_at=\\$3\\);"
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	exists, err := storage.ReadErrorExists(1, "123", time.Now())
+	if err != nil {
+		t.Error("error was not expected while querying read_errors table", err)
+	}
+
+	assert.False(t, exists, "False return value is expected")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
 // TestWriteReadError function checks the method
 // Storage.WriteReadError.
 func TestWriteReadError(t *testing.T) {

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -353,6 +353,14 @@ func (_m *Storage) WriteReadError(
 	return nil
 }
 
+func (_m *Storage) ReadErrorExists(
+	orgID types.OrgID,
+	clusterName types.ClusterName,
+	lastCheckedTime time.Time,
+) (bool, error) {
+	return false, nil
+}
+
 type mockConstructorTestingTNewStorage interface {
 	mock.TestingT
 	Cleanup(func())


### PR DESCRIPTION
# Description

- Method to check if `read_errors` contains an error for given cluster and given timestamp
- Unit tests covering the whole method (with one exception - closing error, that is IMHO not possible to test using SQL mock)

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
