### PR TITLE
[CCXDEV-16560] Register `--ignore-disabled-rules` CLI flag

### DIFF
--- a/cmd/ccx-notification-service/cli.go
+++ b/cmd/ccx-notification-service/cli.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2024, 2025, 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -42,6 +58,7 @@ func setupCliFlags() types.CliFlags {
 	flag.BoolVar(&cliFlags.PerformOldReportsCleanup, "old-reports-cleanup", false, "perform old reports clean up")
 	flag.BoolVar(&cliFlags.CleanupOnStartup, "cleanup-on-startup", false, "perform database clean up on startup")
 	flag.BoolVar(&cliFlags.Verbose, "verbose", false, "verbose logs")
+	flag.BoolVar(&cliFlags.IgnoreDisabledRules, "ignore-disabled-rules", false, "skip disabled rules check, process all rules as if none are disabled")
 	flag.StringVar(&cliFlags.MaxAge, "max-age", "", "max age for displaying/cleaning old records")
 	flag.Parse()
 	return cliFlags

--- a/cmd/ccx-notification-service/cli_test.go
+++ b/cmd/ccx-notification-service/cli_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright © 2024, 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+TestSetupCliFlagsIgnoreDisabledRulesRegistered checks that the
+
+	--ignore-disabled-rules flag is registered and its default value is
+	false.
+*/
+func TestSetupCliFlagsIgnoreDisabledRulesRegistered(t *testing.T) {
+	// Reset global flag.CommandLine so that setupCliFlags can register
+	// flags cleanly without conflicting with previously registered flags
+	// or real os.Args.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+	cliFlags := setupCliFlags()
+	assert.False(t, cliFlags.IgnoreDisabledRules,
+		"IgnoreDisabledRules should default to false")
+}
+
+/*
+TestSetupCliFlagsIgnoreDisabledRulesSetTrue checks that passing
+
+	--ignore-disabled-rules on the command line sets the flag to true.
+*/
+func TestSetupCliFlagsIgnoreDisabledRulesSetTrue(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+	// Temporarily override os.Args to include the flag
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"cmd", "--ignore-disabled-rules"}
+
+	cliFlags := setupCliFlags()
+	assert.True(t, cliFlags.IgnoreDisabledRules,
+		"IgnoreDisabledRules should be true when --ignore-disabled-rules is passed")
+}
+
+/*
+TestSetupCliFlagsIgnoreDisabledRulesDescription checks that the
+
+	--ignore-disabled-rules flag has the expected usage description.
+*/
+func TestSetupCliFlagsIgnoreDisabledRulesDescription(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"cmd"}
+
+	setupCliFlags()
+
+	f := flag.CommandLine.Lookup("ignore-disabled-rules")
+	require.NotNil(t, f, "Flag --ignore-disabled-rules should be registered")
+	assert.Equal(t,
+		"skip disabled rules check, process all rules as if none are disabled",
+		f.Usage,
+		"Flag description should match the spec")
+}
+
+/*
+TestSetupCliFlagsIgnoreDisabledRulesVisibleInHelp checks that the
+
+	--ignore-disabled-rules flag is visible when iterating over all
+	registered flags (as --help does).
+*/
+func TestSetupCliFlagsIgnoreDisabledRulesVisibleInHelp(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"cmd"}
+
+	setupCliFlags()
+
+	found := false
+	flag.CommandLine.VisitAll(func(f *flag.Flag) {
+		if f.Name == "ignore-disabled-rules" {
+			found = true
+		}
+	})
+	assert.True(t, found,
+		"--ignore-disabled-rules should be visible in --help output (registered flags)")
+}
+
+/*
+TestSetupCliFlagsAllExistingFlagsStillRegistered checks that adding
+
+	the new flag did not remove any previously existing flags.
+*/
+func TestSetupCliFlagsAllExistingFlagsStillRegistered(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"cmd"}
+
+	setupCliFlags()
+
+	expectedFlags := []string{
+		"instant-reports",
+		"show-version",
+		"show-authors",
+		"show-configuration",
+		"print-new-reports-for-cleanup",
+		"new-reports-cleanup",
+		"print-old-reports-for-cleanup",
+		"old-reports-cleanup",
+		"cleanup-on-startup",
+		"verbose",
+		"ignore-disabled-rules",
+		"max-age",
+	}
+
+	for _, name := range expectedFlags {
+		f := flag.CommandLine.Lookup(name)
+		assert.NotNilf(t, f, "Flag --%s should be registered", name)
+	}
+}
+
+/*
+TestSetupCliFlagsIgnoreDisabledRulesDefaultFalseExplicit checks that
+
+	explicitly passing --ignore-disabled-rules=false keeps the value false.
+*/
+func TestSetupCliFlagsIgnoreDisabledRulesDefaultFalseExplicit(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"cmd", "--ignore-disabled-rules=false"}
+
+	cliFlags := setupCliFlags()
+	assert.False(t, cliFlags.IgnoreDisabledRules,
+		"IgnoreDisabledRules should be false when --ignore-disabled-rules=false is passed")
+}

--- a/cmd/ccx-notification-service/cli_test.go
+++ b/cmd/ccx-notification-service/cli_test.go
@@ -25,12 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-/*
-TestSetupCliFlagsIgnoreDisabledRulesRegistered checks that the
-
-	--ignore-disabled-rules flag is registered and its default value is
-	false.
-*/
+// TestSetupCliFlagsIgnoreDisabledRulesRegistered checks that the
+// --ignore-disabled-rules flag is registered and its default value is
+// false.
 func TestSetupCliFlagsIgnoreDisabledRulesRegistered(t *testing.T) {
 	// Reset global flag.CommandLine so that setupCliFlags can register
 	// flags cleanly without conflicting with previously registered flags
@@ -42,11 +39,8 @@ func TestSetupCliFlagsIgnoreDisabledRulesRegistered(t *testing.T) {
 		"IgnoreDisabledRules should default to false")
 }
 
-/*
-TestSetupCliFlagsIgnoreDisabledRulesSetTrue checks that passing
-
-	--ignore-disabled-rules on the command line sets the flag to true.
-*/
+// TestSetupCliFlagsIgnoreDisabledRulesSetTrue checks that passing
+// --ignore-disabled-rules on the command line sets the flag to true.
 func TestSetupCliFlagsIgnoreDisabledRulesSetTrue(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
@@ -60,11 +54,8 @@ func TestSetupCliFlagsIgnoreDisabledRulesSetTrue(t *testing.T) {
 		"IgnoreDisabledRules should be true when --ignore-disabled-rules is passed")
 }
 
-/*
-TestSetupCliFlagsIgnoreDisabledRulesDescription checks that the
-
-	--ignore-disabled-rules flag has the expected usage description.
-*/
+// TestSetupCliFlagsIgnoreDisabledRulesDescription checks that the
+// --ignore-disabled-rules flag has the expected usage description.
 func TestSetupCliFlagsIgnoreDisabledRulesDescription(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
@@ -82,12 +73,9 @@ func TestSetupCliFlagsIgnoreDisabledRulesDescription(t *testing.T) {
 		"Flag description should match the spec")
 }
 
-/*
-TestSetupCliFlagsIgnoreDisabledRulesVisibleInHelp checks that the
-
-	--ignore-disabled-rules flag is visible when iterating over all
-	registered flags (as --help does).
-*/
+// TestSetupCliFlagsIgnoreDisabledRulesVisibleInHelp checks that the
+// --ignore-disabled-rules flag is visible when iterating over all
+// registered flags (as --help does).
 func TestSetupCliFlagsIgnoreDisabledRulesVisibleInHelp(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
@@ -107,11 +95,8 @@ func TestSetupCliFlagsIgnoreDisabledRulesVisibleInHelp(t *testing.T) {
 		"--ignore-disabled-rules should be visible in --help output (registered flags)")
 }
 
-/*
-TestSetupCliFlagsAllExistingFlagsStillRegistered checks that adding
-
-	the new flag did not remove any previously existing flags.
-*/
+// TestSetupCliFlagsAllExistingFlagsStillRegistered checks that adding
+// the new flag did not remove any previously existing flags.
 func TestSetupCliFlagsAllExistingFlagsStillRegistered(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
@@ -142,11 +127,8 @@ func TestSetupCliFlagsAllExistingFlagsStillRegistered(t *testing.T) {
 	}
 }
 
-/*
-TestSetupCliFlagsIgnoreDisabledRulesDefaultFalseExplicit checks that
-
-	explicitly passing --ignore-disabled-rules=false keeps the value false.
-*/
+// TestSetupCliFlagsIgnoreDisabledRulesDefaultFalseExplicit checks that
+// explicitly passing --ignore-disabled-rules=false keeps the value false.
 func TestSetupCliFlagsIgnoreDisabledRulesDefaultFalseExplicit(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 

--- a/types/cli_flags_test.go
+++ b/types/cli_flags_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024, 2025 Red Hat, Inc
+// Copyright 2024, 2025, 2026 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,24 +21,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-/*
-TestCliFlagsIgnoreDisabledRulesDefaultValue checks that the default value
-
-	of IgnoreDisabledRules in a zero-value CliFlags is false, matching the
-	spec requirement that the flag defaults to false.
-*/
+// TestCliFlagsIgnoreDisabledRulesDefaultValue checks that the default value
+// of IgnoreDisabledRules in a zero-value CliFlags is false, matching the
+// spec requirement that the flag defaults to false.
 func TestCliFlagsIgnoreDisabledRulesDefaultValue(t *testing.T) {
 	var cliFlags types.CliFlags
 	assert.False(t, cliFlags.IgnoreDisabledRules,
 		"IgnoreDisabledRules should default to false when CliFlags is zero-initialized")
 }
 
-/*
-TestCliFlagsIgnoreDisabledRulesCanBeEnabled checks that IgnoreDisabledRules
-
-	can be set to true, as required when the flag is passed on the command
-	line.
-*/
+// TestCliFlagsIgnoreDisabledRulesCanBeEnabled checks that IgnoreDisabledRules
+// can be set to true, as required when the flag is passed on the command
+// line.
 func TestCliFlagsIgnoreDisabledRulesCanBeEnabled(t *testing.T) {
 	cliFlags := types.CliFlags{
 		IgnoreDisabledRules: true,
@@ -47,11 +41,8 @@ func TestCliFlagsIgnoreDisabledRulesCanBeEnabled(t *testing.T) {
 		"IgnoreDisabledRules should be true when explicitly set")
 }
 
-/*
-TestCliFlagsIgnoreDisabledRulesDoesNotAffectOtherFlags checks that
-
-	setting IgnoreDisabledRules does not interfere with other CLI flags.
-*/
+// TestCliFlagsIgnoreDisabledRulesDoesNotAffectOtherFlags checks that
+// setting IgnoreDisabledRules does not interfere with other CLI flags.
 func TestCliFlagsIgnoreDisabledRulesDoesNotAffectOtherFlags(t *testing.T) {
 	cliFlags := types.CliFlags{
 		InstantReports:      true,

--- a/types/cli_flags_test.go
+++ b/types/cli_flags_test.go
@@ -1,0 +1,73 @@
+// Copyright 2024, 2025 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/ccx-notification-service/types"
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+TestCliFlagsIgnoreDisabledRulesDefaultValue checks that the default value
+
+	of IgnoreDisabledRules in a zero-value CliFlags is false, matching the
+	spec requirement that the flag defaults to false.
+*/
+func TestCliFlagsIgnoreDisabledRulesDefaultValue(t *testing.T) {
+	var cliFlags types.CliFlags
+	assert.False(t, cliFlags.IgnoreDisabledRules,
+		"IgnoreDisabledRules should default to false when CliFlags is zero-initialized")
+}
+
+/*
+TestCliFlagsIgnoreDisabledRulesCanBeEnabled checks that IgnoreDisabledRules
+
+	can be set to true, as required when the flag is passed on the command
+	line.
+*/
+func TestCliFlagsIgnoreDisabledRulesCanBeEnabled(t *testing.T) {
+	cliFlags := types.CliFlags{
+		IgnoreDisabledRules: true,
+	}
+	assert.True(t, cliFlags.IgnoreDisabledRules,
+		"IgnoreDisabledRules should be true when explicitly set")
+}
+
+/*
+TestCliFlagsIgnoreDisabledRulesDoesNotAffectOtherFlags checks that
+
+	setting IgnoreDisabledRules does not interfere with other CLI flags.
+*/
+func TestCliFlagsIgnoreDisabledRulesDoesNotAffectOtherFlags(t *testing.T) {
+	cliFlags := types.CliFlags{
+		InstantReports:      true,
+		Verbose:             true,
+		IgnoreDisabledRules: true,
+	}
+	assert.True(t, cliFlags.InstantReports,
+		"InstantReports should remain true")
+	assert.True(t, cliFlags.Verbose,
+		"Verbose should remain true")
+	assert.True(t, cliFlags.IgnoreDisabledRules,
+		"IgnoreDisabledRules should be true")
+	assert.False(t, cliFlags.ShowVersion,
+		"ShowVersion should remain false (default)")
+	assert.False(t, cliFlags.CleanupOnStartup,
+		"CleanupOnStartup should remain false (default)")
+	assert.Equal(t, "", cliFlags.MaxAge,
+		"MaxAge should remain empty (default)")
+}

--- a/types/types.go
+++ b/types/types.go
@@ -149,6 +149,7 @@ type CliFlags struct {
 	PerformOldReportsCleanup  bool
 	CleanupOnStartup          bool
 	Verbose                   bool
+	IgnoreDisabledRules       bool
 	MaxAge                    string
 }
 


### PR DESCRIPTION
# Description
This is the first issue done via the Claude Code dynamic workflow (coming in PRs: https://github.com/RedHatInsights/ccx-notification-service/pull/1257)

This is a very simple change, but it's the first step. The only change I had to do after the workflow was done was to add a License header to one file, the agent had trouble running that license script.

Here's a full output from the workflow (nothing is automatic, this is all defined). Collapsed by default:
<details>

<summary>Full output from the dynamic workflow</summary>
## Workflow results

**Added the `IgnoreDisabledRules` boolean field to the `CliFlags` struct in `types/types.go` and registered the `--ignore-disabled-rules` CLI flag (default `false`) in `setupCliFlags()` in `cmd/ccx-notification-service/cli.go`. The flag description is "skip disabled rules check, process all rules as if none are disabled", matching the spec's failure handling guidance. The flag follows the same pattern as existing boolean flags like `--verbose` and `--instant-reports`. `make style` passes. The code compiles without errors.**

| Phase | Result |
|-------|--------|
| Implement | 2 file(s) change, 2 files added |
| Tests | 9 test(s), passed |
| Verify | pass_with_notes, before_commit: FAILED |

### Verification report

## Verification Report for CCXDEV-16560: Register --ignore-disabled-rules CLI flag

### Acceptance Criteria Verification

1. **IgnoreDisabledRules field added to CliFlags struct in types/types.go** -- PASS
   The field `IgnoreDisabledRules bool` is added at the correct position in the `CliFlags` struct, between `Verbose` and `MaxAge`, following the existing naming convention (PascalCase) and type pattern (bool).

2. **Flag registered in setupCliFlags() in cmd/ccx-notification-service/cli.go** -- PASS
   `flag.BoolVar(&cliFlags.IgnoreDisabledRules, "ignore-disabled-rules", false, "skip disabled rules check, process all rules as if none are disabled")` is added between the `--verbose` and `--max-age` flag registrations, following the exact pattern of other bool flags.

3. **Flag is visible in --help output** -- PASS
   Verified by `TestSetupCliFlagsIgnoreDisabledRulesVisibleInHelp` which iterates all registered flags via `flag.CommandLine.VisitAll()` and confirms the flag is found. Also confirmed by the stderr output in `TestSetupCliFlagsIgnoreDisabledRulesRegistered` which shows the full usage dump including the flag.

4. **Unit test verifying default value is false** -- PASS
   Covered by both `TestSetupCliFlagsIgnoreDisabledRulesRegistered` (tests the flag registration default) and `TestCliFlagsIgnoreDisabledRulesDefaultValue` (tests the Go zero-value default). Both assert `false`.

5. **Any other unit tests to cover the code in a meaningful way** -- PASS
   9 total tests across two new test files:
   - `cmd/ccx-notification-service/cli_test.go` (6 tests): default value, setting to true, description text, help visibility, all existing flags still registered, explicit false value
   - `types/cli_flags_test.go` (3 tests): zero-value default, can be set to true, does not affect other flags

### Design Document Alignment

The design document (Section 4, "New CLI flag: --ignore-disabled-rules") specifies:
- Boolean flag, default false -- MATCH
- Description: "skip disabled rules check, process all rules as if none are disabled" -- EXACT MATCH (the spec's fallback description text)
- Purpose: local dev, BDD testing, debugging -- N/A (no behavioral implementation in this issue)
- "The flag should be checked early in the start function" -- N/A (deferred to a future issue per the spec: "the disabled rules feature isn't implemented")

### BDD Feature File

The provided `notifications_disabled_rules.feature` file covers the full disabled-rules behavior (10 scenarios for the Kafka path). None of these scenarios are testable with this change because the flag has no behavioral effect yet -- it is just registered. The BDD scenarios will become relevant when the disabled rules filtering logic is implemented. The feature file is tagged `@skip` as expected per the design document.

### Code Quality

- The implementation follows the exact pattern of existing flags (same `flag.BoolVar` call pattern, same struct field style).
- The flag description matches the spec's recommended text exactly.
- The `WeeklyReports` field in `CliFlags` is not registered in `setupCliFlags()` (pre-existing issue, not introduced by this change).
- No bugs, nil pointer risks, race conditions, or resource leaks introduced.
- Test assertions check spec-defined expected values (false default, true when set, exact description text) rather than just mirroring return values.

### Test File Observations

Both test files are new (untracked, not previously existing). They have proper Apache 2.0 license headers with "Red Hat, Inc" copyright. The `cli_test.go` is in `package main` (same package as the code under test, giving access to the unexported `setupCliFlags` function). The `cli_flags_test.go` is in `package types_test` (external test package, following the project convention).

### make before_commit Result

Failed at the `license` target due to a pre-existing environment issue: the installed version of `addlicense` does not support the `-ignore` flag used in the Makefile. This is unrelated to the change. Style checks (shellcheck, abcgo, golangci-lint), all unit tests, and coverage all passed.

### Agent feedback on workflow instructions

- **[tests]** The instruction to run 'make license' as the last step is good practice, but in this repo the addlicense tool version does not support the -ignore flag used in the Makefile target, so 'make license' always fails regardless of test changes. The instruction could note that a pre-existing make license failure should be reported but not treated as a blocker.
- **[tests]** The instruction to run 'make coverage' and 'maintain or improve coverage' is slightly ambiguous when the overall coverage is already below threshold before the test changes. In this case, setupCliFlags went from 0% to 100% coverage (an improvement), but the overall total remained at 68.9% (below the 73% threshold) due to pre-existing uncovered code in other packages. The instruction could clarify that pre-existing coverage debt is not the test author's responsibility.
- **[verify]** The instructions say 'Run git diff a1e8fcb...' to see the full diff, including test files, but git diff does not show untracked files. The new test files (cli_test.go, cli_flags_test.go) are untracked and only visible via git status. The instructions should mention checking git status for new untracked files or using git diff with --no-index, or instruct to also run 'git status' to find new files that are part of the change.
- **[verify]** The instruction to run 'git stash' to test pre-existing failures is risky -- in this case, the stash operation succeeded for some files but failed for .claude/settings.json (device busy), and then stash pop failed, effectively losing the working tree changes. I had to manually re-apply the changes from the diff I captured earlier. A safer approach would be to compare against the base commit without modifying the working tree, or to suggest using git worktrees for isolation.

### Estimated costs

| Phase | Cost |
|-------|------|
| Setup | $0.3960 |
| Implement | $0.6694 |
| Tests | $2.7879 |
| Verify | $2.2113 |
| **Total** | **$6.0646** |

*Estimates based on output tokens. Run `/usage` for actuals.*
</details>

Fixes CCXDEV-16560

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Configuration update

## Testing steps
`make before_commit` + real run with CLI flag

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
