### PR TITLE
[CCXDEV-10823] Adding Glitchtip confiuration to notification service

### DIFF
--- a/cmd/ccx-notification-service/main.go
+++ b/cmd/ccx-notification-service/main.go
@@ -84,7 +84,7 @@ func main() {
 		log.Err(err).Msg(loadConfigurationMessage)
 		os.Exit(ExitStatusConfiguration)
 	}
-
+	log.Error().Msg("TEST ERROR FOR NOTIFICATION SERVICE")
 	// configuration is loaded, so it would be possible to display it if
 	// asked by user
 	if cliFlags.ShowConfiguration {

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,11 @@
 debug = false
 log_level = "info"
 logging_to_cloud_watch_enabled = false
+logging_to_sentry_enabled = false
+
+[sentry]
+dsn = ""
+environment = "dev"
 
 [kafka_broker]
 enabled = true

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -70,6 +70,8 @@ objects:
             value: ${LOG_LEVEL}
           - name: CCX_NOTIFICATION_SERVICE__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED
             value: ${LOGGING_TO_CLOUD_WATCH_ENABLED}
+          - name: CCX_NOTIFICATION_SERVICE__LOGGING__LOGGING_TO_SENTRY_ENABLED
+            value: ${SENTRY_ENABLED}
           - name: CCX_NOTIFICATION_SERVICE__CLOUDWATCH__DEBUG
             value: ${CLOUDWATCH_DEBUG}
           - name: CCX_NOTIFICATION_SERVICE__CLOUDWATCH__STREAM_NAME
@@ -100,6 +102,14 @@ objects:
                 name: cloudwatch
                 key: aws_secret_access_key
                 optional: true
+          - name: CCX_NOTIFICATION_SERVICE__SENTRY__DSN
+            valueFrom:
+              secretKeyRef:
+                key: dsn
+                name: ccx-notification-service-dsn
+                optional: true
+          - name: CCX_NOTIFICATION_SERVICE__SENTRY__ENVIRONMENT
+            value: ${ENV_NAME}
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_SERVER
             value: http://ccx-insights-content-service:${CONTENT_SERVICE_PORT}/api/v1/
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_ENDPOINT
@@ -204,6 +214,8 @@ objects:
             value: ${LOG_LEVEL}
           - name: CCX_NOTIFICATION_SERVICE__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED
             value: ${LOGGING_TO_CLOUD_WATCH_ENABLED}
+          - name: CCX_NOTIFICATION_SERVICE__LOGGING__LOGGING_TO_SENTRY_ENABLED
+            value: ${SENTRY_ENABLED}
           - name: CCX_NOTIFICATION_SERVICE__CLOUDWATCH__DEBUG
             value: ${CLOUDWATCH_DEBUG}
           - name: CCX_NOTIFICATION_SERVICE__CLOUDWATCH__STREAM_NAME
@@ -234,6 +246,14 @@ objects:
                 name: cloudwatch
                 key: aws_secret_access_key
                 optional: true
+          - name: CCX_NOTIFICATION_SERVICE__SENTRY__DSN
+            valueFrom:
+              secretKeyRef:
+                key: dsn
+                name: ccx-notification-service-dsn
+                optional: true
+          - name: CCX_NOTIFICATION_SERVICE__SENTRY__ENVIRONMENT
+            value: ${ENV_NAME}
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_SERVER
             value: http://ccx-insights-content-service:${CONTENT_SERVICE_PORT}/api/v1/
           - name: CCX_NOTIFICATION_SERVICE__DEPENDENCIES__CONTENT_ENDPOINT
@@ -360,6 +380,9 @@ parameters:
   value: '8 days'
 - description: Domain name and port of the content template renderer API
   name: TEMPLATE_RENDERER_SERVER
+# Sentry
+- name : SENTRY_ENABLED
+  value: "false"
 # Service Log
 - description: URL of the Service Log API
   name: SERVICE_LOG__URL

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -996,6 +996,7 @@ func Run(config conf.ConfigStruct, cliFlags types.CliFlags) int {
 	if cliFlags.InstantReports {
 		notificationType = types.InstantNotif
 	}
+	log.Error().Msg("TEST ERROR FOR NOTIFICATION SERVICE IN DIFFER")
 
 	// prepare the storage
 	storageConfiguration := conf.GetStorageConfiguration(&config)


### PR DESCRIPTION
# Description
Adding configuration for notification service to be able to send error mesages to GlitchTip.

Fixes # [CCXDEV-10823](https://issues.redhat.com/browse/CCXDEV-10823)

## Type of change

- New feature (non-breaking change which adds functionality)
- Configuration update

## Testing steps

Tested locally with config.toml file and also by exporting the env var

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
