### PR TITLE
Do not replace Module field in reports to render

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -464,7 +464,6 @@ func getReportsWithIssuesToNotify(reports types.ReportContent, cluster types.Clu
 			log.Info().
 				Str(clusterName, string(cluster.ClusterName)).
 				Msg(differentReportMessage)
-			r.Module = types.ModuleName(ruleName)
 			reportsWithIssues = append(reportsWithIssues, r)
 		}
 	}
@@ -524,11 +523,11 @@ func produceEntriesToServiceLog(configuration *conf.ConfigStruct, cluster types.
 		}
 
 		for _, r := range reportsToRender {
-			ruleName := r.Module
+			ruleName := moduleToRuleName(r.Module)
 			errorKey := r.ErrorKey
 
 			ReportWithHighImpact.Inc()
-			renderedReport, err := findRenderedReport(renderedReports, types.RuleName(ruleName), errorKey)
+			renderedReport, err := findRenderedReport(renderedReports, ruleName, errorKey)
 
 			if err != nil {
 				log.Err(err).Msgf("Output from content template renderer does not contain "+


### PR DESCRIPTION
# Description

Replacing the `module` field of the reports to render to not call `moduleToRuleName` twice was a really bad idea, as the content template renderer expects the full module name or fails.

Fixes bug introduced in #592

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Run service locally with real template renderer and real rules

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
