### PR TITLE
Do not try to push metrics if namespace or auth token are not set

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -751,12 +751,13 @@ func setupNotificationStates(storage Storage) error {
 
 // registerMetrics registers metrics using the provided namespace, if any
 func registerMetrics(metricsConfig *conf.MetricsConfiguration) {
-	if metricsConfig.Namespace != "" {
-		log.Info().Str("namespace", metricsConfig.Namespace).Msg("Setting metrics namespace")
-		AddMetricsWithNamespaceAndSubsystem(
-			metricsConfig.Namespace,
-			metricsConfig.Subsystem)
+	if metricsConfig.Namespace == "" {
+		return
 	}
+	log.Info().Str("namespace", metricsConfig.Namespace).Msg("Setting metrics namespace")
+	AddMetricsWithNamespaceAndSubsystem(
+		metricsConfig.Namespace,
+		metricsConfig.Subsystem)
 }
 
 func closeStorage(storage Storage) error {
@@ -778,6 +779,10 @@ func closeNotifier(notifier producer.Producer) error {
 }
 
 func pushMetrics(metricsConf *conf.MetricsConfiguration) error {
+	if metricsConf.Namespace == "" || metricsConf.GatewayAuthToken == "" {
+		log.Debug().Msg("No metrics configuration detected. Metrics will not be pushed")
+		return nil
+	}
 	err := PushCollectedMetrics(metricsConf)
 	if err != nil {
 		log.Err(err).Msg(metricsPushFailedMessage)

--- a/differ/metrics.go
+++ b/differ/metrics.go
@@ -298,20 +298,22 @@ func PushCollectedMetrics(metricsConf *conf.MetricsConfiguration) error {
 
 // PushMetricsInLoop pushes the metrics in a loop until context is done
 func PushMetricsInLoop(ctx context.Context, metricsConf *conf.MetricsConfiguration) {
-	log.Info().Msgf("Metrics will be pushed in loop each %f seconds", metricsConf.GatewayTimeBetweenPush.Seconds())
+	if metricsConf.Namespace != "" && metricsConf.GatewayAuthToken != "" {
+		log.Info().Msgf("Metrics will be pushed in loop each %f seconds", metricsConf.GatewayTimeBetweenPush.Seconds())
 
-	ticker := time.NewTicker(metricsConf.GatewayTimeBetweenPush)
-	for {
-		select {
-		case <-ticker.C:
-			log.Debug().Msg("Pushing metrics")
-			err := PushCollectedMetrics(metricsConf)
-			if err != nil {
-				log.Error().Err(err).Msg("Error pushing the metrics in loop")
+		ticker := time.NewTicker(metricsConf.GatewayTimeBetweenPush)
+		for {
+			select {
+			case <-ticker.C:
+				log.Debug().Msg("Pushing metrics")
+				err := PushCollectedMetrics(metricsConf)
+				if err != nil {
+					log.Error().Err(err).Msg("Error pushing the metrics in loop")
+				}
+				log.Debug().Msg("Metrics pushed")
+			case <-ctx.Done():
+				return
 			}
-			log.Debug().Msg("Metrics pushed")
-		case <-ctx.Done():
-			return
 		}
 	}
 }


### PR DESCRIPTION
# Description

When metrics are not configured or the authentication token for the push gateway is not set, do not try to push the metrics.

Fixes CCXDEV-12409

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

- Updated corresponding UTs
- CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
