### PR TITLE
Reformat `differ_test.go` to make linters happy

### DIFF
--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021, 2022 Red Hat, Inc.
+Copyright © 2021, 2022, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1554,47 +1554,47 @@ func TestConvertLogLevel(t *testing.T) {
 	}
 
 	testData := []TestData{
-		TestData{
+		{
 			Input:  "",
 			Output: zerolog.DebugLevel,
 		},
-		TestData{
+		{
 			Input:  "debug",
 			Output: zerolog.DebugLevel,
 		},
-		TestData{
+		{
 			Input:  " debug",
 			Output: zerolog.DebugLevel,
 		},
-		TestData{
+		{
 			Input:  " debug ",
 			Output: zerolog.DebugLevel,
 		},
-		TestData{
+		{
 			Input:  "info",
 			Output: zerolog.InfoLevel,
 		},
-		TestData{
+		{
 			Input:  "warn",
 			Output: zerolog.WarnLevel,
 		},
-		TestData{
+		{
 			Input:  "warning",
 			Output: zerolog.WarnLevel,
 		},
-		TestData{
+		{
 			Input:  "error",
 			Output: zerolog.ErrorLevel,
 		},
-		TestData{
+		{
 			Input:  "fatal",
 			Output: zerolog.FatalLevel,
 		},
-		TestData{
+		{
 			Input:  " fatal",
 			Output: zerolog.FatalLevel,
 		},
-		TestData{
+		{
 			Input:  "fatal ",
 			Output: zerolog.FatalLevel,
 		},


### PR DESCRIPTION
# Description

Reformat `differ_test.go` to make linters happy

Fixes https://issues.redhat.com/browse/CCXDEV-10063

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
