### PR TITLE
config: store less jobs in history

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -24,8 +24,8 @@ objects:
         concurrencyPolicy: Forbid
         activeDeadlineSeconds: ${{JOB_DEADLINE__NOTIFICATION_BACKEND}}
         suspend: ${{SUSPEND_JOB__NOTIFICATION_BACKEND}}
-        successfulJobsHistoryLimit: 60
-        failedJobsHistoryLimit: 60
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           resources:


### PR DESCRIPTION
# Description

There's an [alert](https://redhat-internal.slack.com/archives/C013UJ5H3LP/p1767086744604439) triggering because of some old errored pods stored in the kubernetes history. There's no need to keep 60 jobs in there, so let's decrease it to 3, not only to avoid the alert but also to use less storage.

## Type of change

- Configuration update

## Testing steps



## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
