### PR TITLE
Remove toolchain directive from go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/RedHatInsights/ccx-notification-service
 
 go 1.24.0
 
-toolchain go1.24.6
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
# Description

Remove toolchain directive from go.mod file

The directive is misleading as it is being autoupdated by MintMaker but the version used in the one in the ubi image

## Type of change

- Configuration update

## Testing steps


## Checklist
* [ ] `make before-commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
