### PR TITLE
Don't close row set twice in `Storage.ReadStates`

### DIFF
--- a/differ/storage.go
+++ b/differ/storage.go
@@ -345,6 +345,8 @@ func (storage DBStorage) ReadStates() ([]types.State, error) {
 	}
 
 	defer func() {
+		// try to close row set in all cases
+		// even on scan error etc.
 		err := rows.Close()
 		if err != nil {
 			log.Error().Err(err).Msg(unableToCloseDBRowsHandle)
@@ -359,9 +361,6 @@ func (storage DBStorage) ReadStates() ([]types.State, error) {
 		)
 
 		if err := rows.Scan(&id, &value, &comment); err != nil {
-			if closeErr := rows.Close(); closeErr != nil {
-				log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
-			}
 			return states, err
 		}
 		states = append(states, types.State{


### PR DESCRIPTION
# Description

Don't close row set twice in `Storage.ReadStates`
Already covered by unit tests

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

To be re-checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
