### PR TITLE
Unit test for method `storage.PrintOldReportsForCleanup`

### DIFF
--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -2055,3 +2055,41 @@ func TestPrintOldReportsForCleanupEmptyRecordSet(t *testing.T) {
 	// check if all expectations were met
 	checkAllExpectations(t, mock)
 }
+
+// TestPrintOldReportsForCleanupNonEmptyRecordSet checks if method Storage.PrintOldReportsForCleanup performs
+// the right query when non empty set is returned.
+func TestPrintOldReportsForCleanupNonEmptyRecordSet(t *testing.T) {
+	const maxAge = "1 day"
+
+	// prepare Old mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"org_id", "account_number", "cluster_name", "updated_at", "kafka_offset"})
+
+	// these three rows should be returned
+	rows.AddRow(0, 1000, "ID=0", time.Now(), 0)
+	rows.AddRow(1, 1001, "ID=1", time.Now(), 0)
+	rows.AddRow(2, 1002, "ID=2", time.Now(), 0)
+
+	// expected query performed by tested function
+	expectedQuery := "SELECT org_id, account_number, cluster, updated_at, 0\n\t\t  FROM reported\n\t\t WHERE updated_at < NOW\\(\\) - \\$1::INTERVAL\n\t\t ORDER BY updated_at\n"
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	err := storage.PrintOldReportsForCleanup(maxAge)
+
+	// tested method should NOT return an error
+	assert.NoError(t, err, "error was not expected while querying database")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -1989,7 +1989,7 @@ func TestPrintNewReportsForCleanupOnScanError(t *testing.T) {
 	checkAllExpectations(t, mock)
 }
 
-// TestPrintNewReportsForCleanupOnError checks if method Storage.ReadNotificationTypes returns
+// TestPrintNewReportsForCleanupOnError checks if method Storage.PrintNewReportsForCleanup returns
 // expected results on error.
 func TestPrintNewReportsForCleanupOnError(t *testing.T) {
 	const maxAge = "1 day"
@@ -2132,7 +2132,7 @@ func TestPrintOldReportsForCleanupOnScanError(t *testing.T) {
 	checkAllExpectations(t, mock)
 }
 
-// TestPrintOldReportsForCleanupOnError checks if method Storage.ReadNotificationTypes returns
+// TestPrintOldReportsForCleanupOnError checks if method Storage.PrintOldReportsForCleanup returns
 // expected results on error.
 func TestPrintOldReportsForCleanupOnError(t *testing.T) {
 	const maxAge = "1 day"


### PR DESCRIPTION
# Description

Unit test for method `storage.PrintOldReportsForCleanup`

## Fixes #538 

## Type of change

- Unit tests (no changes in the code)

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
