### PR TITLE
add prerequisite Claude settings to allow dynamic workflows to run 

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,66 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(rm -rf *)",
+      "Bash(rm -fr *)"
+    ],
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+
+      "mcp__atlassian__getJiraIssue",
+
+      "Bash(make *)",
+      "Bash(go *)",
+      "Bash(git diff*)",
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git rev-parse*)",
+      "Bash(git branch*)",
+      "Bash(git show*)",
+      
+      "Bash(./ccx-notification-service *)"
+    ]
+  },
+  "sandbox": {
+    "enabled": false,
+    "autoAllow": true,
+    "failIfUnavailable": false,
+    "allowUnsandboxedCommands": false,
+    "filesystem": {
+      "allowWrite": [
+        "~/go",
+        "~/.cache"
+      ],
+      "denyRead": [
+        "~/.ssh",
+        "~/.gnupg",
+        "~/.aws",
+        "~/.config/gh",
+        "~/.git-credentials"
+      ]
+    },
+    "credentials": {
+      "envVars": [
+        { "name": "GITHUB_TOKEN", "mode": "deny" },
+        { "name": "GH_TOKEN", "mode": "deny" },
+        { "name": "GITLAB_TOKEN", "mode": "deny" },
+        { "name": "AWS_ACCESS_KEY_ID", "mode": "deny" },
+        { "name": "AWS_SECRET_ACCESS_KEY", "mode": "deny" },
+        { "name": "SSH_AUTH_SOCK", "mode": "deny" },
+        { "name": "KUBECONFIG", "mode": "deny" }
+      ]
+    },
+    "network": {
+      "allowedDomains": [
+        "proxy.golang.org",
+        "sum.golang.org",
+        "storage.googleapis.com",
+        "github.com",
+        "objects.githubusercontent.com"
+      ]
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,21 +10,17 @@
 
       "mcp__atlassian__getJiraIssue",
 
-      "Bash(make *)",
-      "Bash(go *)",
       "Bash(git diff*)",
       "Bash(git status*)",
       "Bash(git log*)",
       "Bash(git rev-parse*)",
       "Bash(git branch*)",
-      "Bash(git show*)",
-
-      "Bash(./ccx-notification-service *)"
+      "Bash(git show*)"
     ]
   },
   "sandbox": {
     "enabled": false,
-    "autoAllow": true,
+    "autoAllowBashIfSandboxed": true,
     "failIfUnavailable": false,
     "allowUnsandboxedCommands": false,
     "filesystem": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,7 @@
 {
   "permissions": {
     "deny": [
-      "Bash(sudo *)",
-      "Bash(rm -rf *)",
-      "Bash(rm -fr *)"
+      "Bash(sudo *)"
     ],
     "allow": [
       "Read",
@@ -20,7 +18,7 @@
       "Bash(git rev-parse*)",
       "Bash(git branch*)",
       "Bash(git show*)",
-      
+
       "Bash(./ccx-notification-service *)"
     ]
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 @AGENTS.md
+
+## Workflow policy
+
+When a workflow fails (e.g., `/go-implement` failing because the sandbox is not enabled), report the error and tell the user how to fix it. Do not fall back to doing the work yourself.


### PR DESCRIPTION
# Description
The dynamic workflow for Go implementation is going to come in following PRs, just making it easier to review by splitting it.

- add instructions for Claude to not  take over the work if a dynamic workflow fails (tested on several failing states and it seems to work well). Without this, Claude often said something like "it's a simple change, let me do it myself", ignoring the failing workflow
- add Claude `settings.json` with some basic allow/deny permissions to make it easier for agents
  - the allow/deny permissions are by no means exhaustive or attempting to make it safe, they're also mere suggestions, they're not actually 100% enforced by Claude (that's where the Sandbox comes in)
- adding a Sandbox to the Claude `settings.json`. Sandboxes and their permissions are **enforced on the OS level**, you can read up on them more: [Claude docs](https://code.claude.com/docs/en/sandbox-environments#sandboxed-bash-tool)
  - `autoAllowBashIfSandboxed` allows Bash commands to run in a sandbox. This allows the agents to run `make`, `go`, and any other commands. They're still affected by the following restrictions.
  - `allowWrite` the Sandbox allows the agent to work with Go modules by allowing it to write to the default `~/go` and `~/.cache` paths without having to ask for permissions
  - `denyRead` these paths are completely denied. Again, not exhaustive, not meant to be a total safeguard, just a few critical/obvious paths are included
  - `credentials` section strips these env vars from the Sandbox. Just stripping the most obvious / dangerous ones (recent npm supply chain attack was caused by a leaked Github token)
  - `network.allowedDomains`  the agent can only make requests to the following domains, giving a slight protection against the agents running wild and making requests to random URLs.

The sandbox is disabled by default because it's quite restrictive, but the dynamic workflow (coming in following PR) will refuse to run unless the Sandbox is enabled, because the dynamic workflows are more autonomous than regular interactive Claude sessions.

I'll keep improving these when running the workflow on more complex tasks.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps
tested all of these while running the dynamic workflows

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
