### PR TITLE
Reduce log level to WARN to avoid duplicate Glitchtip issues

### DIFF
--- a/differ/comparator.go
+++ b/differ/comparator.go
@@ -116,7 +116,7 @@ func updateNotificationRecordSentState(storage Storage, cluster types.ClusterEnt
 }
 
 func updateNotificationRecordErrorState(storage Storage, err error, cluster types.ClusterEntry, report types.ClusterReport, notifiedAt types.Timestamp, eventTarget types.EventTarget) {
-	log.Error().Err(err).Str(clusterStr, string(cluster.ClusterName)).Msg("New issues couldn't be notified")
+	log.Warn().Err(err).Str(clusterStr, string(cluster.ClusterName)).Msg("New issues couldn't be notified")
 	NotificationNotSentErrorState.Inc()
 	err = storage.WriteNotificationRecordForCluster(cluster, notificationTypes.Instant, states.ErrorState, report, notifiedAt, err.Error(), eventTarget)
 	if err != nil {

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -422,7 +422,8 @@ func (d *Differ) ProduceEntriesToServiceLog(configuration *conf.ConfigStruct, cl
 			reportsToRender, rules)
 
 		if err != nil {
-			log.Err(err).
+			log.Warn().
+				Err(err).
 				Str("cluster name", string(cluster.ClusterName)).
 				Msg(renderReportsFailedMessage)
 			return totalMessages, err


### PR DESCRIPTION
# Description

Reduce log level in code to avoid Glitchtip duplicates (specifically [CCXDEV-15681](https://issues.redhat.com/browse/CCXDEV-15681), [CCXDEV-15682](https://issues.redhat.com/browse/CCXDEV-15682) and [CCXDEV-15683](https://issues.redhat.com/browse/CCXDEV-15683)). The error level is kept near the source (when template renderer request fails).

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

NA

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
