### PR TITLE
[CCXDEV-10291] Push metrics in loop

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -197,13 +197,14 @@ type NotificationsConfiguration struct {
 
 // MetricsConfiguration holds metrics related configuration
 type MetricsConfiguration struct {
-	Job              string        `mapstructure:"job_name" toml:"job_name"`
-	Namespace        string        `mapstructure:"namespace" toml:"namespace"`
-	Subsystem        string        `mapstructure:"subsystem" toml:"subsystem"`
-	GatewayURL       string        `mapstructure:"gateway_url" toml:"gateway_url"`
-	GatewayAuthToken string        `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
-	Retries          int           `mapstructure:"retries" toml:"retries"`
-	RetryAfter       time.Duration `mapstructure:"retry_after" toml:"retry_after"`
+	Job                    string        `mapstructure:"job_name" toml:"job_name"`
+	Namespace              string        `mapstructure:"namespace" toml:"namespace"`
+	Subsystem              string        `mapstructure:"subsystem" toml:"subsystem"`
+	GatewayURL             string        `mapstructure:"gateway_url" toml:"gateway_url"`
+	GatewayAuthToken       string        `mapstructure:"gateway_auth_token" toml:"gateway_auth_token"`
+	Retries                int           `mapstructure:"retries" toml:"retries"`
+	RetryAfter             time.Duration `mapstructure:"retry_after" toml:"retry_after"`
+	GatewayTimeBetweenPush time.Duration `mapstructure:"gateway_time_between_push" toml:"gateway_time_between_push"`
 }
 
 // ProcessingConfiguration represents configuration for processing subsystem

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -334,6 +334,7 @@ func TestLoadMetricsConfiguration(t *testing.T) {
 	assert.Equal(t, "ccx_notification_service_namespace", configuration.Namespace)
 	assert.Equal(t, ":9091", configuration.GatewayURL)
 	assert.Equal(t, "", configuration.GatewayAuthToken)
+	assert.Equal(t, 60*time.Second, configuration.GatewayTimeBetweenPush)
 }
 
 // TestLoadNotificationsConfiguration tests loading the notifications configuration sub-tree

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -63,6 +63,7 @@ namespace = "ccx_notification_service"
 subsystem = "devel"
 gateway_url = "localhost:9091"
 gateway_auth_token = ""
+gateway_time_between_push = "3s"
 
 [cleaner]
 # valid units are SQL epoch time units: months days hours minutes seconds"

--- a/config.toml
+++ b/config.toml
@@ -76,6 +76,7 @@ gateway_auth_token = ""
 retries = 3
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 retry_after = "60s"
+gateway_time_between_push = "30s"
 
 [cleaner]
 # valid units are SQL epoch time units: months days hours minutes seconds"

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -25,6 +25,7 @@ package differ
 // https://redhatinsights.github.io/ccx-notification-service/packages/differ/differ.html
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -1133,6 +1134,7 @@ func startDiffer(config *conf.ConfigStruct, storage *DBStorage, verbose bool) {
 	setupFiltersAndThresholds(config)
 	setupNotificationStates(storage)
 	setupNotificationTypes(storage)
+	PushMetricsInLoop(context.Background(), conf.GetMetricsConfiguration(config))
 
 	clusters, err := storage.ReadClusterList()
 	if err != nil {

--- a/differ/metrics_test.go
+++ b/differ/metrics_test.go
@@ -60,10 +60,10 @@ func TestAddMetricsWithNamespaceAndSubsystem(t *testing.T) {
 
 func TestPushMetricsGatewayNotFailingWithRetriesThenOk(t *testing.T) {
 	var (
-		pushes          int
-		expectedPushes  = 6
-		timeBetweenPush = 200 * time.Millisecond // 0.5s
-		totalTime       = 2 * time.Second        // give enough time
+		pushes             int
+		expectedPushes     = 6
+		timeBetweenRetries = 200 * time.Millisecond // 0.5s
+		totalTime          = 2 * time.Second        // give enough time
 	)
 
 	testServer := httptest.NewServer(
@@ -85,7 +85,7 @@ func TestPushMetricsGatewayNotFailingWithRetriesThenOk(t *testing.T) {
 		Job:        "ccx_notification_service",
 		Namespace:  "ccx_notification_service",
 		GatewayURL: testServer.URL,
-		RetryAfter: timeBetweenPush,
+		RetryAfter: timeBetweenRetries,
 		Retries:    10,
 	}
 
@@ -102,10 +102,10 @@ func TestPushMetricsGatewayNotFailingWithRetriesThenOk(t *testing.T) {
 
 func TestPushMetricsGatewayNotFailingWithRetries(t *testing.T) {
 	var (
-		pushes          int
-		expectedPushes  = 1
-		timeBetweenPush = 100 * time.Millisecond // 0.1s
-		totalTime       = 500 * time.Millisecond // give enough time
+		pushes             int
+		expectedPushes     = 1
+		timeBetweenRetries = 100 * time.Millisecond // 0.1s
+		totalTime          = 500 * time.Millisecond // give enough time
 	)
 
 	testServer := httptest.NewServer(
@@ -123,7 +123,7 @@ func TestPushMetricsGatewayNotFailingWithRetries(t *testing.T) {
 		Job:        "ccx_notification_service",
 		Namespace:  "ccx_notification_service",
 		GatewayURL: testServer.URL,
-		RetryAfter: timeBetweenPush,
+		RetryAfter: timeBetweenRetries,
 		Retries:    10,
 	}
 
@@ -141,8 +141,8 @@ func TestPushMetricsGatewayNotFailingWithRetries(t *testing.T) {
 func TestPushMetricsGatewayFailing(t *testing.T) {
 	if os.Getenv("GATEWAY_502_FAIL_ALL_RETRIES") == "1" {
 		var (
-			timeBetweenPush = 100 * time.Millisecond // 0.1s
-			totalTime       = 1 * time.Second        // give enough time
+			timeBetweenRetries = 100 * time.Millisecond // 0.1s
+			totalTime          = 1 * time.Second        // give enough time
 		)
 
 		testServer := httptest.NewServer(
@@ -159,7 +159,7 @@ func TestPushMetricsGatewayFailing(t *testing.T) {
 			Job:        "ccx_notification_service",
 			Namespace:  "ccx_notification_service",
 			GatewayURL: testServer.URL,
-			RetryAfter: timeBetweenPush,
+			RetryAfter: timeBetweenRetries,
 			Retries:    10,
 		}
 

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -59,6 +59,7 @@ max_age = "90 days"
 namespace ="ccx_notification_service_namespace"
 gateway_url = ":9091"
 auth_token = ""
+gateway_time_between_push = "60s"
 
 [processing]
 filter_allowed_clusters = true


### PR DESCRIPTION
# Description

We have a bug in our Grafana dashboards where metrics are constant because they are pushed just at the end of the execution of this job. We need to push the metrics in a loop so that we can see its evolution.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Unit tests.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
