### PR TITLE
Start pushing metrics in loop only if processing is done

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -859,7 +859,6 @@ func (d *Differ) start(config *conf.ConfigStruct) error {
 	if err := setupNotificationTypes(d.Storage); err != nil {
 		return err
 	}
-	go PushMetricsInLoop(context.Background(), &metricsConfiguration)
 
 	clusters, err := d.Storage.ReadClusterList()
 	if err != nil {
@@ -888,6 +887,9 @@ func (d *Differ) start(config *conf.ConfigStruct) error {
 		return err
 	}
 	log.Info().Msg(separator)
+
+	go PushMetricsInLoop(context.Background(), &metricsConfiguration)
+
 	log.Info().Msg("Checking new issues for all new reports")
 	d.ProcessClusters(config, ruleContent, clusters)
 	log.Info().Int(clustersAttribute, entries).Msg("Process Clusters Entries: done")


### PR DESCRIPTION
# Description

It can often be seen in the notification service's logs that metrics start being pushed way before the differ actually starts processing (if there's any processing needed) the data. This small change fixes that

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
