### PR TITLE
add `CLAUDE.md` referencing `AGENTS.md`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
# Description
Claude Code doesn't load `AGENTS.md` by default, which is fine if you're working interactively (once it realizes it needs context, it tries to look for the `AGENTS.md` too), but the subagents might not encounter this scenario, so there's a chance they'll work blind.

This is the simplest way to force the subagents to always load CLAUDE.md/AGENTS.md. We can later think of a more generic solution, but this one is the simplest and least ambiguous.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps
Inspected subagent internals and verified it doesn't need to explore anymore

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
