### PR TITLE
Fix format of notification event timestamp

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -881,7 +881,7 @@ func setupServiceLogProducer(config *conf.ConfigStruct) {
 func generateInstantNotificationMessage(
 	clusterURI *string, accountID, orgID, clusterID string) (
 	notification types.NotificationMessage) {
-	events := []types.Event{}
+	var events []types.Event
 	context := types.NotificationContext{
 		notificationContextDisplayName: clusterID,
 		notificationContextHostURL:     strings.Replace(*clusterURI, "{cluster_id}", clusterID, 1),
@@ -891,7 +891,7 @@ func generateInstantNotificationMessage(
 		Bundle:      notificationBundleName,
 		Application: notificationApplicationName,
 		EventType:   types.InstantNotif.ToString(),
-		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Timestamp:   time.Now().UTC().Format(time.RFC3339Nano),
 		AccountID:   accountID,
 		OrgID:       orgID,
 		Events:      events,


### PR DESCRIPTION
# Description

We are currently sending the notification event to the Kafka backend following [this message format](https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/send-notification.html#_kafka). The timestamp we send does not have the required precision, as the processor uses Java's `LocalDatetime` object, which [toString method](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html#toString--) returns the shorter representation possible.

Fixes CCXDEV-10621

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
