### PR TITLE
Handle read_errors table operations more gracefully

### DIFF
--- a/differ/differ.go
+++ b/differ/differ.go
@@ -537,7 +537,9 @@ func (d *Differ) produceEntriesToKafka(cluster types.ClusterEntry, ruleContent t
 }
 
 // checkReadError function checks whether reading from read_errors table was
-// successful
+// successful. This log gives important context as the insertion into the
+// read_error will fail if there's already a row but we couldn't read it for
+// whatever reason.
 func checkReadError(err error) {
 	if err != nil {
 		log.Err(err).Msg("read_errors read access error")

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -581,6 +581,11 @@ func (d *Differ) processReportsByCluster(config *conf.ConfigStruct, ruleContent 
 
 			// if the error is reported already, skip to next one
 			if reportedAlready {
+				log.Debug().
+					Int(organizationIDAttribute, int(cluster.OrgID)).
+					Str(clusterAttribute, string(cluster.ClusterName)).
+					Time("since", time.Time(cluster.UpdatedAt)).
+					Msg("Read error already exists")
 				continue
 			}
 			// if not reported, process the error

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -576,7 +576,7 @@ func (d *Differ) processReportsByCluster(config *conf.ConfigStruct, ruleContent 
 		report, err := d.Storage.ReadReportForClusterAtTime(cluster.OrgID, cluster.ClusterName, cluster.UpdatedAt)
 		if err != nil {
 			// is the problem reported already?
-			reportedAlready, readErr := d.Storage.ReadErrorExists(cluster.OrgID, cluster.ClusterName, time.Time(cluster.UpdatedAt))
+			reportedAlready, readErr := d.Storage.ReadErrorExists(cluster.OrgID, cluster.ClusterName, cluster.UpdatedAt)
 			checkReadError(readErr)
 
 			// if the error is reported already, skip to next one

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -93,7 +93,7 @@ type Storage interface {
 	ReadErrorExists(
 		orgID types.OrgID,
 		clusterName types.ClusterName,
-		lastCheckedTime time.Time,
+		updatedAt types.Timestamp,
 	) (bool, error)
 	WriteReadError(
 		orgID types.OrgID,
@@ -557,10 +557,10 @@ func (storage DBStorage) WriteNotificationRecordForCluster(
 func (storage DBStorage) ReadErrorExists(
 	orgID types.OrgID,
 	clusterName types.ClusterName,
-	lastCheckedTime time.Time,
+	updatedAt types.Timestamp,
 ) (bool, error) {
 	// perform query
-	rows, err := storage.connection.Query(QueryRecordExistsInReadErrors, orgID, clusterName, lastCheckedTime)
+	rows, err := storage.connection.Query(QueryRecordExistsInReadErrors, orgID, clusterName, time.Time(updatedAt))
 
 	// check for any error during query
 	if err != nil {

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -564,6 +564,10 @@ func (storage DBStorage) ReadErrorExists(
 
 	// check for any error during query
 	if err != nil {
+		// errNoRows is expected
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -270,7 +270,7 @@ func TestReadErrorExistPositiveResult(t *testing.T) {
 	storage := differ.NewFromConnection(connection, 1)
 
 	// call the tested method
-	exists, err := storage.ReadErrorExists(1, "123", time.Now())
+	exists, err := storage.ReadErrorExists(1, "123", types.Timestamp(time.Now()))
 	assert.NoError(t, err, "error was not expected while querying read_errors table")
 
 	assert.True(t, exists, "True return value is expected")
@@ -302,7 +302,7 @@ func TestReadErrorExistNegativeResult(t *testing.T) {
 	storage := differ.NewFromConnection(connection, 1)
 
 	// call the tested method
-	exists, err := storage.ReadErrorExists(1, "123", time.Now())
+	exists, err := storage.ReadErrorExists(1, "123", types.Timestamp(time.Now()))
 	assert.NoError(t, err, "error was not expected while querying read_errors table")
 
 	assert.False(t, exists, "False return value is expected")
@@ -333,7 +333,7 @@ func TestReadErrorExistNothingFound(t *testing.T) {
 	storage := differ.NewFromConnection(connection, 1)
 
 	// call the tested method
-	exists, err := storage.ReadErrorExists(1, "123", time.Now())
+	exists, err := storage.ReadErrorExists(1, "123", types.Timestamp(time.Now()))
 
 	// error is expected to be returned from called method
 	assert.Error(t, err, "error was expected while querying read_errors table")
@@ -367,7 +367,7 @@ func TestReadErrorOnScanError(t *testing.T) {
 	storage := differ.NewFromConnection(connection, 1)
 
 	// call the tested method
-	_, err := storage.ReadErrorExists(1, "123", time.Now())
+	_, err := storage.ReadErrorExists(1, "123", types.Timestamp(time.Now()))
 
 	// error is expected to be returned from called method
 	assert.Error(t, err, "an error is expected while scanning read_errors table")
@@ -399,7 +399,7 @@ func TestReadErrorOnError(t *testing.T) {
 	storage := differ.NewFromConnection(connection, 1)
 
 	// call the tested method
-	_, err := storage.ReadErrorExists(1, "123", time.Now())
+	_, err := storage.ReadErrorExists(1, "123", types.Timestamp(time.Now()))
 
 	// error is expected to be returned from called method
 	assert.Error(t, err, "an error is expected while querying read_errors table")

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -356,7 +356,7 @@ func (_m *Storage) WriteReadError(
 func (_m *Storage) ReadErrorExists(
 	orgID types.OrgID,
 	clusterName types.ClusterName,
-	lastCheckedTime time.Time,
+	updatedAt types.Timestamp,
 ) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
# Description

- Reduce the number of errors generated when handling the `read_errors` table by handling errors better
- Refactor a little bit the naming used in the function's arguments

Fixes CCXDEV-12913

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

- Added UTs -> CI
- Stage -> I want to see if the error message stops being produced with our current testing data

## Checklist

* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
