### PR TITLE
Unit tests for method `Storage.ReadReportForClusterAtTime`

### DIFF
--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -1145,3 +1145,54 @@ func TestReadReportForClusterAtTime(t *testing.T) {
 	// check if all expectations were met
 	checkAllExpectations(t, mock)
 }
+
+// TestReadReportForClusterAtTimeOnScanError checks if method
+// Storage.ReadReportForClusterAtTime returns expected results on
+// scan error.
+func TestReadReportForClusterAtTimeOnScanError(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{
+		"report"})
+
+	// report to be returned
+	expectedReport := 42 // not a string
+
+	// only one result must be returned
+	rows.AddRow(expectedReport)
+
+	// expected query performed by tested function
+	expectedQuery := `
+		SELECT report
+		  FROM new_reports
+		 WHERE org_id = \$1 AND cluster = \$2 AND updated_at = \$3;
+                `
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// parameters for tested method
+	orgID := types.OrgID(42)
+	clusterName := types.ClusterName("foo")
+	updatedAt := types.Timestamp(time.Now())
+
+	// call the tested method
+	returnedReport, err := storage.ReadReportForClusterAtTime(orgID, clusterName, updatedAt)
+
+	// tested method SHOULD return an error
+	assert.Error(t, err, "error SHOULD be thrown while querying new_reports table for given cluster and timestamp")
+
+	// check returned report
+	assert.Empty(t, returnedReport)
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}


### PR DESCRIPTION
# Description

Unit tests for method `Storage.ReadReportForClusterAtTime`

Fixes https://issues.redhat.com/browse/CCXDEV-10035

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
