### PR TITLE
[CCXDEV-10291] Add metrics for service log

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -473,6 +473,7 @@ func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.
 				Int(totalRiskAttribute, totalRisk).
 				Msg(reportWithHighImpactMessage)
 			if !shouldNotify(cluster, r, types.ServiceLogTarget) {
+				NotificationNotSentSameState.Inc()
 				continue
 			}
 			// if new report differs from the older one -> send notification
@@ -504,6 +505,7 @@ func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.
 				Msg("Producing service log message")
 			_, _, err = serviceLogNotifier.ProduceMessage(msgBytes)
 			if err != nil {
+				NotificationNotSentErrorState.Inc()
 				log.Err(err).
 					Str(clusterAttribute, string(cluster.ClusterName)).
 					Str(ruleAttribute, string(ruleName)).
@@ -511,6 +513,7 @@ func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.
 					Msg(serviceLogSendErrorMessage)
 				return totalMessages, err
 			}
+			NotificationSent.Inc()
 			totalMessages++
 		}
 	}


### PR DESCRIPTION
# Description

The `notifications_sent` metric is used in the [updateNotificationRecordSentState](https://github.com/RedHatInsights/ccx-notification-service/blob/e7803c5e4cb1d1d030f8962918a3976c7d369b2b/differ/differ.go#L604) which is just used in the [produceEntriesToKafka](https://github.com/RedHatInsights/ccx-notification-service/blob/e7803c5e4cb1d1d030f8962918a3976c7d369b2b/differ/differ.go#L521) function. For the service log, it is updated in the [updateNotificationRecordState](https://github.com/RedHatInsights/ccx-notification-service/blob/e7803c5e4cb1d1d030f8962918a3976c7d369b2b/differ/differ.go#L684), which is executed just at the end of the processing. This creates a a scatter plot rather than a continuous plot, which is impossible to calculate the rate from so we are seeing a metric = 0 in Grafana.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing steps

Unit tests.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
