### PR TITLE
[CCXDEV-9710] Make push-gateway-secret optional for service log

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -257,11 +257,13 @@ objects:
               secretKeyRef:
                 key: server
                 name: push-gateway-basic-auth
+                optional: true
           - name: CCX_NOTIFICATION_SERVICE__METRICS__GATEWAY_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
                 key: credentials_b64
                 name: push-gateway-basic-auth
+                optional: true
           - name: CCX_NOTIFICATION_SERVICE__METRICS__RETRIES
             value: ${METRICS_PUSH_RETRIES}
           - name: CCX_NOTIFICATION_SERVICE__METRICS__RETRY_AFTER


### PR DESCRIPTION
# Description

push-gateway-secret is not present in ephemeral environment, so this PR makes it optional. 

## Type of change

- Configuration update

## Testing steps

NA

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
