### PR TITLE
Remove details equality check from issue comparison

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -23,7 +23,6 @@ package differ
 // https://redhatinsights.github.io/ccx-notification-service/packages/differ/comparator.html
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 
@@ -145,10 +144,11 @@ func writeNotificationRecordFailed(err error) {
 
 // Function issuesEqual compares two issues from reports
 func issuesEqual(issue1, issue2 types.ReportItem) bool {
+	/* Removing the Details comparison as a fix for https://issues.redhat.com/browse/CCXDEV-10817*/
 	if issue1.Type == issue2.Type &&
 		issue1.Module == issue2.Module &&
-		issue1.ErrorKey == issue2.ErrorKey &&
-		bytes.Equal(issue1.Details, issue2.Details) {
+		issue1.ErrorKey == issue2.ErrorKey {/* &&
+		bytes.Equal(issue1.Details, issue2.Details) */
 		return true
 	}
 	return false

--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -36,6 +36,7 @@ import (
 const (
 	clusterName   = "cluster"
 	resolutionKey = "resolution"
+	resolutionReason = "reason"
 	resolutionMsg = "Should notify user"
 
 	notificationTypeInstant = "instant"
@@ -82,7 +83,7 @@ func getNotificationResolution(issue types.ReportItem, record *types.Notificatio
 	}
 
 	resolution = IssueNotInReport(oldReport, issue)
-	log.Info().Bool(resolutionKey, resolution).Msg(resolutionMsg)
+	log.Info().Bool(resolutionKey, resolution).Str(resolutionReason, "issue not found in previously notified report").Msg(resolutionMsg)
 	return
 }
 
@@ -91,7 +92,7 @@ func shouldNotify(cluster types.ClusterEntry, issue types.ReportItem, eventTarge
 	key := types.ClusterOrgKey{OrgID: cluster.OrgID, ClusterName: cluster.ClusterName}
 	reported, ok := previouslyReported[eventTarget][key]
 	if !ok {
-		log.Info().Bool(resolutionKey, true).Msg(resolutionMsg)
+		log.Info().Bool(resolutionKey, true).Str(resolutionReason, "report not in cooldown").Msg(resolutionMsg)
 		return true
 	}
 

--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -33,10 +33,10 @@ import (
 
 // Messages
 const (
-	clusterName   = "cluster"
-	resolutionKey = "resolution"
+	clusterName      = "cluster"
+	resolutionKey    = "resolution"
+	resolutionMsg    = "Should notify user"
 	resolutionReason = "reason"
-	resolutionMsg = "Should notify user"
 
 	notificationTypeInstant = "instant"
 	notificationTypeWeekly  = "weekly"
@@ -147,7 +147,7 @@ func issuesEqual(issue1, issue2 types.ReportItem) bool {
 	/* Removing the Details comparison as a fix for https://issues.redhat.com/browse/CCXDEV-10817*/
 	if issue1.Type == issue2.Type &&
 		issue1.Module == issue2.Module &&
-		issue1.ErrorKey == issue2.ErrorKey {/* &&
+		issue1.ErrorKey == issue2.ErrorKey { /* &&
 		bytes.Equal(issue1.Details, issue2.Details) */
 		return true
 	}

--- a/differ/comparator_test.go
+++ b/differ/comparator_test.go
@@ -160,7 +160,7 @@ func TestIssuesEqualDifferentDetails(t *testing.T) {
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue is different"),
 	}
-	assert.False(t, issuesEqual(issue1, issue2), "Compared issues should not be equal")
+	assert.True(t, issuesEqual(issue1, issue2), "Compared issues should be equal")
 }
 
 func TestIssuesEqualDifferentModule(t *testing.T) {
@@ -392,7 +392,7 @@ func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 	}
 }
 
-func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
+func TestShouldNotNotifySameRuleDifferentDetails(t *testing.T) {
 	storage := mocks.Storage{}
 	storage.On("ReadLastNotifiedRecordForClusterList",
 		mock.AnythingOfType("[]types.ClusterEntry"),
@@ -431,7 +431,7 @@ func TestShouldNotifySameRuleDifferentDetails(t *testing.T) {
 
 	previouslyReported[types.NotificationBackendTarget], _ = storage.ReadLastNotifiedRecordForClusterList(make([]types.ClusterEntry, 0), "24 hours", types.NotificationBackendTarget)
 	for _, issue := range newReport.Reports {
-		assert.True(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
+		assert.False(t, shouldNotify(testCluster, issue, types.NotificationBackendTarget))
 	}
 }
 

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -354,7 +354,7 @@ func findRuleByNameAndErrorKey(
 }
 
 // evaluateFilterExpression function tries to evaluate event filter expression
-// based on provided threshold values and actual reccomendation values
+// based on provided threshold values and actual recommendation values
 func evaluateFilterExpression(eventFilter string, thresholds EventThresholds, eventValue EventValue) (int, error) {
 
 	// values to be passed into expression evaluator

--- a/docs/packages/differ/comparator.html
+++ b/docs/packages/differ/comparator.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2022 Red Hat, Inc
+ Copyright 2023 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@
       <tr class="section">
 	<td class="doc"></td>
 	<td class="code"><pre><code><div class="comment">/*
-Copyright © 2021 Red Hat, Inc.
+Copyright © 2021, 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
 you may not use this file except in compliance with the License.
@@ -147,12 +147,12 @@ https://redhatinsights.github.io/ccx-notification-service/packages/differ/compar
 </td>
 	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
-	<div class="literal">&#34;bytes&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;encoding/json&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;os&#34;</div><div class="operator"></div>
 
-	<div class="literal">&#34;github.com/RedHatInsights/ccx-notification-service/types&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/rs/zerolog/log&#34;</div><div class="operator"></div>
+
+	<div class="literal">&#34;github.com/RedHatInsights/ccx-notification-service/types&#34;</div><div class="operator"></div>
 <div class="operator">)</div><div class="operator"></div>
 
 </code></pre></td>
@@ -164,6 +164,7 @@ https://redhatinsights.github.io/ccx-notification-service/packages/differ/compar
 	<td class="code"><pre><code><div class="keyword">const</div> <div class="operator">(</div>
 	<div class="ident">clusterName</div>   <div class="operator">=</div> <div class="literal">&#34;cluster&#34;</div><div class="operator"></div>
 	<div class="ident">resolutionKey</div> <div class="operator">=</div> <div class="literal">&#34;resolution&#34;</div><div class="operator"></div>
+	<div class="ident">resolutionReason</div> <div class="operator">=</div> <div class="literal">&#34;reason&#34;</div><div class="operator"></div>
 	<div class="ident">resolutionMsg</div> <div class="operator">=</div> <div class="literal">&#34;Should notify user&#34;</div><div class="operator"></div>
 
 	<div class="ident">notificationTypeInstant</div> <div class="operator">=</div> <div class="literal">&#34;instant&#34;</div><div class="operator"></div>
@@ -198,7 +199,7 @@ https://redhatinsights.github.io/ccx-notification-service/packages/differ/compar
 	<div class="keyword">return</div> <div class="operator">-</div><div class="literal">1</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
-<div class="keyword">func</div> <div class="ident">getNotificationResolution</div><div class="operator">(</div><div class="ident">issue</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ReportItem</div><div class="operator">,</div> <div class="ident">record</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">NotificationRecord</div><div class="operator">)</div> <div class="operator">(</div><div class="ident">resolution</div> <div class="ident">bool</div><div class="operator">)</div> <div class="operator">{</div>
+<div class="keyword">func</div> <div class="ident">getNotificationResolution</div><div class="operator">(</div><div class="ident">issue</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ReportItem</div><div class="operator">,</div> <div class="ident">record</div> <div class="operator">*</div><div class="ident">types</div><div class="operator">.</div><div class="ident">NotificationRecord</div><div class="operator">)</div> <div class="operator">(</div><div class="ident">resolution</div> <div class="ident">bool</div><div class="operator">)</div> <div class="operator">{</div>
 </code></pre></td>
       </tr>
       
@@ -215,7 +216,7 @@ https://redhatinsights.github.io/ccx-notification-service/packages/differ/compar
 	<div class="operator">}</div><div class="operator"></div>
 
 	<div class="ident">resolution</div> <div class="operator">=</div> <div class="ident">IssueNotInReport</div><div class="operator">(</div><div class="ident">oldReport</div><div class="operator">,</div> <div class="ident">issue</div><div class="operator">)</div><div class="operator"></div>
-	<div class="ident">log</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Bool</div><div class="operator">(</div><div class="ident">resolutionKey</div><div class="operator">,</div> <div class="ident">resolution</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="ident">resolutionMsg</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">log</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Bool</div><div class="operator">(</div><div class="ident">resolutionKey</div><div class="operator">,</div> <div class="ident">resolution</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Str</div><div class="operator">(</div><div class="ident">resolutionReason</div><div class="operator">,</div> <div class="literal">&#34;issue not found in previously notified report&#34;</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="ident">resolutionMsg</div><div class="operator">)</div><div class="operator"></div>
 	<div class="keyword">return</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
@@ -229,11 +230,11 @@ https://redhatinsights.github.io/ccx-notification-service/packages/differ/compar
 	<td class="code"><pre><code>	<div class="ident">key</div> <div class="operator">:=</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ClusterOrgKey</div><div class="operator">{</div><div class="ident">OrgID</div><div class="operator">:</div> <div class="ident">cluster</div><div class="operator">.</div><div class="ident">OrgID</div><div class="operator">,</div> <div class="ident">ClusterName</div><div class="operator">:</div> <div class="ident">cluster</div><div class="operator">.</div><div class="ident">ClusterName</div><div class="operator">}</div><div class="operator"></div>
 	<div class="ident">reported</div><div class="operator">,</div> <div class="ident">ok</div> <div class="operator">:=</div> <div class="ident">previouslyReported</div><div class="operator">[</div><div class="ident">eventTarget</div><div class="operator">]</div><div class="operator">[</div><div class="ident">key</div><div class="operator">]</div><div class="operator"></div>
 	<div class="keyword">if</div> <div class="operator">!</div><div class="ident">ok</div> <div class="operator">{</div>
-		<div class="ident">log</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Bool</div><div class="operator">(</div><div class="ident">resolutionKey</div><div class="operator">,</div> <div class="ident">true</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="ident">resolutionMsg</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">log</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Bool</div><div class="operator">(</div><div class="ident">resolutionKey</div><div class="operator">,</div> <div class="ident">true</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Str</div><div class="operator">(</div><div class="ident">resolutionReason</div><div class="operator">,</div> <div class="literal">&#34;report not in cooldown&#34;</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="ident">resolutionMsg</div><div class="operator">)</div><div class="operator"></div>
 		<div class="keyword">return</div> <div class="ident">true</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
-	<div class="keyword">return</div> <div class="ident">getNotificationResolution</div><div class="operator">(</div><div class="ident">issue</div><div class="operator">,</div> <div class="ident">reported</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">return</div> <div class="ident">getNotificationResolution</div><div class="operator">(</div><div class="ident">issue</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">reported</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 <div class="keyword">func</div> <div class="ident">updateNotificationRecordSameState</div><div class="operator">(</div><div class="ident">storage</div> <div class="ident">Storage</div><div class="operator">,</div> <div class="ident">cluster</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ClusterEntry</div><div class="operator">,</div> <div class="ident">report</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ClusterReport</div><div class="operator">,</div> <div class="ident">notifiedAt</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">Timestamp</div><div class="operator">,</div> <div class="ident">eventTarget</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">EventTarget</div><div class="operator">)</div> <div class="operator">{</div>
@@ -269,6 +270,18 @@ https://redhatinsights.github.io/ccx-notification-service/packages/differ/compar
 	<div class="operator">}</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
+<div class="keyword">func</div> <div class="ident">updateNotificationRecordState</div><div class="operator">(</div><div class="ident">storage</div> <div class="ident">Storage</div><div class="operator">,</div> <div class="ident">cluster</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ClusterEntry</div><div class="operator">,</div> <div class="ident">report</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ClusterReport</div><div class="operator">,</div> <div class="ident">numEvents</div> <div class="ident">int</div><div class="operator">,</div> <div class="ident">notifiedAt</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">Timestamp</div><div class="operator">,</div> <div class="ident">eventTarget</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">EventTarget</div><div class="operator">,</div> <div class="ident">err</div> <div class="ident">error</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">switch</div> <div class="operator">{</div>
+	<div class="keyword">case</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div><div class="operator">:</div>
+		<div class="ident">log</div><div class="operator">.</div><div class="ident">Warn</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Int</div><div class="operator">(</div><div class="literal">&#34;issues notified so far&#34;</div><div class="operator">,</div> <div class="ident">numEvents</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Error sending notification events&#34;</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">updateNotificationRecordErrorState</div><div class="operator">(</div><div class="ident">storage</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">,</div> <div class="ident">cluster</div><div class="operator">,</div> <div class="ident">report</div><div class="operator">,</div> <div class="ident">notifiedAt</div><div class="operator">,</div> <div class="ident">eventTarget</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">case</div> <div class="ident">numEvents</div> <div class="operator">==</div> <div class="literal">0</div><div class="operator">:</div>
+		<div class="ident">updateNotificationRecordSameState</div><div class="operator">(</div><div class="ident">storage</div><div class="operator">,</div> <div class="ident">cluster</div><div class="operator">,</div> <div class="ident">report</div><div class="operator">,</div> <div class="ident">notifiedAt</div><div class="operator">,</div> <div class="ident">eventTarget</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">case</div> <div class="ident">numEvents</div> <div class="operator">&gt;</div> <div class="literal">0</div><div class="operator">:</div>
+		<div class="ident">updateNotificationRecordSentState</div><div class="operator">(</div><div class="ident">storage</div><div class="operator">,</div> <div class="ident">cluster</div><div class="operator">,</div> <div class="ident">report</div><div class="operator">,</div> <div class="ident">notifiedAt</div><div class="operator">,</div> <div class="ident">eventTarget</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
 <div class="keyword">func</div> <div class="ident">writeNotificationRecordFailed</div><div class="operator">(</div><div class="ident">err</div> <div class="ident">error</div><div class="operator">)</div> <div class="operator">{</div>
 	<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Write notification record failed&#34;</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
@@ -280,10 +293,11 @@ https://redhatinsights.github.io/ccx-notification-service/packages/differ/compar
 	<td class="doc"><p>Function issuesEqual compares two issues from reports</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">issuesEqual</div><div class="operator">(</div><div class="ident">issue1</div><div class="operator">,</div> <div class="ident">issue2</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">ReportItem</div><div class="operator">)</div> <div class="ident">bool</div> <div class="operator">{</div>
+	<div class="comment">/* Removing the Details comparison as a fix for https://issues.redhat.com/browse/CCXDEV-10817*/</div>
 	<div class="keyword">if</div> <div class="ident">issue1</div><div class="operator">.</div><div class="ident">Type</div> <div class="operator">==</div> <div class="ident">issue2</div><div class="operator">.</div><div class="ident">Type</div> <div class="operator">&amp;&amp;</div>
 		<div class="ident">issue1</div><div class="operator">.</div><div class="ident">Module</div> <div class="operator">==</div> <div class="ident">issue2</div><div class="operator">.</div><div class="ident">Module</div> <div class="operator">&amp;&amp;</div>
-		<div class="ident">issue1</div><div class="operator">.</div><div class="ident">ErrorKey</div> <div class="operator">==</div> <div class="ident">issue2</div><div class="operator">.</div><div class="ident">ErrorKey</div> <div class="operator">&amp;&amp;</div>
-		<div class="ident">bytes</div><div class="operator">.</div><div class="ident">Equal</div><div class="operator">(</div><div class="ident">issue1</div><div class="operator">.</div><div class="ident">Details</div><div class="operator">,</div> <div class="ident">issue2</div><div class="operator">.</div><div class="ident">Details</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="ident">issue1</div><div class="operator">.</div><div class="ident">ErrorKey</div> <div class="operator">==</div> <div class="ident">issue2</div><div class="operator">.</div><div class="ident">ErrorKey</div> <div class="operator">{</div><div class="comment">/* &amp;&amp;
+		bytes.Equal(issue1.Details, issue2.Details) */</div>
 		<div class="keyword">return</div> <div class="ident">true</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 	<div class="keyword">return</div> <div class="ident">false</div><div class="operator"></div>

--- a/docs/packages/differ/comparator_test.html
+++ b/docs/packages/differ/comparator_test.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2022 Red Hat, Inc
+ Copyright 2023 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@
       <tr class="section">
 	<td class="doc"></td>
 	<td class="code"><pre><code><div class="comment">/*
-Copyright © 2021 Red Hat, Inc.
+Copyright © 2021, 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
 you may not use this file except in compliance with the License.
@@ -135,14 +135,23 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">differ</div><div class="operator"></div>
 
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Documentation in literate-programming-style is available at:
+https://redhatinsights.github.io/ccx-notification-writer/packages/differ/comparator_test.html</p>
+</td>
+	<td class="code"><pre><code>
 <div class="keyword">import</div> <div class="operator">(</div>
 	<div class="literal">&#34;testing&#34;</div><div class="operator"></div>
 
-	<div class="literal">&#34;github.com/RedHatInsights/ccx-notification-service/tests/mocks&#34;</div><div class="operator"></div>
-	<div class="literal">&#34;github.com/RedHatInsights/ccx-notification-service/types&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/rs/zerolog&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/stretchr/testify/assert&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/stretchr/testify/mock&#34;</div><div class="operator"></div>
+
+	<div class="literal">&#34;github.com/RedHatInsights/ccx-notification-service/tests/mocks&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/RedHatInsights/ccx-notification-service/types&#34;</div><div class="operator"></div>
 <div class="operator">)</div><div class="operator"></div>
 
 <div class="keyword">var</div> <div class="operator">(</div>
@@ -275,7 +284,7 @@ limitations under the License.
 		<div class="ident">ErrorKey</div><div class="operator">:</div> <div class="literal">&#34;SOME_ERROR_KEY&#34;</div><div class="operator">,</div>
 		<div class="ident">Details</div><div class="operator">:</div>  <div class="operator">[</div><div class="operator">]</div><div class="ident">byte</div><div class="operator">(</div><div class="literal">&#34;details of the issue is different&#34;</div><div class="operator">)</div><div class="operator">,</div>
 	<div class="operator">}</div><div class="operator"></div>
-	<div class="ident">assert</div><div class="operator">.</div><div class="ident">False</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">issuesEqual</div><div class="operator">(</div><div class="ident">issue1</div><div class="operator">,</div> <div class="ident">issue2</div><div class="operator">)</div><div class="operator">,</div> <div class="literal">&#34;Compared issues should not be equal&#34;</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">assert</div><div class="operator">.</div><div class="ident">True</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">issuesEqual</div><div class="operator">(</div><div class="ident">issue1</div><div class="operator">,</div> <div class="ident">issue2</div><div class="operator">)</div><div class="operator">,</div> <div class="literal">&#34;Compared issues should be equal&#34;</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 <div class="keyword">func</div> <div class="ident">TestIssuesEqualDifferentModule</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
@@ -507,7 +516,7 @@ limitations under the License.
 	<div class="operator">}</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
-<div class="keyword">func</div> <div class="ident">TestShouldNotifySameRuleDifferentDetails</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+<div class="keyword">func</div> <div class="ident">TestShouldNotNotifySameRuleDifferentDetails</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
 	<div class="ident">storage</div> <div class="operator">:=</div> <div class="ident">mocks</div><div class="operator">.</div><div class="ident">Storage</div><div class="operator">{</div><div class="operator">}</div><div class="operator"></div>
 	<div class="ident">storage</div><div class="operator">.</div><div class="ident">On</div><div class="operator">(</div><div class="literal">&#34;ReadLastNotifiedRecordForClusterList&#34;</div><div class="operator">,</div>
 		<div class="ident">mock</div><div class="operator">.</div><div class="ident">AnythingOfType</div><div class="operator">(</div><div class="literal">&#34;[]types.ClusterEntry&#34;</div><div class="operator">)</div><div class="operator">,</div>
@@ -546,7 +555,7 @@ limitations under the License.
 
 	<div class="ident">previouslyReported</div><div class="operator">[</div><div class="ident">types</div><div class="operator">.</div><div class="ident">NotificationBackendTarget</div><div class="operator">]</div><div class="operator">,</div> <div class="ident">_</div> <div class="operator">=</div> <div class="ident">storage</div><div class="operator">.</div><div class="ident">ReadLastNotifiedRecordForClusterList</div><div class="operator">(</div><div class="ident">make</div><div class="operator">(</div><div class="operator">[</div><div class="operator">]</div><div class="ident">types</div><div class="operator">.</div><div class="ident">ClusterEntry</div><div class="operator">,</div> <div class="literal">0</div><div class="operator">)</div><div class="operator">,</div> <div class="literal">&#34;24 hours&#34;</div><div class="operator">,</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">NotificationBackendTarget</div><div class="operator">)</div><div class="operator"></div>
 	<div class="keyword">for</div> <div class="ident">_</div><div class="operator">,</div> <div class="ident">issue</div> <div class="operator">:=</div> <div class="keyword">range</div> <div class="ident">newReport</div><div class="operator">.</div><div class="ident">Reports</div> <div class="operator">{</div>
-		<div class="ident">assert</div><div class="operator">.</div><div class="ident">True</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">shouldNotify</div><div class="operator">(</div><div class="ident">testCluster</div><div class="operator">,</div> <div class="ident">issue</div><div class="operator">,</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">NotificationBackendTarget</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">False</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">shouldNotify</div><div class="operator">(</div><div class="ident">testCluster</div><div class="operator">,</div> <div class="ident">issue</div><div class="operator">,</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">NotificationBackendTarget</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 


### PR DESCRIPTION
# Description

No notifications include specific rule response details. Both ServiceLog and email notifications will look exactly the same regardless of differences in rule response details. So to fix issues were difference in details can make us resend a notification that is still in cool-down, we will base the notification resolution solely on the rule response ID (rule module + response key).

Fixes CCXDEV-10817

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

CI (existing UTs and BDD tests should pass)

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
