### PR TITLE
[CCXDEV-11831] Set service log severity based on calculated total risk

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -69,7 +69,7 @@ func getNotificationType(notificationTypes []types.NotificationType, value strin
 	return -1
 }
 
-func getNotificationResolution(issue *types.ReportItem, record *types.NotificationRecord) (resolution bool) {
+func getNotificationResolution(issue *types.EvaluatedReportItem, record *types.NotificationRecord) (resolution bool) {
 	// check if detected issue was included in older report
 	var oldReport types.Report
 	err := json.Unmarshal([]byte(record.Report), &oldReport)
@@ -85,7 +85,7 @@ func getNotificationResolution(issue *types.ReportItem, record *types.Notificati
 
 // ShouldNotify asserts whether an issue has already been sent in a previous
 // notification event
-func (d *Differ) ShouldNotify(cluster types.ClusterEntry, issue *types.ReportItem) bool {
+func (d *Differ) ShouldNotify(cluster types.ClusterEntry, issue *types.EvaluatedReportItem) bool {
 	key := types.ClusterOrgKey{OrgID: cluster.OrgID, ClusterName: cluster.ClusterName}
 	reported, ok := d.PreviouslyReported[key]
 	if !ok {
@@ -141,7 +141,7 @@ func writeNotificationRecordFailed(err error) {
 }
 
 // IssuesEqual compares two issues from reports
-func IssuesEqual(issue1, issue2 *types.ReportItem) bool {
+func IssuesEqual(issue1, issue2 *types.EvaluatedReportItem) bool {
 	/* Removing the Details' comparison as a fix for https://issues.redhat.com/browse/CCXDEV-10817*/
 	if issue1.Type == issue2.Type &&
 		issue1.Module == issue2.Module &&
@@ -155,7 +155,7 @@ func IssuesEqual(issue1, issue2 *types.ReportItem) bool {
 // IssueNotInReport searches for a specific issue in given OCP report.
 // It returns a boolean flag indicating that the report does not
 // contain the issue and thus user needs to be informed about it.
-func IssueNotInReport(oldReport types.Report, issue *types.ReportItem) bool {
+func IssueNotInReport(oldReport types.Report, issue *types.EvaluatedReportItem) bool {
 	for _, oldIssue := range oldReport.Reports {
 		if IssuesEqual(oldIssue, issue) {
 			log.Debug().Bool(resolutionKey, false).Str(resolutionReason, "issue found in previously notified report").Msg(resolutionMsg)

--- a/differ/comparator_test.go
+++ b/differ/comparator_test.go
@@ -119,50 +119,50 @@ func TestGetNotifications(t *testing.T) {
 }
 
 func TestIssuesEqualSameIssues(t *testing.T) {
-	issue1 := types.ReportItem{
+	issue1 := types.EvaluatedReportItem{ReportItem: types.ReportItem{
 		Type:     "rule",
 		Module:   "ccx_rules_ocp.external.rules.rule_1.report",
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue"),
-	}
-	issue2 := types.ReportItem{
+	}}
+	issue2 := types.EvaluatedReportItem{ReportItem: types.ReportItem{
 		Type:     "rule",
 		Module:   "ccx_rules_ocp.external.rules.rule_1.report",
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue"),
-	}
+	}}
 	assert.True(t, differ.IssuesEqual(&issue1, &issue2), "Compared issues should be equal")
 }
 
 func TestIssuesEqualDifferentDetails(t *testing.T) {
-	issue1 := types.ReportItem{
+	issue1 := types.EvaluatedReportItem{ReportItem: types.ReportItem{
 		Type:     "rule",
 		Module:   "ccx_rules_ocp.external.rules.rule_1.report",
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue"),
-	}
-	issue2 := types.ReportItem{
+	}}
+	issue2 := types.EvaluatedReportItem{ReportItem: types.ReportItem{
 		Type:     "rule",
 		Module:   "ccx_rules_ocp.external.rules.rule_1.report",
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue is different"),
-	}
+	}}
 	assert.True(t, differ.IssuesEqual(&issue1, &issue2), "Compared issues should be equal")
 }
 
 func TestIssuesEqualDifferentModule(t *testing.T) {
-	issue1 := types.ReportItem{
+	issue1 := types.EvaluatedReportItem{ReportItem: types.ReportItem{
 		Type:     "rule",
 		Module:   "ccx_rules_ocp.external.rules.rule_1.report",
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue"),
-	}
-	issue2 := types.ReportItem{
+	}}
+	issue2 := types.EvaluatedReportItem{ReportItem: types.ReportItem{
 		Type:     "rule",
 		Module:   "ccx_rules_ocp.external.rules.rule_2.report",
 		ErrorKey: "SOME_ERROR_KEY",
 		Details:  []byte("details of the issue"),
-	}
+	}}
 	assert.False(t, differ.IssuesEqual(&issue1, &issue2), "Compared issues should not be equal")
 }
 
@@ -170,20 +170,22 @@ func TestNewIssueNotInOldReport(t *testing.T) {
 	oldReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 		},
 	}
 
-	issue := types.ReportItem{
+	issue := types.EvaluatedReportItem{ReportItem: types.ReportItem{
 		Type:     "rule",
 		Module:   "ccx_rules_ocp.external.rules.rule_2.report",
 		ErrorKey: "SOME_OTHER_ERROR_KEY",
 		Details:  []byte("details of the other issue"),
-	}
+	}}
 
 	assert.True(t,
 		differ.IssueNotInReport(oldReport, &issue),
@@ -196,32 +198,38 @@ func TestIssueNotInReportSameItemsInNewReport(t *testing.T) {
 	oldReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_2.report",
-				ErrorKey: "SOME_OTHER_ERROR_KEY",
-				Details:  []byte("details of the other issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_2.report",
+					ErrorKey: "SOME_OTHER_ERROR_KEY",
+					Details:  []byte("details of the other issue"),
+				},
 			},
 		},
 	}
 	newReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_2.report",
-				ErrorKey: "SOME_OTHER_ERROR_KEY",
-				Details:  []byte("details of the other issue"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_2.report",
+					ErrorKey: "SOME_OTHER_ERROR_KEY",
+					Details:  []byte("details of the other issue"),
+				},
 			},
 		},
 	}
@@ -238,32 +246,39 @@ func TestIssueNotInReportSameLengthDifferentItemsInNewReport(t *testing.T) {
 	oldReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_2.report",
-				ErrorKey: "SOME_OTHER_ERROR_KEY",
-				Details:  []byte("details of the other issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_2.report",
+					ErrorKey: "SOME_OTHER_ERROR_KEY",
+					Details:  []byte("details of the other issue"),
+				},
 			},
 		},
 	}
 	newReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_3.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue 3"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_3.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue 3"),
+				},
 			},
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_4.report",
-				ErrorKey: "SOME_OTHER_ERROR_KEY",
-				Details:  []byte("details of the other issue 4"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_4.report",
+					ErrorKey: "SOME_OTHER_ERROR_KEY",
+					Details:  []byte("details of the other issue 4"),
+				},
 			},
 		},
 	}
@@ -280,26 +295,30 @@ func TestIssueNotInReportLessItemsInNewReportAndIssueNotFoundInOldReports(t *tes
 	oldReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_2.report",
-				ErrorKey: "SOME_OTHER_ERROR_KEY",
-				Details:  []byte("details of the other issue"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_2.report",
+					ErrorKey: "SOME_OTHER_ERROR_KEY",
+					Details:  []byte("details of the other issue"),
+				},
 			},
 		},
 	}
 	newReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_3.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the new issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_3.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the new issue"),
+				},
 			},
 		},
 	}
@@ -316,26 +335,30 @@ func TestIssueNotInReportLessItemsInNewReportAndIssueFoundInOldReports(t *testin
 	oldReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_2.report",
-				ErrorKey: "SOME_OTHER_ERROR_KEY",
-				Details:  []byte("details of the other issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_2.report",
+					ErrorKey: "SOME_OTHER_ERROR_KEY",
+					Details:  []byte("details of the other issue"),
+				},
 			},
 		},
 	}
 	newReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 		},
 	}
@@ -365,10 +388,12 @@ func TestShouldNotifyNoPreviousRecord(t *testing.T) {
 	newReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_1.report",
-				ErrorKey: "SOME_ERROR_KEY",
-				Details:  []byte("details of the issue"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_1.report",
+					ErrorKey: "SOME_ERROR_KEY",
+					Details:  []byte("details of the issue"),
+				},
 			},
 		},
 	}
@@ -412,10 +437,11 @@ func TestShouldNotNotifySameRuleDifferentDetails(t *testing.T) {
 	newReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.rule_4.report",
-				ErrorKey: "RULE_4",
-				Details:  []byte("The details differ somehow"),
+				ReportItem: types.ReportItem{Type: "rule",
+					Module:   "ccx_rules_ocp.external.rules.rule_4.report",
+					ErrorKey: "RULE_4",
+					Details:  []byte("The details differ somehow"),
+				},
 			},
 		},
 	}
@@ -460,10 +486,12 @@ func TestShouldNotifyIssueNotFoundInPreviousRecords(t *testing.T) {
 	newReport := types.Report{
 		Reports: types.ReportContent{
 			{
-				Type:     "rule",
-				Module:   "ccx_rules_ocp.external.rules.new_rule.report",
-				ErrorKey: "NEW_RULE_NOT_PREVIOUSLY_REPORTED",
-				Details:  []byte("New rule with bunch of details"),
+				ReportItem: types.ReportItem{
+					Type:     "rule",
+					Module:   "ccx_rules_ocp.external.rules.new_rule.report",
+					ErrorKey: "NEW_RULE_NOT_PREVIOUSLY_REPORTED",
+					Details:  []byte("New rule with bunch of details"),
+				},
 			},
 		},
 	}

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -101,7 +101,7 @@ const (
 	clustersAttribute           = "clusters"
 	totalRiskAttribute          = "totalRisk"
 	errorStr                    = "Error:"
-	reportWithHighImpactMessage = "Report with high impact detected"
+	ReportWithHighImpactMessage = "Report with impact higher than configured threshold detected"
 	invalidJSONContent          = "The provided content cannot be encoded as JSON."
 	metricsPushFailedMessage    = "Couldn't push prometheus metrics"
 	tagsNotSetMessage           = "Tags for tag filter not set"
@@ -332,7 +332,8 @@ func (d *Differ) getReportsWithIssuesToNotify(reports types.ReportContent, clust
 				Int(likelihoodAttribute, likelihood).
 				Int(impactAttribute, impact).
 				Int(totalRiskAttribute, totalRisk).
-				Msg(reportWithHighImpactMessage)
+				Msg(ReportWithHighImpactMessage)
+
 			reportsWithIssues = append(reportsWithIssues, r)
 		}
 	}
@@ -463,7 +464,7 @@ func (d *Differ) produceEntriesToKafka(cluster types.ClusterEntry, ruleContent t
 				Int(likelihoodAttribute, likelihood).
 				Int(impactAttribute, impact).
 				Int(totalRiskAttribute, totalRisk).
-				Msg(reportWithHighImpactMessage)
+				Msg(ReportWithHighImpactMessage)
 			ReportWithHighImpact.Inc()
 			notificationPayloadURL := generateNotificationPayloadURL(&notificationEventURLs.RuleDetails, string(cluster.ClusterName), module, errorKey)
 			appendEventToNotificationMessage(notificationPayloadURL, &notificationMsg, description, totalRisk, time.Time(cluster.UpdatedAt).UTC().Format(time.RFC3339Nano))

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -790,7 +790,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskImportant(t *testing.T) {
 	d.ProcessClusters(&conf.ConfigStruct{Kafka: conf.KafkaConfiguration{Enabled: true}}, ruleContent, clusters)
 
 	executionLog := buf.String()
-	assert.Contains(t, executionLog, "Report with high impact detected", "processClusters should create a notification for 'first_cluster' with given data")
+	assert.Contains(t, executionLog, differ.ReportWithHighImpactMessage, "processClusters should create a notification for 'first_cluster' with given data")
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"cluster\":\"first_cluster\",\"number of events\":1,\"message\":\"Producing instant notification\"}", "processClusters should generate one notification for 'first_cluster' with given data")
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"cluster\":\"second_cluster\",\"number of events\":1,\"message\":\"Producing instant notification\"}", "processClusters should generate one notification for 'first_cluster' with given data")
 
@@ -935,7 +935,7 @@ func TestProcessClustersInstantNotifsAndTotalRiskCritical(t *testing.T) {
 	d.ProcessClusters(&conf.ConfigStruct{Kafka: conf.KafkaConfiguration{Enabled: true}}, ruleContent, clusters)
 
 	executionLog := buf.String()
-	assert.Contains(t, executionLog, "{\"level\":\"warn\",\"type\":\"rule\",\"rule\":\"rule_1\",\"error key\":\"RULE_1\",\"likelihood\":4,\"impact\":4,\"totalRisk\":4,\"message\":\"Report with high impact detected\"}\n")
+	assert.Contains(t, executionLog, fmt.Sprintf("{\"level\":\"warn\",\"type\":\"rule\",\"rule\":\"rule_1\",\"error key\":\"RULE_1\",\"likelihood\":4,\"impact\":4,\"totalRisk\":4,\"message\":\"%s\"}\n", differ.ReportWithHighImpactMessage))
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"cluster\":\"first_cluster\",\"number of events\":1,\"message\":\"Producing instant notification\"}", "processClusters should generate one notification for 'first_cluster' with given data")
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"cluster\":\"second_cluster\",\"number of events\":1,\"message\":\"Producing instant notification\"}", "processClusters should generate one notification for 'first_cluster' with given data")
 
@@ -1210,7 +1210,7 @@ func TestProcessClustersNewIssuesNotPreviouslyNotified(t *testing.T) {
 	d.ProcessClusters(&conf.ConfigStruct{Kafka: conf.KafkaConfiguration{Enabled: true}}, ruleContent, clusters)
 
 	executionLog := buf.String()
-	assert.Contains(t, executionLog, "{\"level\":\"warn\",\"type\":\"rule\",\"rule\":\"rule_1\",\"error key\":\"RULE_1\",\"likelihood\":4,\"impact\":4,\"totalRisk\":4,\"message\":\"Report with high impact detected\"}\n")
+	assert.Contains(t, executionLog, fmt.Sprintf("{\"level\":\"warn\",\"type\":\"rule\",\"rule\":\"rule_1\",\"error key\":\"RULE_1\",\"likelihood\":4,\"impact\":4,\"totalRisk\":4,\"message\":\"%s\"}\n", differ.ReportWithHighImpactMessage))
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"cluster\":\"first_cluster\",\"number of events\":1,\"message\":\"Producing instant notification\"}", "processClusters should generate one notification for 'first_cluster' with given data")
 	assert.Contains(t, executionLog, "{\"level\":\"info\",\"cluster\":\"second_cluster\",\"number of events\":1,\"message\":\"Producing instant notification\"}", "processClusters should generate one notification for 'second_cluster' with given data")
 }

--- a/differ/evaluator_test.go
+++ b/differ/evaluator_test.go
@@ -29,7 +29,7 @@ import (
 // evaluator for default expression used by Notification Service
 func TestEvaluatorDefaultExpression(t *testing.T) {
 	const expression = "totalRisk >= totalRiskThreshold"
-	const totalRiskThreshold = 3
+	const totalRiskThreshold = TotalRiskImportant
 
 	thresholds := EventThresholds{
 		Likelihood: 0,
@@ -42,7 +42,7 @@ func TestEvaluatorDefaultExpression(t *testing.T) {
 		Likelihood: 0,
 		Impact:     0,
 		Severity:   0,
-		TotalRisk:  3,
+		TotalRisk:  TotalRiskImportant,
 	}
 
 	// try all combinations of totalRisk

--- a/differ/export_test.go
+++ b/differ/export_test.go
@@ -54,6 +54,7 @@ var (
 	ServiceLogDescriptionMaxLength = serviceLogDescriptionMaxLength
 	SetServiceLogSeverityMap       = setServiceLogSeverityMap
 	CreateServiceLogEntry          = createServiceLogEntry
+	GetServiceLogSeverity          = getServiceLogSeverity
 )
 
 const (
@@ -67,6 +68,8 @@ const (
 	NotificationStateSame       = notificationStateSame
 	NotificationStateLower      = notificationStateLower
 	NotificationStateError      = notificationStateError
+	ReportWithHighImpactMessage = reportWithHighImpactMessage
+	NoEquivalentSeverityMessage = noEquivalentSeverityMessage
 )
 
 func InClauseFromStringSlice(slice []string) string {

--- a/differ/export_test.go
+++ b/differ/export_test.go
@@ -29,9 +29,10 @@ package differ
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd
 // to see why this trick is needed.
 var (
-	NotificationType  = notificationType
-	NotificationTypes = &notificationTypes
-	States            = &states
+	NotificationType      = notificationType
+	NotificationTypes     = &notificationTypes
+	ServiceLogSeverityMap = &serviceLogSeverityMap
+	States                = &states
 
 	GetAllContentFromMap               = getAllContentFromMap
 	ConvertLogLevel                    = convertLogLevel
@@ -48,6 +49,11 @@ var (
 	GetStates            = getStates
 	GetNotificationType  = getNotificationType
 	GetNotificationTypes = getNotificationTypes
+
+	ServiceLogSummaryMaxLength     = serviceLogSummaryMaxLength
+	ServiceLogDescriptionMaxLength = serviceLogDescriptionMaxLength
+	SetServiceLogSeverityMap       = setServiceLogSeverityMap
+	CreateServiceLogEntry          = createServiceLogEntry
 )
 
 const (

--- a/differ/metrics.go
+++ b/differ/metrics.go
@@ -51,6 +51,7 @@ const (
 	NotificationNotSentSameStateName  = "notification_not_sent_same_state"
 	NotificationNotSentErrorStateName = "notification_not_sent_error_state"
 	NotificationSentName              = "notification_sent"
+	NoSeverityTotalRiskName           = "total_risk_no_severity"
 )
 
 // Metrics helps
@@ -66,6 +67,7 @@ const (
 	NotificationNotSentSameStateHelp  = "The total number of notifications not sent because we parsed the same report"
 	NotificationNotSentErrorStateHelp = "The total number of notifications not sent because of a Kafka producer error"
 	NotificationSentHelp              = "The total number of notifications sent"
+	NoSeverityTotalRiskHelp           = "The total number of times we handled a total risk that does not have an equivalent service log severity level"
 )
 
 // PushGatewayClient is a simple wrapper over http.Client so that prometheus
@@ -159,6 +161,12 @@ var NotificationSent = promauto.NewCounter(prometheus.CounterOpts{
 	Help: NotificationSentHelp,
 })
 
+// NoSeverityTotalRisk shows how many times a total risk not mapped to a service log severity is received
+var NoSeverityTotalRisk = promauto.NewCounter(prometheus.CounterOpts{
+	Name: NoSeverityTotalRiskName,
+	Help: NoSeverityTotalRiskHelp,
+})
+
 // AddMetricsWithNamespaceAndSubsystem register the desired metrics using a given namespace
 func AddMetricsWithNamespaceAndSubsystem(namespace, subsystem string) {
 	// exposed metrics
@@ -174,6 +182,7 @@ func AddMetricsWithNamespaceAndSubsystem(namespace, subsystem string) {
 	prometheus.Unregister(NotificationNotSentSameState)
 	prometheus.Unregister(NotificationNotSentErrorState)
 	prometheus.Unregister(NotificationSent)
+	prometheus.Unregister(NoSeverityTotalRisk)
 
 	// FetchContentErrors shows number of errors during fetch from content service
 	FetchContentErrors = promauto.NewCounter(prometheus.CounterOpts{
@@ -254,6 +263,14 @@ func AddMetricsWithNamespaceAndSubsystem(namespace, subsystem string) {
 		Name:      NotificationSentName,
 		Help:      NotificationSentHelp,
 	})
+
+	// NoSeverityTotalRisk shows  how many times a total risk not mapped to a service log severity is received
+	NoSeverityTotalRisk = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      NoSeverityTotalRiskName,
+		Help:      NoSeverityTotalRiskHelp,
+	})
 }
 
 // PushCollectedMetrics function pushes the metrics to the configured prometheus push
@@ -274,6 +291,7 @@ func PushCollectedMetrics(metricsConf *conf.MetricsConfiguration) error {
 		Collector(NotificationNotSentSameState).
 		Collector(NotificationNotSentErrorState).
 		Collector(NotificationSent).
+		Collector(NoSeverityTotalRisk).
 		Client(&client).
 		Push()
 }

--- a/differ/metrics_test.go
+++ b/differ/metrics_test.go
@@ -54,9 +54,8 @@ func TestAddMetricsWithNamespaceAndSubsystem(t *testing.T) {
 	assert.NotNil(t, differ.NotificationNotSentSameState)
 	assert.NotNil(t, differ.NotificationNotSentErrorState)
 	assert.NotNil(t, differ.NotificationSent)
+	assert.NotNil(t, differ.NoSeverityTotalRisk)
 }
-
-// TODO: TestPushMetrics
 
 func TestPushMetricsGatewayNotFailingWithRetriesThenOk(t *testing.T) {
 	var (

--- a/differ/renderer_test.go
+++ b/differ/renderer_test.go
@@ -103,19 +103,22 @@ func TestRenderReportsForCluster(t *testing.T) {
 
 	reports := types.ReportContent{
 		{
-			Type:     "rule",
-			Module:   "rule_1.report",
-			ErrorKey: "RULE_1",
-			Details:  json.RawMessage("{}"),
+			ReportItem: types.ReportItem{
+				Type:     "rule",
+				Module:   "rule_1.report",
+				ErrorKey: "RULE_1",
+				Details:  json.RawMessage("{}"),
+			},
 		},
 		{
-			Type:     "rule",
-			Module:   "rule_2.report",
-			ErrorKey: "RULE_2",
-			Details:  json.RawMessage("{}"),
+			ReportItem: types.ReportItem{
+				Type:     "rule",
+				Module:   "rule_2.report",
+				ErrorKey: "RULE_2",
+				Details:  json.RawMessage("{}"),
+			},
 		},
 	}
-
 	rendereredReports, err := renderReportsForCluster(&config, "e1a379e4-9ac5-4353-8f82-ad066a734f18", reports, rules)
 	v, _ := json.Marshal(rendereredReports)
 	log.Info().Msg(string(v))

--- a/docs/event_targets.md
+++ b/docs/event_targets.md
@@ -69,6 +69,17 @@ severity. This is an example how log entry could look like:
 }
 ```
 
+The severity field is set using a 1-1 relationship with the calculated total risk
+of the processed issues. The equivalence between our severity levels and the service
+log severity levels is as follows:
+
+```
+Critical - Critical
+Important - Major
+Moderate - Warning
+Low - Info
+```
+
 ### Formats and styles in description field
 
 The description field of logs supports markdown formatting and it is encouraged

--- a/types/types.go
+++ b/types/types.go
@@ -153,7 +153,7 @@ type CliFlags struct {
 }
 
 // ReportContent represents the array of items expected in a report
-type ReportContent []*ReportItem
+type ReportContent []*EvaluatedReportItem
 
 // Report represents report send in a message consumed from any broker
 type Report struct {
@@ -178,6 +178,12 @@ type ReportItem struct {
 	Module   ModuleName      `json:"component"`
 	ErrorKey ErrorKey        `json:"key"`
 	Details  json.RawMessage `json:"details"`
+}
+
+// EvaluatedReportItem represents a report item with additional information after evaluation
+type EvaluatedReportItem struct {
+	ReportItem
+	TotalRisk int
 }
 
 // EventType represents the allowed event types in notification messages


### PR DESCRIPTION
# Description

- Introduce `EvaluatedReportItem` structure to hold the `ReportItem` with additional metadata (calculated total risk, so far)
- Set the severity in the created service log event depending on the calculated total risk. The severity is set to the corresponding critical risk when possible, or to "Info" if we somehow handle an unexpected total risk value.
- Added service-log related UTs

Fixes CCXDEV-11831

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update
- Unit tests (no changes in the code)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
