### PR TITLE
[CCXDEV-15516] Add CI for checking Go version sync

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -1,0 +1,25 @@
+name: Check Go Version Consistency
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  check-versions:
+    name: Verify Go versions are in sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install skopeo
+        run: sudo apt-get update && sudo apt-get install -y skopeo
+
+      - name: Check Go version consistency
+        run: ./scripts/check_go_versions.sh
+
+      - name: Report status
+        if: failure()
+        run: |
+          echo "::error::Go version mismatch detected. Please sync versions in go.mod, Dockerfile, and gotests.yaml."

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -8,18 +8,13 @@ on:
 jobs:
   gotests:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go-version:
-          - "1.23"
-          - "1.24"
-    name: Tests for Go ${{ matrix.go-version}}
+    name: Go tests
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.25"
       - name: Unit tests
         run: env
       - name: Retrieve code coverage

--- a/scripts/check_go_versions.sh
+++ b/scripts/check_go_versions.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+echo "Checking Go version consistency across files..."
+echo ""
+
+# Extract Docker image name from Dockerfile
+DOCKER_IMAGE=$(grep 'FROM registry.access.redhat.com/ubi9/go-toolset:' Dockerfile | head -n 1 | sed -E 's/.*FROM ([^ ]+).*/\1/')
+
+if [ -z "$DOCKER_IMAGE" ]; then
+    echo "ERROR: Could not extract Docker image from Dockerfile"
+    exit 1
+fi
+
+echo "INFO: Inspecting Docker image: $DOCKER_IMAGE"
+
+# Use skopeo to inspect the image and extract Go version from labels
+DOCKER_MAJOR_MINOR=$(skopeo inspect docker://$DOCKER_IMAGE | jq -r '.Labels.version_major_minor // empty')
+
+if [ -z "$DOCKER_MAJOR_MINOR" ]; then
+    echo "ERROR: Could not extract Go version from Docker image"
+    exit 1
+fi
+
+echo "INFO: Dockerfile: $DOCKER_MAJOR_MINOR"
+
+# Extract Go version from gotests workflow
+GOTESTS_VERSION=$(grep 'go-version:' .github/workflows/gotests.yaml | sed -E 's/.*go-version:\s*"?([0-9]+\.[0-9]+)"?.*/\1/')
+echo "INFO: gotests.yaml: $GOTESTS_VERSION"
+
+# Extract major.minor version from gotests (e.g., 1.24 from 1.24.0)
+GOTESTS_MAJOR_MINOR=$(echo "$GOTESTS_VERSION" | cut -d. -f1,2)
+
+echo ""
+echo "Comparing major.minor versions:"
+echo "  Dockerfile:   $DOCKER_MAJOR_MINOR"
+echo "  gotests.yaml: $GOTESTS_MAJOR_MINOR (from $GOTESTS_VERSION)"
+
+# Compare major.minor versions only
+if [ "$DOCKER_MAJOR_MINOR" != "$GOTESTS_MAJOR_MINOR" ]; then
+    echo ""
+    echo "ERROR: Go version mismatch between Dockerfile and gotests.yaml!"
+    echo "  Dockerfile:   $DOCKER_MAJOR_MINOR"
+    echo "  gotests.yaml: $GOTESTS_MAJOR_MINOR (from $GOTESTS_VERSION)"
+    echo ""
+    echo "Please ensure Go major.minor versions are synchronized."
+    exit 1
+fi
+
+echo ""
+echo "SUCCESS: Go major.minor versions are in sync ($DOCKER_MAJOR_MINOR)"
+echo "  Dockerfile:   $DOCKER_MAJOR_MINOR"
+echo "  gotests.yaml: $GOTESTS_MAJOR_MINOR (from $GOTESTS_VERSION)"


### PR DESCRIPTION
# Description

Add a CI job that checks Go version sync between Dockerfile, go.mod and .github/workflows/gotests.yml files.

## Type of change

- Configuration update

## Testing steps

CI script has been tested locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
