### PR TITLE
Send severity (info) in service log entry

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -260,6 +260,7 @@ func createServiceLogEntry(report *types.RenderedReport, cluster types.ClusterEn
 		ClusterUUID: cluster.ClusterName,
 		Description: report.Reason,
 		ServiceName: serviceName,
+		Severity:    "Info",
 		Summary:     report.Description,
 		CreatedBy:   createdBy,
 		Username:    username,

--- a/types/types.go
+++ b/types/types.go
@@ -297,6 +297,7 @@ type ServiceLogEntry struct {
 	ClusterUUID ClusterName `json:"cluster_uuid"`
 	Description string      `json:"description"`
 	ServiceName string      `json:"service_name"`
+	Severity    string      `json:"severity"`
 	Summary     string      `json:"summary"`
 	CreatedBy   string      `json:"created_by"`
 	Username    string      `json:"username"`


### PR DESCRIPTION
# Description

Include default severity in created service log entries. The actual severity levels we want to send still need to be decided. The issue is that right now this attribute is needed, when it used to be set by default.

Fixes CCXDEV-12062

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

- Already tested in UTs (funny, right?)
- BDDs pass
- Stage should be fixed by this change

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
