### PR TITLE
Added missing unit test case for Storage.ReadLastNotifiedRecordForClusterList: empty input sequence

### DIFF
--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -77,6 +77,33 @@ func checkAllExpectations(t *testing.T, mock sqlmock.Sqlmock) {
 	}
 }
 
+// TestReadLastNotifiedRecordForClusterListEmptyClusterEntries test checks how
+// empty sequence of cluster entries is handled by metohd
+// ReadLastNotifiedRecordForClusterList
+func TestReadLastNotifiedRecordForClusterListEmptyClusterEntries(t *testing.T) {
+	// empty sequence of cluster entries
+	clusterEntries := []types.ClusterEntry{}
+
+	// second parameter passed to tested method
+	timeOffset := "1 day"
+
+	// prepare database mock
+	db, _ := newMock(t)
+	defer func() { _ = db.Close() }()
+
+	// establish connection to mocked database
+	sut := differ.NewFromConnection(db, types.DBDriverPostgres)
+
+	// call tested method
+	records, err := sut.ReadLastNotifiedRecordForClusterList(
+		clusterEntries, timeOffset, types.NotificationBackendTarget)
+
+	// test returned values
+	assert.NoError(t, err, "error running ReadLastNotifiedRecordForClusterList")
+	assert.Len(t, records, 0, "empty output is expected")
+
+}
+
 func TestReadLastNotifiedRecordForClusterList(t *testing.T) {
 	var (
 		now            = time.Now()


### PR DESCRIPTION
# Description

Added missing unit test case for `Storage.ReadLastNotifiedRecordForClusterList` method: empty input sequence

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
