### PR TITLE
Make push-gateway-basic-auth secret optional

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -121,6 +121,7 @@ objects:
               secretKeyRef:
                 key: server
                 name: push-gateway-basic-auth
+                optional: true
           - name: CCX_NOTIFICATION_SERVICE__METRICS__GATEWAY_AUTH_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
# Description

This secret is not set in all the environments we use. Since the service is now prepared to work without `CCX_NOTIFICATION_SERVICE__METRICS__GATEWAY_AUTH_TOKEN` env var, let's mark it as optional so the deployment doesn't fail when the secret does not exist.

Fixes CCXDEV-11428

## Type of change

- New feature (non-breaking change which adds functionality)
- Configuration update

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
