### PR TITLE
[CCXDEV-16555] add second increment of the dynamic Claude code `/go-implement` workflow.

### DIFF
--- a/.claude/workflows/go-implement.js
+++ b/.claude/workflows/go-implement.js
@@ -48,12 +48,78 @@ export const meta = {
     { title: 'Verify', detail: 'Adversarial review of the full diff against the specification' },
   ],
 }
+// ---------------------------------------------------------------------------
+// Cost estimation
+// ---------------------------------------------------------------------------
+// The agents don't have access to /usage or any other actual cost data.
+//
+// The workflow tracks cost per phase using budget.spent(), which only returns
+// output tokens. The total is estimated by assuming input tokens are a multiple
+// of output tokens (INPUT_RATIO).
+//
+// Why the need for an INPUT_RATIO:
+// Claude Code agents read a lot of context (AGENTS.md, source files, diffs)
+// but produce relatively little output. The 50:1 ratio was calibrated from
+// /usage data across a few real issues (Opus 4 on Vertex AI). Cache reads
+// dominate input costs. If estimates drift from /usage actuals, re-calibrate
+// by comparing estimated vs actual costs.
+//
+// Pricing (as of 2026-07, Claude Opus 4 on Vertex AI):
+// $5/MTok input, $25/MTok output (same as the Anthropic API).
+const USD_PER_OUTPUT_MTOK = 25
+const USD_PER_INPUT_MTOK = 5
+const INPUT_RATIO = 50
+
+// Estimate the dollar cost for a given number of output tokens.
+// Input tokens are not tracked by the runtime, so they are estimated
+// as OUTPUT_TOKENS * INPUT_RATIO (see the comment block above).
+function estimateCost(outputTokens) {
+  const estimatedInputTokens = outputTokens * INPUT_RATIO
+  const usd =
+    (outputTokens * USD_PER_OUTPUT_MTOK + estimatedInputTokens * USD_PER_INPUT_MTOK) / 1_000_000
+  return usd
+}
+
+// Format a dollar amount for display, e.g. 0.095 -> "$0.0950"
+function formatCost(usd) {
+  return '$' + usd.toFixed(4)
+}
+
+// ---------------------------------------------------------------------------
+// Agent feedback
+// ---------------------------------------------------------------------------
+// Collect and log feedback from all phases that returned results.
+// Each phase is instructed to give a `feedback` array with agent commentary
+// on the workflow / spec instructions themselves.
+function logFeedback(phases) {
+  // Object.entries converts { implement: ..., tests: ..., verify: ... } into
+  // an array of [name, result] pairs. flatMap collects feedback from each phase
+  // into a single list, prefixed with the phase name.
+  const feedbackLines = Object.entries(phases)
+    .flatMap(([phaseName, result]) => {
+      const items = (result && result.feedback) || []
+      return items.map(f => `[${phaseName}] ${f}`)
+    })
+  if (feedbackLines.length) {
+    log('')
+    log('Agent feedback on workflow instructions:')
+    feedbackLines.forEach(f => log('  ' + f))
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
-// Agent return schemas. The workflow runtime validates responses against these
-// and retries if they don't match.
+// Each agent is required to return structured JSON matching these schemas.
+// The workflow runtime validates the output and retries if it doesn't match.
+// This gives typed results (filesModified, testsPassed, verdict) instead
+// of free-text responses.
+
+const FEEDBACK_FIELD = {
+  type: 'array',
+  items: { type: 'string' },
+  description: 'Feedback about the instructions you were given - not about the code. Report if any instruction was unclear, missing a step, wrong, or if you had to take a different approach than what was described and why.',
+}
 
 // Jira issue description fetched via MCP.
 // Example: { issueBody: "Summary: Fix cooldown logic\n\nAs a user, I want..." }
@@ -64,6 +130,58 @@ const JIRA_ISSUE_SCHEMA = {
     issueBody: { type: 'string', description: 'The full issue summary and description, or empty string if fetch failed. Handled later as a failure state.' },
   },
 }
+
+// Sandbox enforcement check: did curl to an unlisted domain get blocked?
+// Example (sandbox active):  { curlExitCode: 7, blocked: true }
+// Example (sandbox missing): { curlExitCode: 0, blocked: false, httpStatus: "200" }
+const SANDBOX_CANARY_SCHEMA = {
+  type: 'object',
+  required: ['curlExitCode', 'blocked'],
+  properties: {
+    curlExitCode: { type: 'integer', description: 'Exit code of the curl command' },
+    httpStatus: { type: 'string', description: 'HTTP status code returned by curl, if any' },
+    blocked: { type: 'boolean', description: 'True if curl failed to connect (exit code != 0 or connection refused/timeout)' },
+  },
+}
+
+// Git state check before the workflow starts.
+// Example: { branch: "feature-aggregator-db", cleanTree: true, headSha: "a1b2c3d4..." }
+const GIT_PREFLIGHT_SCHEMA = {
+  type: 'object',
+  required: ['branch', 'cleanTree', 'headSha'],
+  properties: {
+    branch: { type: 'string', description: 'Current branch name' },
+    cleanTree: { type: 'boolean', description: 'True if git status --porcelain produced no output' },
+    headSha: { type: 'string', description: 'Full 40-char HEAD SHA' },
+    dirtyFiles: { type: 'string', description: 'Output of git status --porcelain if not clean' },
+  },
+}
+
+// Phase 1 result: what files were changed and any concerns.
+// Example: { filesModified: ["differ/storage.go", "differ/differ.go"], summary: "Added aggregator DB connection", warnings: [] }
+const IMPLEMENT_SCHEMA = {
+  type: 'object',
+  required: ['filesModified', 'summary'],
+  properties: {
+    filesModified: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'List of files created or modified',
+    },
+    summary: {
+      type: 'string',
+      description: 'Brief description of what was implemented',
+    },
+    warnings: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Ambiguities or concerns encountered during implementation',
+    },
+    feedback: FEEDBACK_FIELD,
+  },
+}
+
+const tokensBeforeSetup = budget.spent()
 
 // ---------------------------------------------------------------------------
 // Args
@@ -86,7 +204,6 @@ if (!parsed || !parsed.issue) {
 
 const issueKey = parsed.issue
 const designDocPath = parsed.designDoc || ''
-// bddPaths can be passed as a single string or an array; normalize to array
 const bddPathsRaw = parsed.bddPaths || []
 const bddPaths = Array.isArray(bddPathsRaw) ? bddPathsRaw : [bddPathsRaw]
 
@@ -122,10 +239,11 @@ const issue = jiraResult.issueBody
 // ---------------------------------------------------------------------------
 // Shared prompt fragments
 // ---------------------------------------------------------------------------
-// Spec context injected into every agent prompt. Combines the Jira issue
-// body, design doc path, and BDD feature file paths (last two if provided).
-// Each agent sees the same context so they're all working from the same spec.
+// These are injected into every agent prompt via template literals.
+//   - specContext combines all the provided specifications and gives each agent the same context to work from.
+//   - FEEDBACK_PROMPT tells each agent how to use the feedback output field.
 
+// The Jira issue body is always present (fetched above).
 const specSections = [
   `## Issue Specification (${issueKey})
 
@@ -148,12 +266,217 @@ These feature files describe expected user-facing behavior:
 ${bddPaths.map(p => '- \`' + p + '\`').join('\n')}`)
 }
 
+// Join all possible sections of the spec into the main specification prompt injected into every agent.
 const specContext = specSections.join('\n\n')
 
-// TODO: Sandbox canary check, pre-flight git checks, and Phases 1-3
-// (Implement, Unit Tests, Verify) will be added in follow-up commits.
-log('Setup complete. issue=' + issueKey + ', specContext built (' + specContext.length + ' chars)')
+// FEEDBACK_PROMPT tells each agent to report issues with the workflow instructions, spec
+// contradictions, design doc gaps, or unclear BDD scenarios. Logged at the
+// end of the run for a human to review.
+//
+// In theory, this creates a feedback loop where agents help improve the
+// prompts that control them. What could possibly go wrong.
+const FEEDBACK_PROMPT = `## Workflow feedback
+
+Your structured output includes a \`feedback\` array of strings. Add one entry per issue you encountered with these instructions - not about the code. For example: an instruction that was unclear or ambiguous, a step that was missing, a prescribed approach that did not work, the Jira spec contradicting the design document or BDD scenarios (if provided), or anything else that would help improve these instructions. Leave it empty if everything worked as described.`
+
+// ---------------------------------------------------------------------------
+// Sandbox canary check
+// ---------------------------------------------------------------------------
+// Try to reach a domain that is NOT in the sandbox allowedDomains list.
+// If the request succeeds, the sandbox is not active and the workflow exits.
+
+log('Checking sandbox enforcement...')
+const canary = await agent(
+  `Run this exact command with no modifications - no leading whitespace, no extra flags, no wrapping with echo or other commands:
+
+curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 --max-time 5 https://google.com
+
+Copy-paste the command exactly as shown above. Report the exit code and the HTTP status code. If curl fails with a connection error or timeout, that counts as blocked.`,
+  {
+    label: 'sandbox-canary',
+    effort: 'low',
+    schema: SANDBOX_CANARY_SCHEMA,
+  }
+)
+
+if (!canary) {
+  log('ERROR: Sandbox canary agent failed to run.')
+  return { error: 'Sandbox canary check failed - the agent did not return a result' }
+}
+
+if (!canary.blocked) {
+  log('ERROR: Sandbox is not active! This workflow requires sandbox enforcement.')
+  log('Enable it in .claude/settings.json: set "sandbox.enabled" to true, then restart Claude Code.')
+  return { error: 'Sandbox not enabled. Set sandbox.enabled=true in .claude/settings.json and restart Claude Code.' }
+}
+
+log('Sandbox confirmed: network access to non-allowed domains is blocked.')
+
+// ---------------------------------------------------------------------------
+// Pre-flight checks
+// ---------------------------------------------------------------------------
+// A lightweight agent checks the git state. baseSha is captured here rather
+// than trusting the implementation agent to report it, because all subsequent
+// git diffs depend on this being correct.
+
+const preflight = await agent(
+  `Run these checks and report the results. Do not fix anything, just report.
+
+1. Run \`git rev-parse --abbrev-ref HEAD\` and report the branch name.
+2. Run \`git status --porcelain\` and report whether the working tree is clean (empty output = clean).
+3. Run \`git rev-parse HEAD\` and report the full 40-character SHA.
+
+Return all three values.`,
+  {
+    label: 'preflight',
+    effort: 'low',
+    schema: GIT_PREFLIGHT_SCHEMA,
+  }
+)
+
+if (!preflight) {
+  log('Pre-flight check failed or was skipped.')
+  return { error: 'Pre-flight check failed' }
+}
+
+if (['main', 'master'].includes(preflight.branch)) {
+  log('Error: Refusing to run on protected branch "' + preflight.branch + '". Create a feature branch first.')
+  return { error: 'Cannot run on ' + preflight.branch + '. Create a feature branch first' }
+}
+
+if (!preflight.cleanTree) {
+  log('Warning: Working tree is not clean')
+  log('  Dirty files: ' + (preflight.dirtyFiles || '(unknown)'))
+}
+
+// Store the starting SHA. All git diffs in later phases use this as the base.
+const baseSha = preflight.headSha
+const setupCost = estimateCost(budget.spent() - tokensBeforeSetup)
+log('Setup OK: branch=' + preflight.branch + ' baseSha=' + baseSha.substring(0, 8) + ' | cost~' + formatCost(setupCost))
+
+// ---------------------------------------------------------------------------
+// Phase 1: Implement
+// ---------------------------------------------------------------------------
+// Writes the production code. This is the only phase that modifies non-test
+// files, so it also runs make style and fixes any issues it finds.
+// budget.spent() deltas track cost per phase (see Cost estimation above).
+
+phase('Implement')
+log('Phase 1: Writing production code...')
+
+const tokensBeforeImpl = budget.spent()
+const impl = await agent(
+  `You are implementing a Go code change in this repository. The project conventions from AGENTS.md are already in your context.
+
+${specContext}
+
+## Scope
+
+- You may make additional changes beyond the steps below if they are needed to implement the specification correctly (e.g., small refactors, extracting helpers).
+- You must run through the full checklist at the end regardless of what you changed.
+
+## Instructions
+
+1. Read the files you are going to modify in full before writing anything. Also read any files referenced in the issue specification. You may explore other files if you have a specific reason (understanding a type, checking an interface, reading a dependency), but stay focused on the task.
+2. Implement the production code changes described in the acceptance criteria. If a design document is provided above, use it as the primary guide for architecture and approach. Follow the existing code style and patterns in the repo.
+3. If you added new imports or dependencies, run \`go mod tidy\`.
+4. If you added or modified any interface, run \`make gen-mocks\` (see AGENTS.md for details).
+5. Run \`make style\` to check linting. Fix any issues it reports and re-run \`make style\` until it passes. If you cannot resolve an issue after 3 attempts, stop and describe the issue and the \`make style\` error output in warnings.
+6. Run \`make license\` to add license headers to any new \`.go\` files. This must be last because earlier steps (gen-mocks, style fixes) may create new files.
+
+## Constraints
+
+- Do not write unit tests. They will be written separately.
+- Do not run \`make before_commit\`, \`make test\`, or \`make coverage\`.
+- Do not create any git commits. Leave all changes in the working tree.
+- If the specification is ambiguous on any point, note it in warnings rather than guessing.
+- If a dependency from another issue is not yet merged or available, stop and include an explanation in warnings. Report whatever files you did manage to create in filesModified.
+
+## Before finishing, verify
+
+1. If you changed an interface, mocks are regenerated (you ran \`make gen-mocks\`).
+2. \`make style\` passes with no errors.
+3. \`make license\` was run after all other steps.
+4. Every acceptance criteria from the specification has a corresponding code change.
+5. No git commits were created. All changes are in the working tree only.
+
+${FEEDBACK_PROMPT}`,
+  { label: 'implement', schema: IMPLEMENT_SCHEMA }
+)
+
+if (!impl) {
+  log('Phase 1 failed or was skipped.')
+  return {
+    error: 'Implementation phase failed',
+    displaySummary: '## Workflow stopped\n\n**Error:** Implementation phase failed.\n\nThe implement agent did not return a result. Check the workflow logs for details.',
+    implement: null, tests: null, verify: null,
+    setupCostUsd: setupCost, totalCostUsd: setupCost,
+  }
+}
+
+const implCost = estimateCost(budget.spent() - tokensBeforeImpl)
+const filesModified = impl.filesModified || []
+log(
+  'Phase 1 complete: ' +
+    filesModified.length +
+    ' file(s) modified: ' +
+    filesModified.join(', ') +
+    ' | cost~' + formatCost(implCost)
+)
+if (impl.warnings && impl.warnings.length) {
+  impl.warnings.forEach(w => log('  warning: ' + w))
+}
+
+// Gate: termination check to prevent the following phases from running
+if (!filesModified.length) {
+  log('Phase 1 produced no file changes. Nothing to test or verify.')
+  return {
+    error: 'No files modified',
+    displaySummary: `## Workflow stopped
+
+**Error:** Phase 1 (Implement) completed but produced no file changes.
+
+**Summary:** ${impl.summary}${impl.warnings && impl.warnings.length ? '\n\n**Warnings:**\n' + impl.warnings.map(w => '- ' + w).join('\n') : ''}
+
+### Estimated costs
+
+| Phase | Cost |
+|-------|------|
+| Setup | ${formatCost(setupCost)} |
+| Implement | ${formatCost(implCost)} |
+| **Total** | **${formatCost(setupCost + implCost)}** |
+
+*Estimates based on output tokens. Run \`/usage\` for actuals.*`,
+    implement: { ...impl, costUsd: implCost }, tests: null, verify: null,
+    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost,
+  }
+}
+
+// TODO: Phase 2 (Unit Tests) and Phase 3 (Verify) will be added in follow-up commits.
+log('Phase 1 complete. Phases 2 and 3 not yet implemented.')
+logFeedback({ implement: impl })
+
 return {
-  issueKey,
-  specContext,
+  displaySummary: `## Workflow results (Phase 1 only)
+
+**${impl.summary}**
+
+| Phase | Result |
+|-------|--------|
+| Implement | ${filesModified.length} file(s) |
+
+### Estimated costs
+
+| Phase | Cost |
+|-------|------|
+| Setup | ${formatCost(setupCost)} |
+| Implement | ${formatCost(implCost)} |
+| **Total** | **${formatCost(setupCost + implCost)}** |
+
+*Estimates based on output tokens. Run \`/usage\` for actuals.*`,
+  implement: { ...impl, costUsd: implCost },
+  tests: null,
+  verify: null,
+  setupCostUsd: setupCost,
+  totalCostUsd: setupCost + implCost,
 }

--- a/.claude/workflows/go-implement/tests/test-costs.mjs
+++ b/.claude/workflows/go-implement/tests/test-costs.mjs
@@ -1,0 +1,95 @@
+// Test script for estimateCost and formatCost from go-implement.js
+
+// --- Extracted from go-implement.js ---
+const USD_PER_OUTPUT_MTOK = 25
+const USD_PER_INPUT_MTOK = 5
+const INPUT_RATIO = 50
+
+function estimateCost(outputTokens) {
+  const estimatedInputTokens = outputTokens * INPUT_RATIO
+  const usd =
+    (outputTokens * USD_PER_OUTPUT_MTOK + estimatedInputTokens * USD_PER_INPUT_MTOK) / 1_000_000
+  return usd
+}
+
+function formatCost(usd) {
+  return '$' + usd.toFixed(4)
+}
+
+// --- Test harness ---
+let passed = 0
+let failed = 0
+
+function test(id, description, actual, expected) {
+  const ok = Object.is(actual, expected) || (typeof actual === 'number' && typeof expected === 'number' && Math.abs(actual - expected) < 1e-12)
+  if (ok) {
+    console.log(`[PASS] #${id}: ${description}`)
+    passed++
+  } else {
+    console.log(`[FAIL] #${id}: ${description} - expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    failed++
+  }
+}
+
+// --- estimateCost tests (1-4) ---
+// Formula: usd = (outputTokens * 25 + outputTokens * 50 * 5) / 1_000_000
+//        = outputTokens * (25 + 250) / 1_000_000
+//        = outputTokens * 275 / 1_000_000
+
+test(1, 'estimateCost(0) = 0', estimateCost(0), 0)
+
+test(2, 'estimateCost(1000)', estimateCost(1000), 1000 * 275 / 1_000_000)
+// 1000 * 275 / 1e6 = 0.275
+
+test(3, 'estimateCost(100000)', estimateCost(100000), 100000 * 275 / 1_000_000)
+// 100000 * 275 / 1e6 = 27.5
+
+test(4, 'estimateCost(1000000)', estimateCost(1000000), 1000000 * 275 / 1_000_000)
+// 1000000 * 275 / 1e6 = 275
+
+// --- formatCost tests (5-9) ---
+
+test(5, 'formatCost(0) = "$0.0000"', formatCost(0), '$0.0000')
+
+test(6, 'formatCost(0.275) = "$0.2750"', formatCost(0.275), '$0.2750')
+
+test(7, 'formatCost(27.5) = "$27.5000"', formatCost(27.5), '$27.5000')
+
+test(8, 'formatCost(275) = "$275.0000"', formatCost(275), '$275.0000')
+
+test(9, 'formatCost(0.00001) = "$0.0000"', formatCost(0.00001), '$0.0000')
+
+// --- Cost tracking simulation (10-15) ---
+// Simulate the workflow's budget.spent() pattern.
+// budget.spent() returns cumulative output tokens at each checkpoint.
+// Sequence: 0 -> 500 -> 5000 -> 12000 -> 18000
+
+const spentValues = [0, 500, 5000, 12000, 18000]
+
+const preSetup = spentValues[0]
+const setupCost = estimateCost(spentValues[1] - preSetup)
+test(10, 'Setup phase: 500 output tokens', setupCost, estimateCost(500))
+
+const preImpl = spentValues[1]
+const implCost = estimateCost(spentValues[2] - preImpl)
+test(11, 'Implement phase: 4500 output tokens', implCost, estimateCost(4500))
+
+const preTests = spentValues[2]
+const testsCost = estimateCost(spentValues[3] - preTests)
+test(12, 'Tests phase: 7000 output tokens', testsCost, estimateCost(7000))
+
+const preVerify = spentValues[3]
+const verifyCost = estimateCost(spentValues[4] - preVerify)
+test(13, 'Verify phase: 6000 output tokens', verifyCost, estimateCost(6000))
+
+const totalCost = setupCost + implCost + testsCost + verifyCost
+test(14, 'Total cost = sum of phase costs', totalCost, setupCost + implCost + testsCost + verifyCost)
+
+test(15, 'Total cost = estimateCost(18000)', totalCost, estimateCost(18000))
+
+// --- Summary ---
+console.log('')
+console.log(`Total: ${passed + failed} tests, ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  process.exit(1)
+}

--- a/.claude/workflows/go-implement/tests/test-feedback.mjs
+++ b/.claude/workflows/go-implement/tests/test-feedback.mjs
@@ -1,0 +1,172 @@
+// Test suite for logFeedback() from go-implement.js
+//
+// Uses the actual phase key names from the workflow: implement, tests, verify.
+
+// --- Extract the function under test, injecting a mock log() ---
+
+let captured = []
+
+function log(...args) {
+  captured.push(args.join(' '))
+}
+
+function logFeedback(phases) {
+  const feedbackLines = Object.entries(phases)
+    .flatMap(([phaseName, result]) => {
+      const items = (result && result.feedback) || []
+      return items.map(f => `[${phaseName}] ${f}`)
+    })
+  if (feedbackLines.length) {
+    log('')
+    log('Agent feedback on workflow instructions:')
+    feedbackLines.forEach(f => log('  ' + f))
+  }
+}
+
+// --- Test harness ---
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  captured = []
+  try {
+    fn()
+    passed++
+    console.log(`[PASS] ${name}`)
+  } catch (e) {
+    failed++
+    console.log(`[FAIL] ${name}`)
+    console.log(`       ${e.message}`)
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg)
+}
+
+function assertDeep(actual, expected, msg) {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a !== e) throw new Error(`${msg}\n         expected: ${e}\n         actual:   ${a}`)
+}
+
+// --- Tests ---
+
+test('1. No feedback from any phase', () => {
+  logFeedback({
+    implement: { feedback: [] },
+    tests:     { feedback: [] },
+    verify:    { feedback: [] },
+  })
+  assertDeep(captured, [], 'should produce no output when all feedback arrays are empty')
+})
+
+test('2. One phase with feedback', () => {
+  logFeedback({
+    implement: { feedback: ['improve the prompt'] },
+    tests:     { feedback: [] },
+    verify:    { feedback: [] },
+  })
+  assertDeep(captured, [
+    '',
+    'Agent feedback on workflow instructions:',
+    '  [implement] improve the prompt',
+  ], 'should log feedback from the single phase that has it')
+})
+
+test('3. All three phases with feedback', () => {
+  logFeedback({
+    implement: { feedback: ['impl note'] },
+    tests:     { feedback: ['test note'] },
+    verify:    { feedback: ['verify note'] },
+  })
+  assertDeep(captured, [
+    '',
+    'Agent feedback on workflow instructions:',
+    '  [implement] impl note',
+    '  [tests] test note',
+    '  [verify] verify note',
+  ], 'should log feedback from all phases in insertion order')
+})
+
+test('4. Null phase result', () => {
+  logFeedback({
+    implement: { feedback: ['something'] },
+    tests:     null,
+    verify:    { feedback: ['other'] },
+  })
+  assertDeep(captured, [
+    '',
+    'Agent feedback on workflow instructions:',
+    '  [implement] something',
+    '  [verify] other',
+  ], 'null result should be safely skipped via (result && result.feedback) || []')
+})
+
+test('5. Missing feedback field ({})', () => {
+  logFeedback({
+    implement: {},
+    tests:     {},
+    verify:    {},
+  })
+  assertDeep(captured, [], 'empty objects with no feedback field should produce no output')
+})
+
+test('6. Undefined feedback', () => {
+  logFeedback({
+    implement: { feedback: undefined },
+    tests:     { feedback: undefined },
+    verify:    { feedback: undefined },
+  })
+  assertDeep(captured, [], 'undefined feedback should be treated as empty via || []')
+})
+
+test('7. Multiple items from one phase', () => {
+  logFeedback({
+    implement: { feedback: ['first note', 'second note', 'third note'] },
+  })
+  assertDeep(captured, [
+    '',
+    'Agent feedback on workflow instructions:',
+    '  [implement] first note',
+    '  [implement] second note',
+    '  [implement] third note',
+  ], 'multiple feedback items from one phase should each get their own line')
+})
+
+test('8. Early exit (2 phases only)', () => {
+  // Matches the actual early-exit call : logFeedback({ implement: impl, tests })
+  logFeedback({
+    implement: { feedback: ['early feedback'] },
+    tests:     { feedback: ['test feedback'] },
+  })
+  assertDeep(captured, [
+    '',
+    'Agent feedback on workflow instructions:',
+    '  [implement] early feedback',
+    '  [tests] test feedback',
+  ], 'should work with fewer than 3 phases (mirrors the early exit path)')
+})
+
+test('9. Object.entries ordering preserved', () => {
+  // Object.entries preserves insertion order for string keys in modern JS engines.
+  // Use the actual phase keys in a deliberate order to confirm.
+  const phases = {}
+  phases.verify    = { feedback: ['v'] }
+  phases.implement = { feedback: ['i'] }
+  phases.tests     = { feedback: ['t'] }
+
+  logFeedback(phases)
+
+  // Order must follow insertion: verify, implement, tests
+  assert(captured[2] === '  [verify] v',    `expected verify first, got: ${captured[2]}`)
+  assert(captured[3] === '  [implement] i', `expected implement second, got: ${captured[3]}`)
+  assert(captured[4] === '  [tests] t',     `expected tests third, got: ${captured[4]}`)
+})
+
+// --- Summary ---
+
+console.log('')
+console.log(`Total: ${passed + failed} | Passed: ${passed} | Failed: ${failed}`)
+process.exit(failed > 0 ? 1 : 0)

--- a/.claude/workflows/go-implement/tests/test-preflight.mjs
+++ b/.claude/workflows/go-implement/tests/test-preflight.mjs
@@ -1,0 +1,340 @@
+// Test script for pre-flight failure paths in go-implement.js
+//
+// Extracts the guard logic from three sections of the workflow:
+//   1. Jira fetch
+//   2. Sandbox canary
+//   3. Preflight checks
+//
+// Each section is wrapped in a function that accepts mocked agent() and log()
+// and returns the same {error} or success shape as the real workflow.
+
+// ---------------------------------------------------------------------------
+// Extracted guard functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulates the Jira fetch guard.
+ * @param {Function} agentFn - mock for agent(), returns the jiraResult
+ * @param {Function} logFn   - mock for log()
+ * @returns {{ error: string } | { issueBody: string }}
+ */
+async function jiraFetchGuard(agentFn, logFn) {
+  const issueKey = 'TEST-123'
+
+  logFn('Fetching Jira issue ' + issueKey + '...')
+  const jiraResult = await agentFn()
+
+  if (!jiraResult || !jiraResult.issueBody) {
+    logFn('Error: Could not fetch Jira issue ' + issueKey + '. Make sure the Jira MCP is connected.')
+    return { error: 'Failed to fetch Jira issue ' + issueKey }
+  }
+
+  const issue = jiraResult.issueBody
+  return { issueBody: issue }
+}
+
+/**
+ * Simulates the sandbox canary guard.
+ * @param {Function} agentFn - mock for agent(), returns the canary result
+ * @param {Function} logFn   - mock for log()
+ * @returns {{ error: string } | { ok: true }}
+ */
+async function canaryGuard(agentFn, logFn) {
+  logFn('Checking sandbox enforcement...')
+  const canary = await agentFn()
+
+  if (!canary) {
+    logFn('ERROR: Sandbox canary agent failed to run.')
+    return { error: 'Sandbox canary check failed - the agent did not return a result' }
+  }
+
+  if (!canary.blocked) {
+    logFn('ERROR: Sandbox is not active! This workflow requires sandbox enforcement.')
+    logFn('Enable it in .claude/settings.json: set "sandbox.enabled" to true, then restart Claude Code.')
+    return { error: 'Sandbox not enabled. Set sandbox.enabled=true in .claude/settings.json and restart Claude Code.' }
+  }
+
+  logFn('Sandbox confirmed: network access to non-allowed domains is blocked.')
+  return { ok: true }
+}
+
+/**
+ * Simulates the preflight checks guard.
+ * @param {Function} agentFn - mock for agent(), returns the preflight result
+ * @param {Function} logFn   - mock for log()
+ * @returns {{ error: string } | { branch: string, baseSha: string }}
+ */
+async function preflightGuard(agentFn, logFn) {
+  const preflight = await agentFn()
+
+  if (!preflight) {
+    logFn('Pre-flight check failed or was skipped.')
+    return { error: 'Pre-flight check failed' }
+  }
+
+  if (['main', 'master'].includes(preflight.branch)) {
+    logFn('Error: Refusing to run on protected branch "' + preflight.branch + '". Create a feature branch first.')
+    return { error: 'Cannot run on ' + preflight.branch + '. Create a feature branch first' }
+  }
+
+  if (!preflight.cleanTree) {
+    logFn('Error: Working tree is not clean. Commit or stash changes before running this workflow.')
+    logFn('  Dirty files: ' + (preflight.dirtyFiles || '(unknown)'))
+    return { error: 'Working tree is not clean' }
+  }
+
+  const baseSha = preflight.headSha
+  logFn('Setup OK: branch=' + preflight.branch + ' baseSha=' + baseSha.substring(0, 8))
+  return { branch: preflight.branch, baseSha }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+let passed = 0
+let failed = 0
+
+function createLog() {
+  const messages = []
+  const fn = (msg) => messages.push(msg)
+  fn.messages = messages
+  return fn
+}
+
+async function runTest(testNum, description, testFn) {
+  const log = createLog()
+  try {
+    const { pass, detail } = await testFn(log)
+    if (pass) {
+      passed++
+      console.log(`[PASS] Test ${testNum}: ${description}`)
+      if (detail) console.log(`       ${detail}`)
+    } else {
+      failed++
+      console.log(`[FAIL] Test ${testNum}: ${description}`)
+      console.log(`       ${detail}`)
+      if (log.messages.length) {
+        console.log(`       Logged: ${log.messages.join(' | ')}`)
+      }
+    }
+  } catch (err) {
+    failed++
+    console.log(`[FAIL] Test ${testNum}: ${description}`)
+    console.log(`       Exception: ${err.message}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+console.log('=== Testing go-implement.js pre-flight failure paths ===')
+console.log('')
+console.log('--- Jira Fetch Guard ---')
+
+// Test 1: null result from agent
+await runTest(1, 'Jira: null agent result returns error', async (log) => {
+  const result = await jiraFetchGuard(() => null, log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Failed to fetch Jira issue')
+  const loggedError = log.messages.some(m => m.includes('Could not fetch Jira issue'))
+  return {
+    pass: hasError && correctMsg && loggedError,
+    detail: hasError
+      ? `error="${result.error}", logged=${loggedError}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 2: empty issueBody
+await runTest(2, 'Jira: empty issueBody returns error', async (log) => {
+  const result = await jiraFetchGuard(() => ({ issueBody: '' }), log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Failed to fetch Jira issue')
+  return {
+    pass: hasError && correctMsg,
+    detail: hasError
+      ? `error="${result.error}"`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 3: valid issueBody
+await runTest(3, 'Jira: valid issueBody returns success', async (log) => {
+  const body = 'Summary: Fix the widget\n\nDetailed description here.'
+  const result = await jiraFetchGuard(() => ({ issueBody: body }), log)
+  const isSuccess = !result.error && result.issueBody === body
+  return {
+    pass: isSuccess,
+    detail: isSuccess
+      ? `issueBody="${result.issueBody.substring(0, 40)}..."`
+      : 'Expected success with issueBody but got: ' + JSON.stringify(result),
+  }
+})
+
+console.log('')
+console.log('--- Sandbox Canary Guard ---')
+
+// Test 4: null result from agent
+await runTest(4, 'Canary: null agent result returns error', async (log) => {
+  const result = await canaryGuard(() => null, log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('canary check failed')
+  const loggedError = log.messages.some(m => m.includes('canary agent failed to run'))
+  return {
+    pass: hasError && correctMsg && loggedError,
+    detail: hasError
+      ? `error="${result.error}", logged=${loggedError}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 5: blocked=false (sandbox not active)
+await runTest(5, 'Canary: blocked=false returns sandbox-not-active error', async (log) => {
+  const result = await canaryGuard(() => ({ curlExitCode: 0, httpStatus: '200', blocked: false }), log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Sandbox not enabled')
+  const loggedError = log.messages.some(m => m.includes('Sandbox is not active'))
+  return {
+    pass: hasError && correctMsg && loggedError,
+    detail: hasError
+      ? `error="${result.error}", logged=${loggedError}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 6: blocked=true (sandbox is active)
+await runTest(6, 'Canary: blocked=true returns success', async (log) => {
+  const result = await canaryGuard(() => ({ curlExitCode: 7, blocked: true }), log)
+  const isSuccess = !result.error && result.ok === true
+  const loggedOk = log.messages.some(m => m.includes('Sandbox confirmed'))
+  return {
+    pass: isSuccess && loggedOk,
+    detail: isSuccess
+      ? `ok=${result.ok}, logged=${loggedOk}`
+      : 'Expected success but got: ' + JSON.stringify(result),
+  }
+})
+
+console.log('')
+console.log('--- Preflight Guard ---')
+
+// Test 7: null result from agent
+await runTest(7, 'Preflight: null agent result returns error', async (log) => {
+  const result = await preflightGuard(() => null, log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Pre-flight check failed')
+  const loggedError = log.messages.some(m => m.includes('Pre-flight check failed'))
+  return {
+    pass: hasError && correctMsg && loggedError,
+    detail: hasError
+      ? `error="${result.error}", logged=${loggedError}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 8: branch=main
+await runTest(8, 'Preflight: branch=main returns protected branch error', async (log) => {
+  const result = await preflightGuard(() => ({
+    branch: 'main',
+    cleanTree: true,
+    headSha: 'a'.repeat(40),
+  }), log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Cannot run on main')
+  const loggedError = log.messages.some(m => m.includes('Refusing to run on protected branch'))
+  return {
+    pass: hasError && correctMsg && loggedError,
+    detail: hasError
+      ? `error="${result.error}", logged=${loggedError}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 9: branch=master
+await runTest(9, 'Preflight: branch=master returns protected branch error', async (log) => {
+  const result = await preflightGuard(() => ({
+    branch: 'master',
+    cleanTree: true,
+    headSha: 'b'.repeat(40),
+  }), log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Cannot run on master')
+  const loggedError = log.messages.some(m => m.includes('Refusing to run on protected branch "master"'))
+  return {
+    pass: hasError && correctMsg && loggedError,
+    detail: hasError
+      ? `error="${result.error}", logged=${loggedError}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 10: dirty tree with dirtyFiles
+await runTest(10, 'Preflight: dirty tree with dirtyFiles lists them', async (log) => {
+  const dirtyFiles = 'M  differ/differ.go\n?? scratch.txt'
+  const result = await preflightGuard(() => ({
+    branch: 'feature/test',
+    cleanTree: false,
+    headSha: 'c'.repeat(40),
+    dirtyFiles,
+  }), log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Working tree is not clean')
+  const loggedDirty = log.messages.some(m => m.includes('differ/differ.go'))
+  return {
+    pass: hasError && correctMsg && loggedDirty,
+    detail: hasError
+      ? `error="${result.error}", dirtyFilesLogged=${loggedDirty}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 11: dirty tree without dirtyFiles (falls back to "(unknown)")
+await runTest(11, 'Preflight: dirty tree without dirtyFiles shows (unknown)', async (log) => {
+  const result = await preflightGuard(() => ({
+    branch: 'feature/test',
+    cleanTree: false,
+    headSha: 'd'.repeat(40),
+    // no dirtyFiles field
+  }), log)
+  const hasError = !!result.error
+  const correctMsg = result.error && result.error.includes('Working tree is not clean')
+  const loggedUnknown = log.messages.some(m => m.includes('(unknown)'))
+  return {
+    pass: hasError && correctMsg && loggedUnknown,
+    detail: hasError
+      ? `error="${result.error}", unknownLogged=${loggedUnknown}`
+      : 'Expected error but got: ' + JSON.stringify(result),
+  }
+})
+
+// Test 12: clean feature branch (success path)
+await runTest(12, 'Preflight: clean feature branch returns success', async (log) => {
+  const sha = 'abcdef01'.repeat(5)  // 40 chars
+  const result = await preflightGuard(() => ({
+    branch: 'feature/CCXDEV-12345',
+    cleanTree: true,
+    headSha: sha,
+  }), log)
+  const isSuccess = !result.error && result.branch === 'feature/CCXDEV-12345' && result.baseSha === sha
+  const loggedOk = log.messages.some(m => m.includes('Setup OK') && m.includes('feature/CCXDEV-12345'))
+  return {
+    pass: isSuccess && loggedOk,
+    detail: isSuccess
+      ? `branch="${result.branch}", baseSha="${result.baseSha.substring(0, 8)}...", logged=${loggedOk}`
+      : 'Expected success but got: ' + JSON.stringify(result),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log('')
+console.log('=== Results ===')
+console.log(`Total: ${passed + failed} | Passed: ${passed} | Failed: ${failed}`)
+
+if (failed > 0) {
+  process.exit(1)
+}


### PR DESCRIPTION
# Description
Second increment of the `/go-implement` workflow. Adds the sandbox check, git pre-flight validation, and Phase 1 (Implement) with the full agent prompt. 

The workflow now fetches the Jira issue, verifies the sandbox is active, checks git state, and runs the implementation phase. Phases 2 and 3 will follow in subsequent PRs.

First increment was merged in this PR:
https://github.com/RedHatInsights/ccx-notification-service/pull/1257/

For the full workflow with all phases, see the draft PR:
https://github.com/RedHatInsights/ccx-notification-service/pull/1256

## What's new in this increment

- **Cost estimation** (`estimateCost`, `formatCost`)
  - Tracks cost per phase using `budget.spent()` output token deltas
  - INPUT_RATIO = 50 (calibrated from real /usage data with Opus 4 on Vertex AI)

- **Agent feedback** (`logFeedback` helper)
  - Collects feedback from all phases about the workflow instructions themselves
  - Logged at the end of the run for the team to review

- **Schemas** (added to existing Jira schema)
  - `FEEDBACK_FIELD` - shared feedback array field used by all phase schemas
  - `SANDBOX_CANARY_SCHEMA` - curl exit code and blocked status
  - `GIT_PREFLIGHT_SCHEMA` - branch, clean tree, head SHA
  - `IMPLEMENT_SCHEMA` - files modified, summary, warnings, feedback

- **Shared prompt fragment** (`FEEDBACK_PROMPT`)
  - Appended to every agent prompt explaining the feedback array
  - Asks agents to report unclear instructions, spec contradictions, etc.

- **Sandbox canary check**
  - Tries to curl a domain not in the sandbox allowlist
  - If it succeeds, the sandbox is not active and the workflow stops
  - Separate error messages for "agent failed" vs "sandbox not enabled"

- **Git pre-flight checks**
  - Refuses to run on main/master
  - Warns on dirty working tree
  - Captures baseSha for all subsequent git diffs

- **Phase 1: Implement**
  - Full agent prompt: read spec, write code, go mod tidy, make gen-mocks, make style, make license
  - Gate: stops if agent returns null or produces no file changes
  - `displaySummary` on all exit paths so the user always gets a formatted report

- **Tests** (4 new test files)
  - `test-costs.mjs` - 15 tests for cost estimation and formatting
  - `test-feedback.mjs` - 9 tests for the logFeedback helper
  - `test-preflight.mjs` - 12 tests for Jira fetch, sandbox canary, and git preflight guards
  - `test-phases.mjs` - 8 tests for Phase 1 and Phase 2 gate logic

## What's NOT included (coming in follow-up PRs)

- Phase 2 (Unit Tests) agent prompt and gate logic
- Phase 3 (Verify) agent prompt
- UNIT_TEST_SCHEMA and VERIFICATION_SCHEMA
- Summary section with full displaySummary construction

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

- [x] `node .claude/workflows/go-implement/tests/test-costs.mjs` - 15 tests pass
- [x] `node .claude/workflows/go-implement/tests/test-feedback.mjs` - 9 tests pass
- [x] `node .claude/workflows/go-implement/tests/test-preflight.mjs` - 12 tests pass
- [x] `node .claude/workflows/go-implement/tests/test-phases.mjs` - 8 tests pass
- [x] Invoke `/go-implement { "issue": "CCXDEV-XXXXX" }` with sandbox enabled -
      should run through setup, Phase 1, then return with "Phases 2 and 3 not yet implemented"

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
