### PR TITLE
Use latest image for insights-behavioral-spec in BDD tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
         - go build
         - wget -O docker-compose.yml https://raw.githubusercontent.com/RedHatInsights/insights-behavioral-spec/main/docker-compose.yml
         - POSTGRES_DB_NAME=notification docker-compose --profile test-notification-services up -d
-        - cid=$(docker ps | grep 'insights-behavioral-spec:ci' | cut -d ' ' -f 1)
+        - cid=$(docker ps | grep 'insights-behavioral-spec:latest' | cut -d ' ' -f 1)
         - docker cp ccx-notification-service $cid:`docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN"'`
         - docker exec -u root $cid /bin/bash -c 'chmod +x $VIRTUAL_ENV_BIN/ccx-notification-service'
       script:


### PR DESCRIPTION
# Description

The `insights-behavioral-spec` image is now built automatically on each merge as part of our CI/CD.  The image is stored in the `cloudservices` organization and tagged as `latest` as well as with the commit's hash. This updates the Travis `BDD tests` to always use that latest image

Follow-up of [CCXDEV-10818](https://issues.redhat.com/browse/CCXDEV-10818)

## Type of change

- (CI) configuration update

## Testing steps

CI passes

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
