### PR TITLE
[CCXDEV-10291] Add some unit tests for checking connection errors with template renderer

### DIFF
--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -130,6 +130,43 @@ func TestRenderReportsForCluster(t *testing.T) {
 	})
 }
 
+func TestRenderReportsForClusterInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`not a JSON`))
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+	}))
+	defer server.Close()
+
+	config := conf.DependenciesConfiguration{
+		TemplateRendererServer:   server.URL,
+		TemplateRendererEndpoint: "",
+		TemplateRendererURL:      server.URL,
+	}
+
+	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", []types.ReportItem{}, []utypes.RuleContent{})
+	v, _ := json.Marshal(rendereredReports)
+	log.Info().Msg(string(v))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid character")
+}
+
+func TestRenderReportsForClusterInvalidURL(t *testing.T) {
+	config := conf.DependenciesConfiguration{
+		TemplateRendererServer:   "not an url",
+		TemplateRendererEndpoint: "",
+		TemplateRendererURL:      "not an url",
+	}
+
+	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", []types.ReportItem{}, []utypes.RuleContent{})
+	v, _ := json.Marshal(rendereredReports)
+	log.Info().Msg(string(v))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid character")
+}
+
 // TestGetAllContentFromMapEmptyCase tests the function getAllContentFromMap
 // for empty input
 func TestGetAllContentFromMapEmptyCase(t *testing.T) {

--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -164,7 +164,7 @@ func TestRenderReportsForClusterInvalidURL(t *testing.T) {
 	v, _ := json.Marshal(rendereredReports)
 	log.Info().Msg(string(v))
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid character")
+	assert.Contains(t, err.Error(), "unsupported protocol")
 }
 
 // TestGetAllContentFromMapEmptyCase tests the function getAllContentFromMap


### PR DESCRIPTION
# Description

Add `TestRenderReportsForClusterInvalidURL` and `TestRenderReportsForClusterInvalidJSON` covering some missing gaps  in the connection with template renderer.

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Unit tests.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
