### PR TITLE
Remove json escaping from notification message

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -874,13 +874,9 @@ func generateInstantNotificationMessage(
 	clusterURI *string, accountID, orgID, clusterID string) (
 	notification types.NotificationMessage) {
 	events := []types.Event{}
-	context := toJSONEscapedString(types.NotificationContext{
+	context := types.NotificationContext{
 		notificationContextDisplayName: clusterID,
 		notificationContextHostURL:     strings.Replace(*clusterURI, "{cluster_id}", clusterID, 1),
-	})
-	if context == "" {
-		log.Error().Msg(contextToEscapedStringError)
-		return
 	}
 
 	notification = types.NotificationMessage{
@@ -898,24 +894,16 @@ func generateInstantNotificationMessage(
 
 // generateWeeklyNotificationMessage function generates a notification message with one event based on the provided digest
 func generateWeeklyNotificationMessage(advisorURI *string, accountID string, digest types.Digest) (notification types.NotificationMessage) {
-	context := toJSONEscapedString(types.NotificationContext{
+	context := types.NotificationContext{
 		notificationContextAdvisorURL: *advisorURI,
-	})
-	if context == "" {
-		log.Error().Msg(contextToEscapedStringError)
-		return
 	}
 
-	payload := toJSONEscapedString(types.EventPayload{
+	payload := types.EventPayload{
 		notificationPayloadTotalClusters:        fmt.Sprint(digest.ClustersAffected),
 		notificationPayloadTotalRecommendations: fmt.Sprint(digest.Recommendations),
 		notificationPayloadTotalIncidents:       fmt.Sprint(digest.Incidents),
 		notificationPayloadTotalCritical:        fmt.Sprint(digest.CriticalNotifications),
 		notificationPayloadTotalImportant:       fmt.Sprint(digest.ImportantNotifications),
-	})
-	if payload == "" {
-		log.Error().Msg("Notification message will not be generated as payload couldn't be converted to escaped string.")
-		return
 	}
 
 	events := []types.Event{
@@ -954,16 +942,13 @@ func generateNotificationPayloadURL(
 // appendEventToNotificationMessage function adds a new event to the given notification message after constructing the payload string
 func appendEventToNotificationMessage(notificationPayloadURL string, notification *types.NotificationMessage, ruleDescription string, totalRisk int, publishDate string) {
 
-	payload := toJSONEscapedString(types.EventPayload{
+	payload := types.EventPayload{
 		notificationPayloadRuleDescription: ruleDescription,
 		notificationPayloadRuleURL:         notificationPayloadURL,
 		notificationPayloadTotalRisk:       fmt.Sprint(totalRisk),
 		notificationPayloadPublishDate:     publishDate,
-	})
-	if payload == "" {
-		log.Error().Msg(contextToEscapedStringError)
-		return
 	}
+
 	event := types.Event{
 		// The insights Notifications backend expects this field to be
 		// an empty object in the received JSON
@@ -973,16 +958,6 @@ func appendEventToNotificationMessage(notificationPayloadURL string, notificatio
 		Payload: payload,
 	}
 	notification.Events = append(notification.Events, event)
-}
-
-// toJSONEscapedString function turns any valid JSON to a string-escaped string
-func toJSONEscapedString(i interface{}) string {
-	b, err := json.Marshal(i)
-	if err != nil {
-		log.Err(err).Msg(invalidJSONContent)
-	}
-	s := string(b)
-	return s
 }
 
 // checkArgs function handles command line options passed to the process

--- a/producer/kafka/kafka_producer_test.go
+++ b/producer/kafka/kafka_producer_test.go
@@ -140,7 +140,7 @@ func TestProducerSendNotificationMessageNoEvents(t *testing.T) {
 		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   "000000",
 		Events:      nil,
-		Context:     "{}",
+		Context:     nil,
 	}
 
 	msgBytes, err := json.Marshal(msg)
@@ -163,7 +163,7 @@ func TestProducerSendNotificationMessageSingleEvent(t *testing.T) {
 	events := []types.Event{
 		{
 			Metadata: types.EventMetadata{},
-			Payload:  "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\"}",
+			Payload:  types.EventPayload{"rule_id": "a unique ID", "what happened": "something baaad happened", "error_code": "3"},
 		},
 	}
 
@@ -174,7 +174,7 @@ func TestProducerSendNotificationMessageSingleEvent(t *testing.T) {
 		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   "000001",
 		Events:      events,
-		Context:     "{}",
+		Context:     nil,
 	}
 
 	msgBytes, err := json.Marshal(msg)
@@ -197,11 +197,11 @@ func TestProducerSendNotificationMessageMultipleEvents(t *testing.T) {
 	events := []types.Event{
 		{
 			Metadata: types.EventMetadata{},
-			Payload:  "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\"}",
+			Payload:  types.EventPayload{"rule_id": "a unique ID", "what happened": "something baaad happened", "error_code": "3"},
 		},
 		{
 			Metadata: types.EventMetadata{},
-			Payload:  "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\", \"more_random_data\": \"why not...\"}",
+			Payload:  types.EventPayload{"rule_id": "a unique ID", "what happened": "something baaad happened", "error_code": "3", "more_random_data": "why not..."},
 		},
 	}
 
@@ -212,7 +212,7 @@ func TestProducerSendNotificationMessageMultipleEvents(t *testing.T) {
 		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   "000001",
 		Events:      events,
-		Context:     "{}",
+		Context:     nil,
 	}
 
 	msgBytes, err := json.Marshal(msg)
@@ -236,11 +236,11 @@ func TestProducerSend(t *testing.T) {
 	events := []types.Event{
 		{
 			Metadata: nil,
-			Payload: "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\"}",
+			Payload: types.EventPayload{"rule_id": "a unique ID", "what happened": "something baaad happened", "error_code":"3"},
 		},
 		{
 			Metadata: nil,
-			Payload: "{\"rule_id\": \"a unique ID\", \"what happened\": \"something baaad happened\", \"error_code\":\"3\"}",
+			Payload: types.EventPayload{"rule_id": "a unique ID", "what happened": "something baaad happened", "error_code":"3"},
 		},
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -206,7 +206,7 @@ type EventPayload map[string]string
 // Event is a structure containing the payload and its metadata.
 type Event struct {
 	Metadata EventMetadata `json:"metadata"`
-	Payload  string        `json:"payload"`
+	Payload  EventPayload  `json:"payload"`
 }
 
 // Digest is a structure containing the counters for weekly digest
@@ -226,14 +226,14 @@ type NotificationContext map[string]interface{}
 // NotificationMessage represents content of messages
 // sent to the notification platform topic in Kafka.
 type NotificationMessage struct {
-	Bundle      string  `json:"bundle"`
-	Application string  `json:"application"`
-	EventType   string  `json:"event_type"`
-	Timestamp   string  `json:"timestamp"`
-	AccountID   string  `json:"account_id"`
-	OrgID       string  `json:"org_id"`
-	Events      []Event `json:"events"`
-	Context     string  `json:"context"`
+	Bundle      string              `json:"bundle"`
+	Application string              `json:"application"`
+	EventType   string              `json:"event_type"`
+	Timestamp   string              `json:"timestamp"`
+	AccountID   string              `json:"account_id"`
+	OrgID       string              `json:"org_id"`
+	Events      []Event             `json:"events"`
+	Context     NotificationContext `json:"context"`
 }
 
 // NotificationRecord structure represents one record stored in `reported` table.


### PR DESCRIPTION
# Description

The notification backend version we are depending on does not need the JSON payload to be escaped.

Fixes [CCXDEV-9819](https://issues.redhat.com/browse/CCXDEV-9819)

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps

Updated corresponding UTs, run BDDs locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
