### PR TITLE
Don't close row set twice in `Storage.ReadNotificationType`

### DIFF
--- a/differ/storage.go
+++ b/differ/storage.go
@@ -309,6 +309,8 @@ func (storage DBStorage) ReadNotificationTypes() ([]types.NotificationType, erro
 	}
 
 	defer func() {
+		// try to close row set in all cases
+		// even on scan error etc.
 		err := rows.Close()
 		if err != nil {
 			log.Error().Err(err).Msg(unableToCloseDBRowsHandle)
@@ -324,9 +326,6 @@ func (storage DBStorage) ReadNotificationTypes() ([]types.NotificationType, erro
 		)
 
 		if err := rows.Scan(&id, &value, &frequency, &comment); err != nil {
-			if closeErr := rows.Close(); closeErr != nil {
-				log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
-			}
 			return notificationTypes, err
 		}
 		notificationTypes = append(notificationTypes, types.NotificationType{


### PR DESCRIPTION
# Description

Don't close row set twice in `Storage.ReadNotificationType`
Already covered by unit tests

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

To be re-checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
