### PR TITLE
Render reports only when there are issues to notify

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -70,7 +70,7 @@ func getNotificationType(notificationTypes []types.NotificationType, value strin
 	return -1
 }
 
-func getNotificationResolution(issue types.ReportItem, record *types.NotificationRecord) (resolution bool) {
+func getNotificationResolution(issue *types.ReportItem, record *types.NotificationRecord) (resolution bool) {
 	// it is not a brand new cluster -> check if issue was included in older report
 	var oldReport types.Report
 	err := json.Unmarshal([]byte(record.Report), &oldReport)
@@ -84,7 +84,7 @@ func getNotificationResolution(issue types.ReportItem, record *types.Notificatio
 	return
 }
 
-func shouldNotify(cluster types.ClusterEntry, issue types.ReportItem, eventTarget types.EventTarget) bool {
+func shouldNotify(cluster types.ClusterEntry, issue *types.ReportItem, eventTarget types.EventTarget) bool {
 	// check if the issue of the given cluster has previously been reported
 	key := types.ClusterOrgKey{OrgID: cluster.OrgID, ClusterName: cluster.ClusterName}
 	reported, ok := previouslyReported[eventTarget][key]
@@ -141,7 +141,7 @@ func writeNotificationRecordFailed(err error) {
 }
 
 // Function issuesEqual compares two issues from reports
-func issuesEqual(issue1, issue2 types.ReportItem) bool {
+func issuesEqual(issue1, issue2 *types.ReportItem) bool {
 	/* Removing the Details comparison as a fix for https://issues.redhat.com/browse/CCXDEV-10817*/
 	if issue1.Type == issue2.Type &&
 		issue1.Module == issue2.Module &&
@@ -155,7 +155,7 @@ func issuesEqual(issue1, issue2 types.ReportItem) bool {
 // IssueNotInReport searches for a specific issue in given OCP report.
 // It returns a boolean flag indicating that the report does not
 // contain the issue and thus user needs to be informed about it.
-func IssueNotInReport(oldReport types.Report, issue types.ReportItem) bool {
+func IssueNotInReport(oldReport types.Report, issue *types.ReportItem) bool {
 	for _, oldIssue := range oldReport.Reports {
 		if issuesEqual(oldIssue, issue) {
 			log.Info().Bool(resolutionKey, false).Str(resolutionReason, "issue found in previously notified report").Msg(resolutionMsg)

--- a/differ/comparator_test.go
+++ b/differ/comparator_test.go
@@ -144,7 +144,7 @@ func TestIssuesEqualSameIssues(t *testing.T) {
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue"),
 	}
-	assert.True(t, issuesEqual(issue1, issue2), "Compared issues should be equal")
+	assert.True(t, issuesEqual(&issue1, &issue2), "Compared issues should be equal")
 }
 
 func TestIssuesEqualDifferentDetails(t *testing.T) {
@@ -160,7 +160,7 @@ func TestIssuesEqualDifferentDetails(t *testing.T) {
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue is different"),
 	}
-	assert.True(t, issuesEqual(issue1, issue2), "Compared issues should be equal")
+	assert.True(t, issuesEqual(&issue1, &issue2), "Compared issues should be equal")
 }
 
 func TestIssuesEqualDifferentModule(t *testing.T) {
@@ -176,12 +176,12 @@ func TestIssuesEqualDifferentModule(t *testing.T) {
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue"),
 	}
-	assert.False(t, issuesEqual(issue1, issue2), "Compared issues should not be equal")
+	assert.False(t, issuesEqual(&issue1, &issue2), "Compared issues should not be equal")
 }
 
 func TestNewIssueNotInOldReport(t *testing.T) {
 	oldReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -199,7 +199,7 @@ func TestNewIssueNotInOldReport(t *testing.T) {
 	}
 
 	assert.True(t,
-		IssueNotInReport(oldReport, issue),
+		IssueNotInReport(oldReport, &issue),
 		"New issue not in old report old report, so result should be true.",
 	)
 
@@ -207,7 +207,7 @@ func TestNewIssueNotInOldReport(t *testing.T) {
 
 func TestIssueNotInReportSameItemsInNewReport(t *testing.T) {
 	oldReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -223,7 +223,7 @@ func TestIssueNotInReportSameItemsInNewReport(t *testing.T) {
 		},
 	}
 	newReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -249,7 +249,7 @@ func TestIssueNotInReportSameItemsInNewReport(t *testing.T) {
 
 func TestIssueNotInReportSameLengthDifferentItemsInNewReport(t *testing.T) {
 	oldReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -265,7 +265,7 @@ func TestIssueNotInReportSameLengthDifferentItemsInNewReport(t *testing.T) {
 		},
 	}
 	newReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_3.report",
@@ -291,7 +291,7 @@ func TestIssueNotInReportSameLengthDifferentItemsInNewReport(t *testing.T) {
 
 func TestIssueNotInReportLessItemsInNewReportAndIssueNotFoundInOldReports(t *testing.T) {
 	oldReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -307,7 +307,7 @@ func TestIssueNotInReportLessItemsInNewReportAndIssueNotFoundInOldReports(t *tes
 		},
 	}
 	newReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_3.report",
@@ -327,7 +327,7 @@ func TestIssueNotInReportLessItemsInNewReportAndIssueNotFoundInOldReports(t *tes
 
 func TestIssueNotInReportLessItemsInNewReportAndIssueFoundInOldReports(t *testing.T) {
 	oldReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -343,7 +343,7 @@ func TestIssueNotInReportLessItemsInNewReportAndIssueFoundInOldReports(t *testin
 		},
 	}
 	newReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -376,7 +376,7 @@ func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 			},
 		)
 	newReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
@@ -419,7 +419,7 @@ func TestShouldNotNotifySameRuleDifferentDetails(t *testing.T) {
 			},
 		)
 	newReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.rule_4.report",
@@ -462,7 +462,7 @@ func TestShouldNotifyIssueNotFoundInPreviousRecords(t *testing.T) {
 			},
 		)
 	newReport := types.Report{
-		Reports: []types.ReportItem{
+		Reports: types.ReportContent{
 			{
 				Type:     "rule",
 				Module:   "ccx_rules_ocp.external.rules.new_rule.report",

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -622,8 +622,8 @@ func TestProcessClustersInvalidReportFormatForClusterEntry(t *testing.T) {
 	processClusters(&conf.ConfigStruct{Kafka: conf.KafkaConfiguration{Enabled: true}}, ruleContent, &storage, clusters)
 
 	executionLog := buf.String()
-	assert.Contains(t, executionLog, "cannot unmarshal object into Go struct field Report.reports of type []types.ReportItem", "The string retrieved is not a list of reports. It should not deserialize correctly")
-	assert.Contains(t, executionLog, "No new issues to notify for cluster second_cluster", "the processReportsByCluster loop did not continue as extpected")
+	assert.Contains(t, executionLog, "cannot unmarshal object into Go struct field Report.reports of type types.ReportContent", "The string retrieved is not a list of reports. It should not deserialize correctly")
+	assert.Contains(t, executionLog, "No new issues to notify for cluster second_cluster", "the processReportsByCluster loop did not continue as expected")
 	assert.Contains(t, executionLog, "Number of reports not retrieved/deserialized: 1", "the first cluster should have been skipped")
 	assert.Contains(t, executionLog, "Number of empty reports skipped: 0")
 

--- a/differ/renderer.go
+++ b/differ/renderer.go
@@ -71,6 +71,7 @@ func renderReportsForCluster(
 
 	log.Debug().Interface("unmarshalled", receivedResult).Msg("Received result")
 
+	//TODO: create map[module+err_key]rendererReport here to not loop through rendered reports once for each report
 	return receivedResult.Reports[clusterName], nil
 }
 

--- a/differ/renderer.go
+++ b/differ/renderer.go
@@ -40,7 +40,7 @@ import (
 func renderReportsForCluster(
 	config *conf.DependenciesConfiguration,
 	clusterName types.ClusterName,
-	reports []types.ReportItem,
+	reports types.ReportContent,
 	ruleContent types.Rules) ([]types.RenderedReport, error) {
 
 	log.Debug().Str("cluster", string(clusterName)).Msg("RenderReportsForCluster")
@@ -88,7 +88,7 @@ func getAllContentFromMap(ruleContent types.RulesMap) []utypes.RuleContent {
 
 func createTemplateRendererRequest(
 	rules types.Rules,
-	reports []types.ReportItem,
+	reports types.ReportContent,
 	clusterName types.ClusterName,
 	rendererURL string) (*http.Request, error) {
 

--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -101,7 +101,7 @@ func TestRenderReportsForCluster(t *testing.T) {
 
 	rules := getAllContentFromMap(ruleContent)
 
-	reports := []types.ReportItem{
+	reports := types.ReportContent{
 		{
 			Type:     "rule",
 			Module:   "rule_1.report",
@@ -146,7 +146,7 @@ func TestRenderReportsForClusterInvalidJSON(t *testing.T) {
 		TemplateRendererURL:      server.URL,
 	}
 
-	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", []types.ReportItem{}, []utypes.RuleContent{})
+	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", types.ReportContent{}, []utypes.RuleContent{})
 	v, _ := json.Marshal(rendereredReports)
 	log.Info().Msg(string(v))
 	assert.Error(t, err)
@@ -160,7 +160,7 @@ func TestRenderReportsForClusterInvalidURL(t *testing.T) {
 		TemplateRendererURL:      "not an url",
 	}
 
-	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", []types.ReportItem{}, []utypes.RuleContent{})
+	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", types.ReportContent{}, []utypes.RuleContent{})
 	v, _ := json.Marshal(rendereredReports)
 	log.Info().Msg(string(v))
 	assert.Error(t, err)

--- a/types/types.go
+++ b/types/types.go
@@ -152,7 +152,7 @@ type CliFlags struct {
 	MaxAge                    string
 }
 
-// Report represents the array of items expected in a report
+// ReportContent represents the array of items expected in a report
 type ReportContent []*ReportItem
 
 // Report represents report send in a message consumed from any broker

--- a/types/types.go
+++ b/types/types.go
@@ -152,9 +152,12 @@ type CliFlags struct {
 	MaxAge                    string
 }
 
+// Report represents the array of items expected in a report
+type ReportContent []*ReportItem
+
 // Report represents report send in a message consumed from any broker
 type Report struct {
-	Reports []ReportItem `json:"reports"`
+	Reports ReportContent `json:"reports"`
 }
 
 // RuleID represents type for rule id


### PR DESCRIPTION
# Description

The change itself is about adding the [reportsToRender slice](https://github.com/RedHatInsights/ccx-notification-service/compare/master...epapbak:ccx-notification-service:render_reports_only_when_needed#diff-eb2af045c98f2dc73f17612ac604b9de75162f75e746af09e33783522bfab653R436) , and modifying the [Report structure](https://github.com/RedHatInsights/ccx-notification-service/compare/master...epapbak:ccx-notification-service:render_reports_only_when_needed#diff-f8d2bd35e1a8c9b86c8c4448dde00bc5480652f85ed0630efc012c3906d3a14fR159) so we can handle a slice of pointers.

This is a performance optimization, as we do not have to query the template renderer when not necessary.

Fixes [CCXDEV-11097](https://issues.redhat.com/browse/CCXDEV-11097) partially

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)

## Testing steps

Tested locally, updated UTs, and BDDs (CI) should pass

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
