### PR TITLE
Make push gateway auth secret optional

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -127,6 +127,7 @@ objects:
               secretKeyRef:
                 key: credentials_b64
                 name: push-gateway-basic-auth
+                optional: true
           - name: CCX_NOTIFICATION_SERVICE__METRICS__RETRIES
             value: ${METRICS_PUSH_RETRIES}
           - name: CCX_NOTIFICATION_SERVICE__METRICS__RETRY_AFTER


### PR DESCRIPTION
# Description

The URL env variable was set as optional in clowdapp, but auth secret is not. Making it optional makes the service runnable in ephemeral environment.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

NA

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
