### PR TITLE
Support for multiple broker addresses

### DIFF
--- a/cmd/ccx-notification-service/cli.go
+++ b/cmd/ccx-notification-service/cli.go
@@ -57,7 +57,7 @@ func showConfiguration(config *conf.ConfigStruct) {
 	brokerConfig := conf.GetKafkaBrokerConfiguration(config)
 	log.Info().
 		Bool("Enabled", brokerConfig.Enabled).
-		Str("Address", brokerConfig.Address).
+		Str("Addresses", brokerConfig.Addresses).
 		Str("SecurityProtocol", brokerConfig.SecurityProtocol).
 		Str("SaslMechanism", brokerConfig.SaslMechanism).
 		Str("Topic", brokerConfig.Topic).

--- a/conf/config_benchmark_test.go
+++ b/conf/config_benchmark_test.go
@@ -190,8 +190,8 @@ func BenchmarkGetKafkaBrokerConfiguration(b *testing.B) {
 		m := conf.GetKafkaBrokerConfiguration(&configuration)
 
 		b.StopTimer()
-		if m.Address != "localhost:9092" {
-			b.Fatal("Wrong configuration: address = '" + m.Address + "'")
+		if m.Addresses != "localhost:9092" {
+			b.Fatal("Wrong configuration: address = '" + m.Addresses + "'")
 		}
 		if m.Cooldown != "24 hours" {
 			b.Fatal("Wrong configuration: cooldown = '" + m.Cooldown + "'")

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -117,7 +117,7 @@ func TestLoadBrokerConfiguration(t *testing.T) {
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&config)
 
 	assert.True(t, brokerCfg.Enabled)
-	assert.Equal(t, "localhost:29092", brokerCfg.Address)
+	assert.Equal(t, "localhost:29092", brokerCfg.Addresses)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
 	assert.Equal(t, expectedTimeout, brokerCfg.Timeout)
 	assert.False(t, brokerCfg.TagFilterEnabled)
@@ -373,7 +373,7 @@ func TestLoadClowderConfiguration(t *testing.T) {
 	assert.NoError(t, err, "error loading configuration")
 
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&cfg)
-	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
+	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Addresses)
 }
 
 // TestLoadStorageConfigFromClowder tests loading a clowder config that should overwrite some
@@ -486,7 +486,7 @@ func TestLoadConfigurationNoKafkaBroker(t *testing.T) {
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&config)
 
 	// check broker configuration
-	assert.Equal(t, "localhost:29092", brokerCfg.Address)
+	assert.Equal(t, "localhost:29092", brokerCfg.Addresses)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
 	assert.True(t, brokerCfg.Enabled)
 }
@@ -521,7 +521,7 @@ func TestLoadConfigurationKafkaBrokerEmptyConfig(t *testing.T) {
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&config)
 
 	// check broker configuration
-	assert.Equal(t, "", brokerCfg.Address)
+	assert.Equal(t, "", brokerCfg.Addresses)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
 	assert.True(t, brokerCfg.Enabled)
 }
@@ -558,7 +558,7 @@ func TestLoadConfigurationKafkaBrokerNoPort(t *testing.T) {
 
 	// check broker configuration
 	// no port should be set
-	assert.Equal(t, "test", brokerCfg.Address)
+	assert.Equal(t, "test", brokerCfg.Addresses)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
 	assert.True(t, brokerCfg.Enabled)
 }
@@ -596,7 +596,7 @@ func TestLoadConfigurationKafkaBrokerPort(t *testing.T) {
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&config)
 
 	// check broker configuration
-	assert.Equal(t, "test:1234", brokerCfg.Address)
+	assert.Equal(t, "test:1234", brokerCfg.Addresses)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
 	assert.True(t, brokerCfg.Enabled)
 }
@@ -638,7 +638,7 @@ func TestLoadConfigurationKafkaBrokerAuthConfigMissingSASL(t *testing.T) {
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&config)
 
 	// check broker configuration
-	assert.Equal(t, "test:1234", brokerCfg.Address)
+	assert.Equal(t, "test:1234", brokerCfg.Addresses)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
 	assert.True(t, brokerCfg.Enabled)
 
@@ -697,7 +697,7 @@ func TestLoadConfigurationKafkaBrokerAuthConfig(t *testing.T) {
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&config)
 
 	// check broker configuration
-	assert.Equal(t, "test:1234", brokerCfg.Address)
+	assert.Equal(t, "test:1234", brokerCfg.Addresses)
 	assert.Equal(t, "ccx_test_notifications", brokerCfg.Topic)
 	assert.True(t, brokerCfg.Enabled)
 
@@ -742,7 +742,7 @@ func TestLoadConfigurationKafkaTopicUpdatedFromClowder(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	brokerCfg := conf.GetKafkaBrokerConfiguration(&config)
-	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
+	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Addresses)
 	assert.Equal(t, newTopicName, brokerCfg.Topic)
 
 	// config with different broker configuration, broker's hostname taken from clowder, but no topic to map to
@@ -752,7 +752,7 @@ func TestLoadConfigurationKafkaTopicUpdatedFromClowder(t *testing.T) {
 	assert.NoError(t, err, "Failed loading configuration file")
 
 	brokerCfg = conf.GetKafkaBrokerConfiguration(&config)
-	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Address)
+	assert.Equal(t, fmt.Sprintf("%s:%d", hostname, port), brokerCfg.Addresses)
 	assert.Equal(t, topicName, brokerCfg.Topic)
 }
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -36,7 +36,7 @@ objects:
               cpu: ${CPU_REQUEST}
               memory: ${MEMORY_REQUEST}
           env:
-          - name: CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ADDRESS
+          - name: CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__ADDRESSES
             value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
           - name: CCX_NOTIFICATION_SERVICE__KAFKA_BROKER__TOPIC
             value: ${OUTGOING_TOPIC}

--- a/differ/differ_test.go
+++ b/differ/differ_test.go
@@ -44,7 +44,7 @@ import (
 
 var (
 	brokerCfg = conf.KafkaConfiguration{
-		Address:     "localhost:9092",
+		Addresses:   "localhost:9092",
 		Topic:       "platform.notifications.ingress",
 		Timeout:     time.Duration(30*10 ^ 9),
 		Enabled:     true,
@@ -178,7 +178,7 @@ func TestModuleNameToRuleNameValidRuleName(t *testing.T) {
 func TestSetupNotificationProducerInvalidBrokerConf(t *testing.T) {
 	testConfig := conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
-			Address:     "invalid_address",
+			Addresses:   "invalid_address",
 			Topic:       "",
 			Timeout:     0,
 			Enabled:     true,
@@ -231,10 +231,10 @@ func TestSetupNotificationProducerValidBrokerConf(t *testing.T) {
 
 	testConfig := conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
-			Address: mockBroker.Addr(),
-			Topic:   brokerCfg.Topic,
-			Timeout: brokerCfg.Timeout,
-			Enabled: brokerCfg.Enabled,
+			Addresses: mockBroker.Addr(),
+			Topic:     brokerCfg.Topic,
+			Timeout:   brokerCfg.Timeout,
+			Enabled:   brokerCfg.Enabled,
 		},
 	}
 
@@ -250,7 +250,7 @@ func TestSetupNotificationProducerValidBrokerConf(t *testing.T) {
 
 	producer := d.Notifier.(*kafka.Producer)
 
-	assert.Equal(t, kafkaProducer.Configuration.Address, producer.Configuration.Address)
+	assert.Equal(t, kafkaProducer.Configuration.Addresses, producer.Configuration.Addresses)
 	assert.Equal(t, kafkaProducer.Configuration.Topic, producer.Configuration.Topic)
 	assert.Equal(t, kafkaProducer.Configuration.Timeout, producer.Configuration.Timeout)
 	assert.Nil(t, kafkaProducer.Producer, "Unexpected behavior: Producer was not set up correctly")
@@ -1345,7 +1345,7 @@ func TestSetupFiltersAndThresholds_Kafka(t *testing.T) {
 
 	testConfig := conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
-			Address:             "localhost:9092",
+			Addresses:           "localhost:9092",
 			Topic:               "platform.notifications.ingress",
 			Enabled:             true,
 			LikelihoodThreshold: 1,
@@ -1380,7 +1380,7 @@ func TestSetupFiltersAndThresholds_Kafka_NonDefaultFilter(t *testing.T) {
 
 	testConfig := conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
-			Address:     "localhost:9092",
+			Addresses:   "localhost:9092",
 			Topic:       "platform.notifications.ingress",
 			Enabled:     true,
 			EventFilter: customFilter,

--- a/differ/errors.go
+++ b/differ/errors.go
@@ -37,14 +37,14 @@ func (e *StatusMetricsError) Error() string {
 	return "StatusMetricsError"
 }
 
-// StatusConfiguration is related to any storage error
+// StatusConfiguration is related to any configuration error
 type StatusConfiguration struct{}
 
 func (e *StatusConfiguration) Error() string {
 	return "StatusConfiguration"
 }
 
-// StatusEventFilterError is related to any storage error
+// StatusEventFilterError is related to any notification filters configuration error
 type StatusEventFilterError struct {
 	Msg string
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ Kafka Broker configuration that is used to communicate with Notification backend
 
 ```
 enabled = true
-address = "kafka:29092" #provide in deployment env or as secret
+addresses = "kafka:29092" #provide in deployment env or as secret
 security_protocol = "PLAINTEXT"
 cert_path = "not-set"
 sasl_mechanism = "PLAIN"
@@ -77,7 +77,7 @@ tags = []
 ```
 
 - `enabled` determines whether the notifications service sends messages to Notification backend via Kafka
-- `address` contains address of Kafka broker
+- `addresses` contains a comma separated list of addresses of Kafka brokers; e.g kafka:9093,localhost:9092,kafka_2:9092
 - `topic` contains Kafka topic to be used
 - `security_protocol` is used by client to connect to Kafka broker by using selected protocol
 - `cert_path`, `sasl_mechanism`, `sasl_username` and `sasl_password` are used to connect to Kafka (these options are not needed for local deployment, for example)

--- a/producer/kafka/kafka_producer.go
+++ b/producer/kafka/kafka_producer.go
@@ -51,9 +51,9 @@ func New(config *conf.ConfigStruct) (*Producer, error) {
 		log.Error().Err(err).Msg("Unable to create a valid Kafka configuration")
 	}
 
-	producer, err := sarama.NewSyncProducer([]string{kafkaConfig.Address}, saramaConfig)
+	producer, err := sarama.NewSyncProducer(strings.Split(kafkaConfig.Addresses, ","), saramaConfig)
 	if err != nil {
-		log.Error().Str("Kafka address", kafkaConfig.Address).Err(err).Msg("unable to start a Kafka producer")
+		log.Error().Str("Kafka address", kafkaConfig.Addresses).Err(err).Msg("unable to start a Kafka producer")
 		return nil, err
 	}
 

--- a/producer/kafka/kafka_producer_test.go
+++ b/producer/kafka/kafka_producer_test.go
@@ -36,10 +36,10 @@ import (
 
 var (
 	brokerCfg = conf.KafkaConfiguration{
-		Address: "localhost:9092",
-		Topic:   "platform.notifications.ingress",
-		Timeout: time.Duration(30*10 ^ 9),
-		Enabled: true,
+		Addresses: "localhost:9092",
+		Topic:     "platform.notifications.ingress",
+		Timeout:   time.Duration(30*10 ^ 9),
+		Enabled:   true,
 	}
 )
 
@@ -54,10 +54,10 @@ func TestNewProducerBadBroker(t *testing.T) {
 
 	_, err := New(&conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
-			Address: "",
-			Topic:   "whatever",
-			Timeout: 0,
-			Enabled: true,
+			Addresses: "",
+			Topic:     "whatever",
+			Timeout:   0,
+			Enabled:   true,
 		}})
 	assert.EqualError(t, err, expectedErrorMessage1)
 
@@ -100,9 +100,9 @@ func TestProducerNew(t *testing.T) {
 
 	prod, err := New(&conf.ConfigStruct{
 		Kafka: conf.KafkaConfiguration{
-			Address: mockBroker.Addr(),
-			Topic:   brokerCfg.Topic,
-			Timeout: brokerCfg.Timeout,
+			Addresses: mockBroker.Addr(),
+			Topic:     brokerCfg.Topic,
+			Timeout:   brokerCfg.Timeout,
 		}})
 	helpers.FailOnError(t, err)
 
@@ -114,7 +114,7 @@ func TestProducerNew(t *testing.T) {
 func TestSaramaConfigFromBrokerWithSASLEnabledNoSASLMechanism(t *testing.T) {
 	// valid broker configuration for local Kafka instance
 	var brokerConfiguration = conf.KafkaConfiguration{
-		Address:          "localhost:9092",
+		Addresses:        "localhost:9092",
 		Topic:            "platform.notifications.ingress",
 		Enabled:          true,
 		SecurityProtocol: "SASL_",
@@ -137,7 +137,7 @@ func TestSaramaConfigFromBrokerWithSASLEnabledNoSASLMechanism(t *testing.T) {
 func TestSaramaConfigFromBrokerWithSASLEnabledSCRAMAuth(t *testing.T) {
 	// valid broker configuration for local Kafka instance
 	var brokerConfiguration = conf.KafkaConfiguration{
-		Address:          "localhost:9092",
+		Addresses:        "localhost:9092",
 		Topic:            "platform.notifications.ingress",
 		Enabled:          true,
 		SecurityProtocol: "SASL_",
@@ -160,7 +160,7 @@ func TestSaramaConfigFromBrokerWithSASLEnabledSCRAMAuth(t *testing.T) {
 func TestSaramaConfigFromBrokerWithSASLEnabledUnexpectedAuthMechanism(t *testing.T) {
 	// valid broker configuration for local Kafka instance
 	var brokerConfiguration = conf.KafkaConfiguration{
-		Address:          "localhost:9092",
+		Addresses:        "localhost:9092",
 		Topic:            "platform.notifications.ingress",
 		Enabled:          true,
 		SecurityProtocol: "SASL_",

--- a/tests/benchmark.toml
+++ b/tests/benchmark.toml
@@ -3,7 +3,7 @@ debug = true
 log_level = ""
 
 [kafka_broker]
-address = "localhost:9092"
+addresses = "localhost:9092"
 topic = "test_notification_topic"
 cooldown = "24 hours"
 

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -1,5 +1,5 @@
 [kafka_broker]
-address = "localhost:9092"
+addresses = "localhost:9092"
 topic = "test_notification_topic"
 
 [dependencies]

--- a/tests/config2.toml
+++ b/tests/config2.toml
@@ -1,5 +1,5 @@
 [kafka_broker]
-address = "localhost:29092"
+addresses = "localhost:29092"
 topic = "ccx_test_notifications"
 timeout = "20s"
 enabled = true

--- a/tests/config4.toml
+++ b/tests/config4.toml
@@ -1,5 +1,5 @@
 [kafka_broker]
-address = "localhost:29092"
+addresses = "localhost:29092"
 topic = "ccx_test_notifications"
 timeout = "20s"
 enabled = true

--- a/tests/config5.toml
+++ b/tests/config5.toml
@@ -1,5 +1,5 @@
 [kafka_broker]
-address = "localhost:29092"
+addresses = "localhost:29092"
 topic = "ccx_test_notifications"
 timeout = "20s"
 enabled = true


### PR DESCRIPTION
# Description

This is the simplest change required to support multiple broker addresses (without refactoring common code out of the service and so on).

Now the configuration of the Kafka Broker expects the field `addresses` instead of `address`, and said field is a comma-separated list of broker addresses. For example: `kafka:9092,kafka:9093,localhost:29092`. The list does not have a minimum or maximum number of addresses, so it can be used as before with only one address: `kafka:29092`.

Fixes CCXDEV-12461

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)
- Documentation update
- Configuration update

## Testing steps

- UTs
- BDDs

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
