### PR TITLE
Update go version to 1.20

### DIFF
--- a/.github/workflows/bdd.yaml
+++ b/.github/workflows/bdd.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
+          - "1.20"
     name: BDD for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '1.20'
       - name: Generate docgo and literate
         run: make godoc
       - name: Build with Jekyll

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
-          - "1.19"
           - "1.20"
           - "1.21"
     name: Tests for Go ${{ matrix.go-version}}

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
-          - "1.19"
           - "1.20"
           - "1.21"
     name: Linters for Go ${{ matrix.go-version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/ubi9/go-toolset:1.18.10 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.20 AS builder
 
 COPY . .
 

--- a/build.sh
+++ b/build.sh
@@ -23,5 +23,5 @@ commit=$(git rev-parse HEAD)
 
 cmd_dir=./cmd/ccx-notification-service
 
-go build -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit'" "${cmd_dir}"
+go build -buildvcs=false -ldflags="-X 'main.BuildTime=$buildtime' -X 'main.BuildVersion=$version' -X 'main.BuildBranch=$branch' -X 'main.BuildCommit=$commit'" "${cmd_dir}"
 exit $?

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/ccx-notification-service
 
-go 1.18
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
# Description

Bump Go version to 1.20.

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
