### PR TITLE
[CCXDEV-12685] Update Dockerfile fixing builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ USER 0
 # build the binary
 RUN umask 0022 && \
     make build && \
+    git config --global --add safe.directory /opt/app-root/src && \
     chmod a+x ccx-notification-service
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ USER 0
 
 # build the binary
 RUN umask 0022 && \
-    make build && \
     git config --global --add safe.directory /opt/app-root/src && \
+    make build && \
     chmod a+x ccx-notification-service
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest


### PR DESCRIPTION
# Description

Our builder for ccx-notification-service fails with

```
#10 0.222 fatal: detected dubious ownership in repository at '/opt/app-root/src'
#10 0.222 To add an exception for this directory, call:
#10 0.222
#10 0.222 git config --global --add safe.directory /opt/app-root/src
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
