### PR TITLE
Update Go version and runner image

### DIFF
--- a/.github/workflows/bdd.yaml
+++ b/.github/workflows/bdd.yaml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   bdd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         go-version:
-          - "1.20"
+          - "1.22"
     name: BDD for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   gotests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         go-version:
-          - "1.20"
-          - "1.21"
+          - "1.22"
+          - "1.23"
     name: Tests for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.20"
-          - "1.21"
+          - "1.22"
+          - "1.23"
     name: Linters for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Shell check

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020, 2021 Red Hat, Inc
+# Copyright 2020, 2021, 2025 Red Hat, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,11 @@ echo -e "${BLUE}Finding functions and methods with high cyclomatic complexity${N
 if ! [ -x "$(command -v gocyclo)" ]
 then
     echo -e "${BLUE}Installing gocyclo${NC}"
-    GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
+    if ! go install github.com/fzipp/gocyclo/cmd/gocyclo@latest; then
+        echo -e "${RED_BG}[FAIL]${NC} Cannot install gocyclo"
+        exit 1
+    fi
+    echo -e "${BLUE}Installed ${NC}"
 fi
 
 if ! gocyclo -over 10 -avg .

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC2317
+
 # --------------------------------------------
 # Options that must be configured by app owner
 # --------------------------------------------


### PR DESCRIPTION
# Description

Update CI to use most recent Go versions, as the base image used for building the ccx-notification-service is already using Go 1.22.

Updated runner image to ubuntu-24.04 because 20.04 is already deprecated.

## Type of change
- Bump-up dependent library (no changes in the code)

## Testing steps

CI configuration update, to be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
