### PR TITLE
add UT coverage for (d *Differ) SetupFiltersAndThresholds

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -920,11 +920,11 @@ func (d *Differ) close() {
 	log.Info().Msg(separator)
 }
 
-// setupFiltersAndThresholds function setup both techniques that can be used to
+// SetupFiltersAndThresholds function setup both techniques that can be used to
 // filter messages sent to targets (Notification backend and ServiceLog at this moment):
 //  1. filter based on likelihood, impact, severity, and total risk
 //  2. filter based on rule type that's identified by tags
-func (d *Differ) setupFiltersAndThresholds(config *conf.ConfigStruct) {
+func (d *Differ) SetupFiltersAndThresholds(config *conf.ConfigStruct) {
 	kafkaBrokerConfiguration := conf.GetKafkaBrokerConfiguration(config)
 	if kafkaBrokerConfiguration.Enabled {
 		d.Thresholds = EventThresholds{
@@ -1098,7 +1098,7 @@ func New(config *conf.ConfigStruct, storage Storage) *Differ {
 		d.setupServiceLogProducer(config)
 		d.CoolDown = conf.GetServiceLogConfiguration(config).Cooldown
 	}
-	d.setupFiltersAndThresholds(config)
+	d.SetupFiltersAndThresholds(config)
 
 	return &d
 }

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -1446,3 +1446,107 @@ func TestCloseStorage(t *testing.T) {
 	err = differ.CloseStorage(storage)
 	assert.Nil(t, err, "Storage should be closed w/o error")
 }
+
+// TestSetupFiltersAndThresholds_Kafka tests proper configuration of filters and thresholds based on config
+func TestSetupFiltersAndThresholds_Kafka(t *testing.T) {
+	tagsSet := types.MakeSetOfTags([]string{"tag1", "tag2"})
+
+	testConfig := conf.ConfigStruct{
+		Kafka: conf.KafkaConfiguration{
+			Address:             "localhost:9092",
+			Topic:               "platform.notifications.ingress",
+			Enabled:             true,
+			LikelihoodThreshold: 1,
+			ImpactThreshold:     2,
+			SeverityThreshold:   3,
+			TotalRiskThreshold:  4,
+			TagFilterEnabled:    true,
+			TagsSet:             tagsSet,
+		},
+	}
+
+	expectedThresholds := differ.EventThresholds{
+		Likelihood: 1,
+		Impact:     2,
+		Severity:   3,
+		TotalRisk:  4,
+	}
+
+	d := differ.Differ{}
+	d.SetupFiltersAndThresholds(&testConfig)
+
+	assert.Equal(t, d.Thresholds, expectedThresholds)
+	assert.Equal(t, d.Filter, differ.DefaultEventFilter)
+	assert.Equal(t, d.FilterByTag, true)
+	assert.Equal(t, d.TagsSet, tagsSet)
+}
+
+// TestSetupFiltersAndThresholds_Kafka_NonDefaultFilter tests proper configuration of differ event filter
+func TestSetupFiltersAndThresholds_Kafka_NonDefaultFilter(t *testing.T) {
+	const customFilter = "totalRisk >= totalRiskThreshold && likelihood+2 > likelihoodThreshold"
+
+	testConfig := conf.ConfigStruct{
+		Kafka: conf.KafkaConfiguration{
+			Address:     "localhost:9092",
+			Topic:       "platform.notifications.ingress",
+			Enabled:     true,
+			EventFilter: customFilter,
+		},
+	}
+
+	d := differ.Differ{}
+	d.SetupFiltersAndThresholds(&testConfig)
+
+	assert.Equal(t, d.Filter, customFilter)
+}
+
+// TestSetupFiltersAndThresholds_Servicelog tests proper configuration of filters and thresholds based on config
+func TestSetupFiltersAndThresholds_Servicelog(t *testing.T) {
+	tagsSet := types.MakeSetOfTags([]string{"tag1", "tag2"})
+
+	testConfig := conf.ConfigStruct{
+		ServiceLog: conf.ServiceLogConfiguration{
+			URL:                 "localhost:9092",
+			Enabled:             true,
+			LikelihoodThreshold: 1,
+			ImpactThreshold:     2,
+			SeverityThreshold:   3,
+			TotalRiskThreshold:  4,
+			TagFilterEnabled:    true,
+			TagsSet:             tagsSet,
+		},
+	}
+
+	expectedThresholds := differ.EventThresholds{
+		Likelihood: 1,
+		Impact:     2,
+		Severity:   3,
+		TotalRisk:  4,
+	}
+
+	d := differ.Differ{}
+	d.SetupFiltersAndThresholds(&testConfig)
+
+	assert.Equal(t, d.Thresholds, expectedThresholds)
+	assert.Equal(t, d.Filter, differ.DefaultEventFilter)
+	assert.Equal(t, d.FilterByTag, true)
+	assert.Equal(t, d.TagsSet, tagsSet)
+}
+
+// TestSetupFiltersAndThresholds_Servicelog_NonDefaultFilter tests proper configuration of differ event filter
+func TestSetupFiltersAndThresholds_Servicelog_NonDefaultFilter(t *testing.T) {
+	const customFilter = "totalRisk >= totalRiskThreshold && likelihood+2 > likelihoodThreshold"
+
+	testConfig := conf.ConfigStruct{
+		ServiceLog: conf.ServiceLogConfiguration{
+			URL:         "localhost:9092",
+			Enabled:     true,
+			EventFilter: customFilter,
+		},
+	}
+
+	d := differ.Differ{}
+	d.SetupFiltersAndThresholds(&testConfig)
+
+	assert.Equal(t, d.Filter, customFilter)
+}


### PR DESCRIPTION
# Description
whole method except for `os.Exit()` block is now covered

https://issues.redhat.com/browse/CCXDEV-10739

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- Unit tests (no changes in the code)

## Testing steps
`make test`

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
