### PR TITLE
[CCXDEV-16555] add the remaining parts (Phase 2+3) to `/go-implement` workflow

### DIFF
--- a/.claude/workflows/go-implement.js
+++ b/.claude/workflows/go-implement.js
@@ -48,6 +48,7 @@ export const meta = {
     { title: 'Verify', detail: 'Adversarial review of the full diff against the specification' },
   ],
 }
+
 // ---------------------------------------------------------------------------
 // Cost estimation
 // ---------------------------------------------------------------------------
@@ -181,6 +182,79 @@ const IMPLEMENT_SCHEMA = {
   },
 }
 
+// Phase 2 result: test files written, pass/fail status, and any failures that couldn't be fixed.
+// Example: { testFiles: ["differ/storage_test.go"], testsWritten: 5, testsPassed: true, summary: "Added 5 tests for ReadAggregatorReport", failures: [] }
+const UNIT_TEST_SCHEMA = {
+  type: 'object',
+  required: ['testFiles', 'testsWritten', 'testsPassed', 'summary'],
+  properties: {
+    testFiles: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Test files created or modified',
+    },
+    testsWritten: {
+      type: 'integer',
+      description: 'Number of test functions written',
+    },
+    testsPassed: {
+      type: 'boolean',
+      description: 'Whether all tests passed on the final run',
+    },
+    testOutput: {
+      type: 'string',
+      description: 'Last go test output (abbreviated if long)',
+    },
+    summary: {
+      type: 'string',
+      description: 'Brief description of what was tested',
+    },
+    failures: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Descriptions of any test failures that could not be fixed',
+    },
+    feedback: FEEDBACK_FIELD,
+  },
+}
+
+// Phase 3 result: independent review verdict, findings by severity, and make before_commit output.
+// make before_commit runs: style (shellcheck + abcgo + golangci-lint), unit tests, license headers, and coverage check.
+// Example: { verdict: "pass_with_notes", deviations: [{issue: "missing nil check", severity: "minor"}], beforeCommitPassed: true, report: "..." }
+const VERIFICATION_SCHEMA = {
+  type: 'object',
+  required: ['verdict', 'deviations', 'beforeCommitPassed', 'report'],
+  properties: {
+    verdict: {
+      type: 'string',
+      enum: ['pass', 'fail', 'pass_with_notes'],
+    },
+    deviations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['issue', 'severity'],
+        properties: {
+          issue: { type: 'string' },
+          severity: { type: 'string', enum: ['critical', 'major', 'minor', 'note'] },
+          detail: { type: 'string' },
+        },
+      },
+    },
+    beforeCommitPassed: { type: 'boolean', description: 'Whether make before_commit passed (style + tests + license + coverage)' },
+    beforeCommitOutput: {
+      type: 'string',
+      description: 'Output of make before_commit (abbreviated if long)',
+    },
+    report: {
+      type: 'string',
+      description: 'Full verification report text',
+    },
+    feedback: FEEDBACK_FIELD,
+  },
+}
+
+// snapshot token count before any agents run, used to calculate per-phase costs
 const tokensBeforeSetup = budget.spent()
 
 // ---------------------------------------------------------------------------
@@ -404,6 +478,7 @@ ${FEEDBACK_PROMPT}`,
   { label: 'implement', schema: IMPLEMENT_SCHEMA }
 )
 
+// Return results early and end the workflow here if implementation phase failed or was skipped.
 if (!impl) {
   log('Phase 1 failed or was skipped.')
   return {
@@ -427,9 +502,10 @@ if (impl.warnings && impl.warnings.length) {
   impl.warnings.forEach(w => log('  warning: ' + w))
 }
 
-// Gate: termination check to prevent the following phases from running
+// Return results early and end the workflow here if implementation phase produced no results.
 if (!filesModified.length) {
   log('Phase 1 produced no file changes. Nothing to test or verify.')
+
   return {
     error: 'No files modified',
     displaySummary: `## Workflow stopped
@@ -452,18 +528,74 @@ if (!filesModified.length) {
   }
 }
 
-// TODO: Phase 2 (Unit Tests) and Phase 3 (Verify) will be added in follow-up commits.
-log('Phase 1 complete. Phases 2 and 3 not yet implemented.')
-logFeedback({ implement: impl })
+// ---------------------------------------------------------------------------
+// Phase 2: Unit Tests
+// ---------------------------------------------------------------------------
+// Writes tests with assertions derived from the spec, but reads the implementation
+// for function signatures, types, and mock setup. Can only modify test files,
+// export_test.go, and regenerated mocks.
 
-return {
-  displaySummary: `## Workflow results (Phase 1 only)
+phase('Unit Tests')
+log('Phase 2: Writing unit tests...')
 
-**${impl.summary}**
+const tokensBeforeTests = budget.spent()
+const tests = await agent(
+  `You are writing unit tests for a Go code change that was just implemented in this repository. The project conventions from AGENTS.md are already in your context.
 
-| Phase | Result |
-|-------|--------|
-| Implement | ${filesModified.length} file(s) |
+${specContext}
+
+## How to approach testing
+
+- Derive your **test scenarios and expected values** from the issue specification, acceptance criteria, design document (if provided), and BDD feature files (if provided). Together these define what the code should do.
+- You must also read the implementation code to understand function signatures, types, package structure, SQL queries, and mock setup. You need this to write tests that compile and follow the repo's patterns.
+- The distinction: assert against spec-defined behavior, but use implementation knowledge for test structure and setup.
+- If a test correctly asserts spec behavior but the test still fails, that likely means the implementation does not match the spec. In that case, report it as a failure with "implementation may not match spec". Do not modify production code and do not weaken the assertion to make it pass.
+
+## Instructions
+
+1. Run \`git diff ${baseSha}\` to see what was implemented and which files changed (these are uncommitted working tree changes).
+2. Read one or two existing test files in the same packages to learn the patterns (assertion libraries, mock setup, test naming, comment style). Match the style you find.
+3. If the diff shows a new or changed interface, run \`make gen-mocks\` to ensure mocks are up to date before writing tests.
+4. Write unit tests that verify each acceptance criteria from the issue specification. If BDD feature files are provided, use them as additional source of expected behavior. They describe expected user-facing behavior and edge cases that the acceptance criteria may not cover explicitly. Follow the \`export_test.go\` and mock patterns from AGENTS.md.
+5. Run \`make style\` to check linting. Fix any issues it reports and re-run until it passes. If you cannot resolve an issue after 3 attempts, stop and describe it in the failures list.
+6. Run \`go test\` for the affected packages. Capture the output.
+7. If a test fails, you may fix the test code. After 3 edit-and-rerun cycles on the same failing test, stop and add a description of what failed and why to the failures list. Keep the failing test in the file (do not delete it).
+8. If some tests pass and others could not be fixed, keep all tests, both passing and failing.
+9. Run \`make coverage\` to test the coverage. You should maintain or improve the coverage, but there might be uncoverable statements, check whether other test cases cover these scenarios or not.
+10. Run \`make license\` to add license headers to any new \`.go\` files. This must be last because earlier steps (gen-mocks, style fixes) may create new files.
+
+## Constraints
+
+- Do not create any git commits. Leave all changes in the working tree.
+- Do not modify production code (non-test files). You may only change test files, \`export_test.go\`, and regenerated mock files.
+- Do not silently skip or delete a failing test.
+- Focus on the packages that appear in the diff. Do not explore unrelated packages.
+
+## Before finishing, verify
+
+1. Every acceptance criteria from the specification has at least one corresponding test.
+2. \`make style\` passes with no errors.
+3. \`go test\` passes for all affected packages (or every failure is documented in the failures list with a description).
+4. \`make coverage\` passes, or explains why it didn't pass (uncoverable statements, non-existing mocks).
+5. \`make license\` was run after all other steps.
+6. Test assertions check spec-defined expected values, not values copied from the implementation output.
+7. No production code was modified. Only test files, \`export_test.go\`, and mock files were changed.
+8. No git commits were created.
+
+${FEEDBACK_PROMPT}`,
+  { label: 'unit-tests', schema: UNIT_TEST_SCHEMA }
+)
+
+// Return results early and end the workflow here if testing phase failed or was skipped.
+if (!tests) {
+  log('Phase 2 failed or was skipped.')
+  return {
+    error: 'Unit test phase failed',
+    displaySummary: `## Workflow stopped
+
+**Error:** Phase 2 (Unit Tests) agent did not return a result. Phase 1 completed: ${filesModified.length} file(s) modified.
+
+**Summary:** ${impl.summary}
 
 ### Estimated costs
 
@@ -474,9 +606,266 @@ return {
 | **Total** | **${formatCost(setupCost + implCost)}** |
 
 *Estimates based on output tokens. Run \`/usage\` for actuals.*`,
+    implement: { ...impl, costUsd: implCost }, tests: null, verify: null,
+    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost,
+  }
+}
+
+const testsCost = estimateCost(budget.spent() - tokensBeforeTests)
+log(
+  'Phase 2 complete: ' +
+    tests.testsWritten +
+    ' test(s), passed: ' +
+    tests.testsPassed +
+    ' | cost~' + formatCost(testsCost)
+)
+if (tests.testFiles && tests.testFiles.length) {
+  log('  test files: ' + tests.testFiles.join(', '))
+}
+
+// Gate: skip the verification phase if tests failed return early. Running make before_commit
+// on broken code wastes an entire agent's budget discovering known failures.
+if (!tests.testsPassed) {
+  if (tests.failures && tests.failures.length) {
+    tests.failures.forEach(f => log('  failure: ' + f))
+  }
+  if (tests.testOutput) {
+    log('  go test output:')
+    log(tests.testOutput)
+  }
+  log('Tests did not pass. Skipping verification to save cost.')
+  logFeedback({ implement: impl, tests })
+  const failureList = (tests.failures && tests.failures.length)
+    ? '\n\n### Test failures\n\n' + tests.failures.map(f => '- ' + f).join('\n')
+    : ''
+  return {
+    aborted: 'Tests did not pass, verification skipped',
+    displaySummary: `## Workflow stopped
+
+**Tests did not pass. Verification was skipped.**
+
+| Phase | Result |
+|-------|--------|
+| Implement | ${filesModified.length} file(s) |
+| Tests | ${tests.testsWritten} test(s), FAILED |
+
+**Summary:** ${impl.summary}${failureList}
+
+### Estimated costs
+
+| Phase | Cost |
+|-------|------|
+| Setup | ${formatCost(setupCost)} |
+| Implement | ${formatCost(implCost)} |
+| Tests | ${formatCost(testsCost)} |
+| **Total** | **${formatCost(setupCost + implCost + testsCost)}** |
+
+*Estimates based on output tokens. Run \`/usage\` for actuals.*`,
+    implement: { ...impl, costUsd: implCost },
+    tests: { ...tests, costUsd: testsCost },
+    verify: null,
+    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost + testsCost,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Verify
+// ---------------------------------------------------------------------------
+// Read-only code review. Does not modify any files. Runs make before_commit
+// as an independent check and produces a pass/fail verdict with findings.
+
+phase('Verify')
+log('Phase 3: Adversarial verification...')
+
+const tokensBeforeVerify = budget.spent()
+const verify = await agent(
+  `You are an independent reviewer. Your job is to find problems, not to confirm everything is fine. Be skeptical. Default to flagging concerns rather than assuming correctness. The project conventions from AGENTS.md are already in your context.
+
+${specContext}
+
+## Context
+
+A previous agent reported: tests passed=${tests.testsPassed}, testsWritten=${tests.testsWritten}. Verify this independently, do not assume it is accurate. All changes are in the working tree, not committed.
+
+${tests.failures && tests.failures.length ? 'The following test failures were already identified before your review. If \`make before_commit\` fails on any of these, treat them as known issues rather than new findings:\n' + tests.failures.map(f => '- ' + f).join('\n') : ''}
+
+## Severity definitions
+
+- **critical**: bug or correctness issue that must be fixed before merge
+- **major**: significant concern (missing edge case, weak test, spec gap)
+- **minor**: style issue or minor improvement
+- **note**: observation, no action required
+
+## Instructions
+
+1. Run \`git diff ${baseSha}\` to see the full diff (these are uncommitted working tree changes, implementation + tests).
+2. Walk through each acceptance criteria from the specification, the design document (if provided) and BDD scenarios (if provided). Check whether all the criteria are met by the code AND covered by a test. Flag any unmet criteria.
+3. Look for missing edge cases, especially scenarios from the specification, design document, or BDD feature files that the code does not handle.
+4. Look for bugs: logic errors, off-by-one mistakes, nil pointer risks, race conditions, resource leaks, or security issues.
+5. Check test quality: do the test assertions check spec-defined expected values, or do they just mirror what the implementation returns? Flag assertions that would pass even if the code were broken (e.g., asserting the return value matches whatever the function happens to return, rather than what the spec says it should return). If the spec does not define exact expected values, note this limitation.
+6. Run \`make before_commit\` to check style, tests, license headers, and coverage. Report the output and whether it passed or failed (for beforeCommitPassed).
+7. If \`make before_commit\` fails, check whether the failing test or file appears in the diff (\`git diff ${baseSha}\`). If it does not, the failure is likely pre-existing. Also check whether the failure could be caused by a changed dependency (e.g., a modified interface that an existing test relies on). Note the distinction between new and pre-existing failures in your report.
+
+## Constraints
+
+- Do not fix any code. This is a read-only review.
+- Do not silently skip a failing check.
+- Do not create any git commits.
+
+## Before finishing, verify
+
+1. You checked every acceptance criteria against the Jira issue, the implementation and the respective tests, as well as the design doc (if provided) and BDD specs (if provided).
+2. You ran \`make before_commit\` and reported the full output.
+3. Every finding has a severity (critical, major, minor, or note).
+4. Your verdict is one of: pass, fail, or pass_with_notes.
+
+${FEEDBACK_PROMPT}`,
+  { label: 'verify', schema: VERIFICATION_SCHEMA }
+)
+
+// Return results early and end the workflow here if the verification phase failed or was skipped.
+if (!verify) {
+  log('Phase 3 failed or was skipped.')
+  const testResult = tests.testsPassed ? 'passed' : 'FAILED'
+  return {
+    error: 'Verification phase failed',
+    displaySummary: `## Workflow stopped
+
+**Error:** Phase 3 (Verify) agent did not return a result. Phases 1 and 2 completed.
+
+| Phase | Result |
+|-------|--------|
+| Implement | ${filesModified.length} file(s) |
+| Tests | ${tests.testsWritten} test(s), ${testResult} |
+
+**Summary:** ${impl.summary}
+
+### Estimated costs
+
+| Phase | Cost |
+|-------|------|
+| Setup | ${formatCost(setupCost)} |
+| Implement | ${formatCost(implCost)} |
+| Tests | ${formatCost(testsCost)} |
+| **Total** | **${formatCost(setupCost + implCost + testsCost)}** |
+
+*Estimates based on output tokens. Run \`/usage\` for actuals.*`,
+    implement: { ...impl, costUsd: implCost },
+    tests: { ...tests, costUsd: testsCost },
+    verify: null,
+    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost + testsCost,
+  }
+}
+
+const verifyCost = estimateCost(budget.spent() - tokensBeforeVerify)
+
+log('Phase 3 complete. Verdict: ' + verify.verdict + ', make before_commit: ' + (verify.beforeCommitPassed ? 'passed' : 'FAILED') + ' | cost~' + formatCost(verifyCost))
+if (verify.deviations && verify.deviations.length) {
+  verify.deviations.forEach(d => log('  [' + d.severity + '] ' + d.issue))
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+// The workflow logs a summary and returns structured results to the main
+// Claude Code session. The user sees something like:
+//
+//   ## Workflow results
+//
+//   **Added aggregator DB connection to the differ package**
+//
+//   | Phase | Result |
+//   |-------|--------|
+//   | Implement | 3 file(s) |
+//   | Tests | 5 test(s), passed |
+//   | Verify | pass_with_notes, before_commit: passed |
+//
+//   ### Verification report
+//
+//   <full review with findings by severity>
+//
+//   ### Estimated costs
+//
+//   | Phase | Cost |
+//   |-------|------|
+//   | Setup | $0.0475 |
+//   | Implement | $0.4275 |
+//   | Tests | $0.6650 |
+//   | Verify | $0.5700 |
+//   | **Total** | **$1.7100** |
+
+const totalCost = setupCost + implCost + testsCost + verifyCost
+
+log('---')
+log('Workflow complete.')
+log('')
+log('Summary: ' + impl.summary)
+log('')
+log('  Implement: ' + filesModified.length + ' file(s)')
+log('  Tests:     ' + tests.testsWritten + ' test(s), ' + (tests.testsPassed ? 'passed' : 'FAILED'))
+log('  Verify:    ' + verify.verdict + ', before_commit: ' + (verify.beforeCommitPassed ? 'passed' : 'FAILED'))
+log('')
+log('Verification report:')
+log(verify.report)
+
+logFeedback({ implement: impl, tests, verify })
+
+log('')
+log('Estimated costs (check /usage for actuals):')
+log('  Setup:     ' + formatCost(setupCost))
+log('  Implement: ' + formatCost(implCost))
+log('  Tests:     ' + formatCost(testsCost))
+log('  Verify:    ' + formatCost(verifyCost))
+log('  Total:     ' + formatCost(totalCost))
+
+const testResult = tests.testsPassed ? 'passed' : 'FAILED'
+const beforeCommitResult = verify.beforeCommitPassed ? 'passed' : 'FAILED'
+
+// Collect feedback for the markdown summary
+const feedbackItems = Object.entries({ implement: impl, tests, verify })
+  .flatMap(([phaseName, result]) => {
+    const items = (result && result.feedback) || []
+    return items.map(f => '- **[' + phaseName + ']** ' + f)
+  })
+
+const feedbackSection = feedbackItems.length
+  ? '\n\n### Agent feedback on workflow instructions\n\n' + feedbackItems.join('\n')
+  : ''
+
+// This is the final return statement that the main Claude session receives back
+// if the workflow finishes successfully.
+// Claude is instructed to always display the full `displaySummary`, but it also
+// returns the full responses from each agent (...impl, ...tests, ...verify),
+// so Claude can access all the data it needs after the workflow finishes.
+return {
+  displaySummary: `## Workflow results
+
+**${impl.summary}**
+
+| Phase | Result |
+|-------|--------|
+| Implement | ${filesModified.length} file(s) |
+| Tests | ${tests.testsWritten} test(s), ${testResult} |
+| Verify | ${verify.verdict}, before_commit: ${beforeCommitResult} |
+
+### Verification report
+
+${verify.report}${feedbackSection}
+
+### Estimated costs
+
+| Phase | Cost |
+|-------|------|
+| Setup | ${formatCost(setupCost)} |
+| Implement | ${formatCost(implCost)} |
+| Tests | ${formatCost(testsCost)} |
+| Verify | ${formatCost(verifyCost)} |
+| **Total** | **${formatCost(totalCost)}** |
+
+*Estimates based on output tokens. Run \`/usage\` for actuals.*`,
   implement: { ...impl, costUsd: implCost },
-  tests: null,
-  verify: null,
+  tests: { ...tests, costUsd: testsCost },
+  verify: { ...verify, costUsd: verifyCost },
   setupCostUsd: setupCost,
-  totalCostUsd: setupCost + implCost,
+  totalCostUsd: totalCost,
 }

--- a/.claude/workflows/go-implement.js
+++ b/.claude/workflows/go-implement.js
@@ -89,23 +89,23 @@ function formatCost(usd) {
 // ---------------------------------------------------------------------------
 // Agent feedback
 // ---------------------------------------------------------------------------
-// Collect and log feedback from all phases that returned results.
-// Each phase is instructed to give a `feedback` array with agent commentary
-// on the workflow / spec instructions themselves.
-function logFeedback(phases) {
-  // Object.entries converts { implement: ..., tests: ..., verify: ... } into
-  // an array of [name, result] pairs. flatMap collects feedback from each phase
-  // into a single list, prefixed with the phase name.
-  const feedbackLines = Object.entries(phases)
+// Collects feedback from all phases, logs it to the workflow progress output,
+// and returns a markdown section for displaySummary. Returns empty string if
+// no feedback was reported by any phase.
+function collectFeedback(phases) {
+  const items = Object.entries(phases)
     .flatMap(([phaseName, result]) => {
-      const items = (result && result.feedback) || []
-      return items.map(f => `[${phaseName}] ${f}`)
+      const feedback = (result && result.feedback) || []
+      return feedback.map(f => ({ phaseName, text: f }))
     })
-  if (feedbackLines.length) {
+  if (items.length) {
     log('')
     log('Agent feedback on workflow instructions:')
-    feedbackLines.forEach(f => log('  ' + f))
+    items.forEach(f => log('  [' + f.phaseName + '] ' + f.text))
   }
+  return items.length
+    ? '\n\n### Agent feedback on workflow instructions\n\n' + items.map(f => '- **[' + f.phaseName + ']** ' + f.text).join('\n')
+    : ''
 }
 
 // ---------------------------------------------------------------------------
@@ -586,7 +586,9 @@ ${FEEDBACK_PROMPT}`,
   { label: 'unit-tests', schema: UNIT_TEST_SCHEMA }
 )
 
-// Return results early and end the workflow here if testing phase failed or was skipped.
+// Calculate cost even if the agent failed (tokens were still spent).
+const testsCost = estimateCost(budget.spent() - tokensBeforeTests)
+
 if (!tests) {
   log('Phase 2 failed or was skipped.')
   return {
@@ -595,7 +597,7 @@ if (!tests) {
 
 **Error:** Phase 2 (Unit Tests) agent did not return a result. Phase 1 completed: ${filesModified.length} file(s) modified.
 
-**Summary:** ${impl.summary}
+**Summary:** ${impl.summary}${collectFeedback({ implement: impl })}
 
 ### Estimated costs
 
@@ -603,15 +605,14 @@ if (!tests) {
 |-------|------|
 | Setup | ${formatCost(setupCost)} |
 | Implement | ${formatCost(implCost)} |
-| **Total** | **${formatCost(setupCost + implCost)}** |
+| Tests | ${formatCost(testsCost)} |
+| **Total** | **${formatCost(setupCost + implCost + testsCost)}** |
 
 *Estimates based on output tokens. Run \`/usage\` for actuals.*`,
     implement: { ...impl, costUsd: implCost }, tests: null, verify: null,
-    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost,
+    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost + testsCost,
   }
 }
-
-const testsCost = estimateCost(budget.spent() - tokensBeforeTests)
 log(
   'Phase 2 complete: ' +
     tests.testsWritten +
@@ -634,7 +635,6 @@ if (!tests.testsPassed) {
     log(tests.testOutput)
   }
   log('Tests did not pass. Skipping verification to save cost.')
-  logFeedback({ implement: impl, tests })
   const failureList = (tests.failures && tests.failures.length)
     ? '\n\n### Test failures\n\n' + tests.failures.map(f => '- ' + f).join('\n')
     : ''
@@ -649,7 +649,7 @@ if (!tests.testsPassed) {
 | Implement | ${filesModified.length} file(s) |
 | Tests | ${tests.testsWritten} test(s), FAILED |
 
-**Summary:** ${impl.summary}${failureList}
+**Summary:** ${impl.summary}${failureList}${collectFeedback({ implement: impl, tests })}
 
 ### Estimated costs
 
@@ -723,7 +723,9 @@ ${FEEDBACK_PROMPT}`,
   { label: 'verify', schema: VERIFICATION_SCHEMA }
 )
 
-// Return results early and end the workflow here if the verification phase failed or was skipped.
+// Calculate cost even if the agent failed (tokens were still spent).
+const verifyCost = estimateCost(budget.spent() - tokensBeforeVerify)
+
 if (!verify) {
   log('Phase 3 failed or was skipped.')
   const testResult = tests.testsPassed ? 'passed' : 'FAILED'
@@ -738,7 +740,7 @@ if (!verify) {
 | Implement | ${filesModified.length} file(s) |
 | Tests | ${tests.testsWritten} test(s), ${testResult} |
 
-**Summary:** ${impl.summary}
+**Summary:** ${impl.summary}${collectFeedback({ implement: impl, tests })}
 
 ### Estimated costs
 
@@ -747,17 +749,16 @@ if (!verify) {
 | Setup | ${formatCost(setupCost)} |
 | Implement | ${formatCost(implCost)} |
 | Tests | ${formatCost(testsCost)} |
-| **Total** | **${formatCost(setupCost + implCost + testsCost)}** |
+| Verify | ${formatCost(verifyCost)} |
+| **Total** | **${formatCost(setupCost + implCost + testsCost + verifyCost)}** |
 
 *Estimates based on output tokens. Run \`/usage\` for actuals.*`,
     implement: { ...impl, costUsd: implCost },
     tests: { ...tests, costUsd: testsCost },
     verify: null,
-    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost + testsCost,
+    setupCostUsd: setupCost, totalCostUsd: setupCost + implCost + testsCost + verifyCost,
   }
 }
-
-const verifyCost = estimateCost(budget.spent() - tokensBeforeVerify)
 
 log('Phase 3 complete. Verdict: ' + verify.verdict + ', make before_commit: ' + (verify.beforeCommitPassed ? 'passed' : 'FAILED') + ' | cost~' + formatCost(verifyCost))
 if (verify.deviations && verify.deviations.length) {
@@ -808,8 +809,6 @@ log('')
 log('Verification report:')
 log(verify.report)
 
-logFeedback({ implement: impl, tests, verify })
-
 log('')
 log('Estimated costs (check /usage for actuals):')
 log('  Setup:     ' + formatCost(setupCost))
@@ -820,17 +819,7 @@ log('  Total:     ' + formatCost(totalCost))
 
 const testResult = tests.testsPassed ? 'passed' : 'FAILED'
 const beforeCommitResult = verify.beforeCommitPassed ? 'passed' : 'FAILED'
-
-// Collect feedback for the markdown summary
-const feedbackItems = Object.entries({ implement: impl, tests, verify })
-  .flatMap(([phaseName, result]) => {
-    const items = (result && result.feedback) || []
-    return items.map(f => '- **[' + phaseName + ']** ' + f)
-  })
-
-const feedbackSection = feedbackItems.length
-  ? '\n\n### Agent feedback on workflow instructions\n\n' + feedbackItems.join('\n')
-  : ''
+const feedbackSection = collectFeedback({ implement: impl, tests, verify })
 
 // This is the final return statement that the main Claude session receives back
 // if the workflow finishes successfully.

--- a/.claude/workflows/go-implement.js
+++ b/.claude/workflows/go-implement.js
@@ -562,7 +562,7 @@ ${specContext}
 7. If a test fails, you may fix the test code. After 3 edit-and-rerun cycles on the same failing test, stop and add a description of what failed and why to the failures list. Keep the failing test in the file (do not delete it).
 8. If some tests pass and others could not be fixed, keep all tests, both passing and failing.
 9. Run \`make coverage\` to test the coverage. You should maintain or improve the coverage, but there might be uncoverable statements, check whether other test cases cover these scenarios or not.
-10. Run \`make license\` to add license headers to any new \`.go\` files. This must be last because earlier steps (gen-mocks, style fixes) may create new files.
+10. Ensure allowed test and mock files have license headers. Do not modify production files; report any missing production-file headers for Phase 1 to address.
 
 ## Constraints
 

--- a/.claude/workflows/go-implement/tests/test-feedback.mjs
+++ b/.claude/workflows/go-implement/tests/test-feedback.mjs
@@ -1,172 +1,159 @@
-// Test suite for logFeedback() from go-implement.js
+// Test suite for collectFeedback() from go-implement.js
 //
-// Uses the actual phase key names from the workflow: implement, tests, verify.
+// collectFeedback both logs feedback to the workflow progress output
+// and returns a markdown section string for displaySummary.
 
-// --- Extract the function under test, injecting a mock log() ---
+const logs = []
+function log(msg) { logs.push(msg) }
 
-let captured = []
-
-function log(...args) {
-  captured.push(args.join(' '))
-}
-
-function logFeedback(phases) {
-  const feedbackLines = Object.entries(phases)
+// Extracted from go-implement.js
+function collectFeedback(phases) {
+  const items = Object.entries(phases)
     .flatMap(([phaseName, result]) => {
-      const items = (result && result.feedback) || []
-      return items.map(f => `[${phaseName}] ${f}`)
+      const feedback = (result && result.feedback) || []
+      return feedback.map(f => ({ phaseName, text: f }))
     })
-  if (feedbackLines.length) {
+  if (items.length) {
     log('')
     log('Agent feedback on workflow instructions:')
-    feedbackLines.forEach(f => log('  ' + f))
+    items.forEach(f => log('  [' + f.phaseName + '] ' + f.text))
   }
+  return items.length
+    ? '\n\n### Agent feedback on workflow instructions\n\n' + items.map(f => '- **[' + f.phaseName + ']** ' + f.text).join('\n')
+    : ''
 }
-
-// --- Test harness ---
 
 let passed = 0
 let failed = 0
 
-function test(name, fn) {
-  captured = []
+function test(id, description, fn) {
+  logs.length = 0
   try {
-    fn()
-    passed++
-    console.log(`[PASS] ${name}`)
+    const ok = fn()
+    if (ok) {
+      console.log(`[PASS] ${id}. ${description}`)
+      passed++
+    } else {
+      console.log(`[FAIL] ${id}. ${description}`)
+      failed++
+    }
   } catch (e) {
+    console.log(`[FAIL] ${id}. ${description} (threw: ${e.message})`)
     failed++
-    console.log(`[FAIL] ${name}`)
-    console.log(`       ${e.message}`)
   }
 }
 
-function assert(cond, msg) {
-  if (!cond) throw new Error(msg)
-}
-
-function assertDeep(actual, expected, msg) {
-  const a = JSON.stringify(actual)
-  const e = JSON.stringify(expected)
-  if (a !== e) throw new Error(`${msg}\n         expected: ${e}\n         actual:   ${a}`)
-}
-
-// --- Tests ---
-
-test('1. No feedback from any phase', () => {
-  logFeedback({
-    implement: { feedback: [] },
-    tests:     { feedback: [] },
-    verify:    { feedback: [] },
+// 1. No feedback from any phase
+test(1, 'No feedback returns empty string and no logs', () => {
+  const result = collectFeedback({
+    implement: { summary: 'did stuff', feedback: [] },
+    tests: { testsWritten: 3, feedback: [] },
+    verify: { verdict: 'pass', feedback: [] },
   })
-  assertDeep(captured, [], 'should produce no output when all feedback arrays are empty')
+  return result === '' && logs.length === 0
 })
 
-test('2. One phase with feedback', () => {
-  logFeedback({
-    implement: { feedback: ['improve the prompt'] },
-    tests:     { feedback: [] },
-    verify:    { feedback: [] },
+// 2. Feedback from one phase
+test(2, 'Single phase feedback returns markdown and logs', () => {
+  const result = collectFeedback({
+    implement: { feedback: ['instruction 2 was unclear'] },
   })
-  assertDeep(captured, [
-    '',
-    'Agent feedback on workflow instructions:',
-    '  [implement] improve the prompt',
-  ], 'should log feedback from the single phase that has it')
+  return result.includes('### Agent feedback') &&
+    result.includes('- **[implement]** instruction 2 was unclear') &&
+    logs.some(l => l.includes('[implement] instruction 2 was unclear'))
 })
 
-test('3. All three phases with feedback', () => {
-  logFeedback({
-    implement: { feedback: ['impl note'] },
-    tests:     { feedback: ['test note'] },
-    verify:    { feedback: ['verify note'] },
+// 3. Feedback from all three phases
+test(3, 'All phases produce prefixed entries', () => {
+  const result = collectFeedback({
+    implement: { feedback: ['a'] },
+    tests: { feedback: ['b'] },
+    verify: { feedback: ['c'] },
   })
-  assertDeep(captured, [
-    '',
-    'Agent feedback on workflow instructions:',
-    '  [implement] impl note',
-    '  [tests] test note',
-    '  [verify] verify note',
-  ], 'should log feedback from all phases in insertion order')
+  return result.includes('**[implement]** a') &&
+    result.includes('**[tests]** b') &&
+    result.includes('**[verify]** c') &&
+    logs.filter(l => l.startsWith('  [')).length === 3
 })
 
-test('4. Null phase result', () => {
-  logFeedback({
-    implement: { feedback: ['something'] },
-    tests:     null,
-    verify:    { feedback: ['other'] },
+// 4. Null phase result
+test(4, 'Null phase result does not crash', () => {
+  const result = collectFeedback({
+    implement: null,
+    tests: { feedback: ['something'] },
   })
-  assertDeep(captured, [
-    '',
-    'Agent feedback on workflow instructions:',
-    '  [implement] something',
-    '  [verify] other',
-  ], 'null result should be safely skipped via (result && result.feedback) || []')
+  return result.includes('**[tests]** something') &&
+    !result.includes('[implement]')
 })
 
-test('5. Missing feedback field ({})', () => {
-  logFeedback({
-    implement: {},
-    tests:     {},
-    verify:    {},
+// 5. Missing feedback field
+test(5, 'Phase with no feedback field produces nothing', () => {
+  const result = collectFeedback({
+    implement: { summary: 'did stuff' },
   })
-  assertDeep(captured, [], 'empty objects with no feedback field should produce no output')
+  return result === '' && logs.length === 0
 })
 
-test('6. Undefined feedback', () => {
-  logFeedback({
+// 6. Undefined feedback
+test(6, 'Undefined feedback treated as empty', () => {
+  const result = collectFeedback({
     implement: { feedback: undefined },
-    tests:     { feedback: undefined },
-    verify:    { feedback: undefined },
   })
-  assertDeep(captured, [], 'undefined feedback should be treated as empty via || []')
+  return result === '' && logs.length === 0
 })
 
-test('7. Multiple items from one phase', () => {
-  logFeedback({
-    implement: { feedback: ['first note', 'second note', 'third note'] },
+// 7. Multiple items from one phase
+test(7, 'Multiple items from one phase each get a line', () => {
+  const result = collectFeedback({
+    implement: { feedback: ['first', 'second', 'third'] },
   })
-  assertDeep(captured, [
-    '',
-    'Agent feedback on workflow instructions:',
-    '  [implement] first note',
-    '  [implement] second note',
-    '  [implement] third note',
-  ], 'multiple feedback items from one phase should each get their own line')
+  const bullets = result.split('\n').filter(l => l.startsWith('- **[implement]**'))
+  return bullets.length === 3 &&
+    logs.filter(l => l.startsWith('  [implement]')).length === 3
 })
 
-test('8. Early exit (2 phases only)', () => {
-  // Matches the actual early-exit call : logFeedback({ implement: impl, tests })
-  logFeedback({
-    implement: { feedback: ['early feedback'] },
-    tests:     { feedback: ['test feedback'] },
+// 8. Early exit with two phases (verify missing)
+test(8, 'Works with only implement and tests', () => {
+  const result = collectFeedback({
+    implement: { feedback: ['a'] },
+    tests: { feedback: ['b'] },
   })
-  assertDeep(captured, [
-    '',
-    'Agent feedback on workflow instructions:',
-    '  [implement] early feedback',
-    '  [tests] test feedback',
-  ], 'should work with fewer than 3 phases (mirrors the early exit path)')
+  return result.includes('**[implement]** a') &&
+    result.includes('**[tests]** b') &&
+    !result.includes('[verify]')
 })
 
-test('9. Object.entries ordering preserved', () => {
-  // Object.entries preserves insertion order for string keys in modern JS engines.
-  // Use the actual phase keys in a deliberate order to confirm.
-  const phases = {}
-  phases.verify    = { feedback: ['v'] }
-  phases.implement = { feedback: ['i'] }
-  phases.tests     = { feedback: ['t'] }
-
-  logFeedback(phases)
-
-  // Order must follow insertion: verify, implement, tests
-  assert(captured[2] === '  [verify] v',    `expected verify first, got: ${captured[2]}`)
-  assert(captured[3] === '  [implement] i', `expected implement second, got: ${captured[3]}`)
-  assert(captured[4] === '  [tests] t',     `expected tests third, got: ${captured[4]}`)
+// 9. Object.entries ordering preserved
+test(9, 'Phase order matches insertion order', () => {
+  const result = collectFeedback({
+    implement: { feedback: ['first'] },
+    tests: { feedback: ['second'] },
+    verify: { feedback: ['third'] },
+  })
+  const implIdx = result.indexOf('[implement]')
+  const testsIdx = result.indexOf('[tests]')
+  const verifyIdx = result.indexOf('[verify]')
+  return implIdx < testsIdx && testsIdx < verifyIdx
 })
 
-// --- Summary ---
+// 10. Return value is valid markdown
+test(10, 'Markdown starts with newlines and heading', () => {
+  const result = collectFeedback({
+    implement: { feedback: ['x'] },
+  })
+  return result.startsWith('\n\n### Agent feedback on workflow instructions\n\n')
+})
+
+// 11. Log output matches expected format
+test(11, 'Log lines use [phaseName] prefix format', () => {
+  collectFeedback({
+    implement: { feedback: ['check this'] },
+  })
+  return logs[0] === '' &&
+    logs[1] === 'Agent feedback on workflow instructions:' &&
+    logs[2] === '  [implement] check this'
+})
 
 console.log('')
 console.log(`Total: ${passed + failed} | Passed: ${passed} | Failed: ${failed}`)
-process.exit(failed > 0 ? 1 : 0)
+if (failed > 0) process.exit(1)

--- a/.claude/workflows/go-implement/tests/test-phases.mjs
+++ b/.claude/workflows/go-implement/tests/test-phases.mjs
@@ -43,7 +43,7 @@ function phase1Gate(impl, setupCost, implCost) {
     }
   }
 
-  
+
   const filesModified = impl.filesModified || []
 
   if (!filesModified.length) {

--- a/.claude/workflows/go-implement/tests/test-phases.mjs
+++ b/.claude/workflows/go-implement/tests/test-phases.mjs
@@ -1,0 +1,290 @@
+// Test script for go-implement.js Phase 1 and Phase 2 gate logic.
+//
+// Extracts cost functions, logFeedback,
+// then simulates Phase 1 and Phase 2
+// gate logic with 8 test cases.
+
+// ---------------------------------------------------------------------------
+// Extracted logFeedback
+// ---------------------------------------------------------------------------
+const logs = []
+function log(msg) { logs.push(msg) }
+
+function logFeedback(phases) {
+  const all = Object.entries(phases)
+    .flatMap(([name, result]) => {
+      const items = (result && result.feedback) || []
+      return items.map(f => `[${name}] ${f}`)
+    })
+  if (all.length) {
+    log('')
+    log('Agent feedback on workflow instructions:')
+    all.forEach(f => log('  ' + f))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Simulate Phase 1 gate logic
+// ---------------------------------------------------------------------------
+// Parameters:
+//   impl       - the agent result (null if failed)
+//   setupCost  - cost from setup phase
+//   implCost   - cost from impl phase (computed externally for testing)
+// Returns the same shape the workflow would return at that gate.
+function phase1Gate(impl, setupCost, implCost) {
+  if (!impl) {
+    return {
+      error: 'Implementation phase failed',
+      implement: null,
+      tests: null,
+      verify: null,
+      setupCostUsd: setupCost,
+      totalCostUsd: setupCost,
+    }
+  }
+
+  
+  const filesModified = impl.filesModified || []
+
+  if (!filesModified.length) {
+    return {
+      error: 'No files modified',
+      implement: { ...impl, costUsd: implCost },
+      tests: null,
+      verify: null,
+      setupCostUsd: setupCost,
+      totalCostUsd: setupCost + implCost,
+    }
+  }
+
+  // Passed gate -- return a sentinel so tests can distinguish
+  return { passed: true, implCost }
+}
+
+// ---------------------------------------------------------------------------
+// Simulate Phase 2 gate logic
+// ---------------------------------------------------------------------------
+// Parameters:
+//   tests      - the agent result (null if failed)
+//   impl       - the impl result (spread into output)
+//   implCost   - cost from Phase 1
+//   testsCost  - cost from Phase 2 (computed externally)
+//   setupCost  - cost from setup phase
+function phase2Gate(tests, impl, implCost, testsCost, setupCost) {
+  if (!tests) {
+    return {
+      error: 'Unit test phase failed',
+      implement: { ...impl, costUsd: implCost },
+      tests: null,
+      verify: null,
+      setupCostUsd: setupCost,
+      totalCostUsd: setupCost + implCost,
+    }
+  }
+
+  if (!tests.testsPassed) {
+    if (tests.failures && tests.failures.length) {
+      // would log failures here
+    }
+    logFeedback({ implement: impl, tests })
+    return {
+      implement: { ...impl, costUsd: implCost },
+      tests: { ...tests, costUsd: testsCost },
+      verify: null,
+      aborted: 'Tests did not pass, verification skipped',
+      setupCostUsd: setupCost,
+      totalCostUsd: setupCost + implCost + testsCost,
+    }
+  }
+
+  // Passed gate
+  return { passed: true, testsCost }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+let passed = 0
+let failed = 0
+
+function assert(condition, label) {
+  if (condition) {
+    console.log(`[PASS] ${label}`)
+    passed++
+  } else {
+    console.log(`[FAIL] ${label}`)
+    failed++
+  }
+}
+
+function has(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key)
+}
+
+// Fixed costs for reproducibility
+const SETUP_COST = 0.05
+const IMPL_COST = 0.12
+const TESTS_COST = 0.08
+
+// ---- Phase 1 tests ----
+
+console.log('\n=== Phase 1 Gate Tests ===\n')
+
+// Test 1: impl=null
+{
+  const r = phase1Gate(null, SETUP_COST, IMPL_COST)
+  assert(
+    r.error === 'Implementation phase failed' &&
+    r.implement === null &&
+    r.tests === null &&
+    r.verify === null &&
+    has(r, 'setupCostUsd') && r.setupCostUsd === SETUP_COST &&
+    has(r, 'totalCostUsd') && r.totalCostUsd === SETUP_COST,
+    'Test 1: impl=null returns error with null phases, totalCostUsd=setupCost'
+  )
+}
+
+// Test 2: filesModified=undefined (impl exists but no filesModified key)
+{
+  const impl = { summary: 'did stuff' }  // no filesModified property
+  const r = phase1Gate(impl, SETUP_COST, IMPL_COST)
+  assert(
+    r.error === 'No files modified' &&
+    r.implement !== null &&
+    has(r.implement, 'costUsd') && r.implement.costUsd === IMPL_COST &&
+    r.implement.summary === 'did stuff' &&
+    r.tests === null &&
+    r.verify === null &&
+    r.setupCostUsd === SETUP_COST &&
+    r.totalCostUsd === SETUP_COST + IMPL_COST,
+    'Test 2: filesModified=undefined triggers no-files gate, impl spread with costUsd'
+  )
+}
+
+// Test 3: filesModified=[] (empty array)
+{
+  const impl = { filesModified: [], summary: 'nothing changed' }
+  const r = phase1Gate(impl, SETUP_COST, IMPL_COST)
+  assert(
+    r.error === 'No files modified' &&
+    r.implement !== null &&
+    has(r.implement, 'costUsd') && r.implement.costUsd === IMPL_COST &&
+    r.implement.filesModified.length === 0 &&
+    r.tests === null &&
+    r.verify === null &&
+    r.setupCostUsd === SETUP_COST &&
+    r.totalCostUsd === SETUP_COST + IMPL_COST,
+    'Test 3: filesModified=[] triggers no-files gate with spread impl'
+  )
+}
+
+// Test 4: filesModified=["file.go"] with warnings -- should pass the gate
+{
+  const impl = {
+    filesModified: ['file.go'],
+    warnings: ['something looked odd'],
+    summary: 'implemented feature',
+  }
+  const r = phase1Gate(impl, SETUP_COST, IMPL_COST)
+  assert(
+    r.passed === true &&
+    r.implCost === IMPL_COST &&
+    !has(r, 'error') &&
+    !has(r, 'implement') &&
+    !has(r, 'tests') &&
+    !has(r, 'verify'),
+    'Test 4: filesModified=["file.go"] with warnings passes gate'
+  )
+}
+
+// ---- Phase 2 tests ----
+
+console.log('\n=== Phase 2 Gate Tests ===\n')
+
+const implForP2 = {
+  filesModified: ['differ/storage.go'],
+  summary: 'added new query',
+}
+
+// Test 5: tests=null
+{
+  const r = phase2Gate(null, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
+  assert(
+    r.error === 'Unit test phase failed' &&
+    r.implement !== null &&
+    has(r.implement, 'costUsd') && r.implement.costUsd === IMPL_COST &&
+    r.implement.summary === 'added new query' &&
+    r.tests === null &&
+    r.verify === null &&
+    has(r, 'setupCostUsd') && r.setupCostUsd === SETUP_COST &&
+    has(r, 'totalCostUsd') && r.totalCostUsd === SETUP_COST + IMPL_COST,
+    'Test 5: tests=null returns error, impl spread with costUsd, tests/verify null'
+  )
+}
+
+// Test 6: testsPassed=false WITH failures array
+{
+  const tests = {
+    testsPassed: false,
+    testsWritten: 3,
+    failures: ['TestFoo: expected 1 got 2', 'TestBar: nil pointer'],
+  }
+  const r = phase2Gate(tests, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
+  assert(
+    !has(r, 'error') &&
+    has(r, 'aborted') && r.aborted === 'Tests did not pass, verification skipped' &&
+    r.implement !== null && r.implement.costUsd === IMPL_COST &&
+    r.tests !== null && r.tests.costUsd === TESTS_COST &&
+    r.tests.testsPassed === false &&
+    r.tests.failures.length === 2 &&
+    r.verify === null &&
+    r.setupCostUsd === SETUP_COST &&
+    r.totalCostUsd === SETUP_COST + IMPL_COST + TESTS_COST,
+    'Test 6: testsPassed=false with failures returns aborted, both phases costed'
+  )
+}
+
+// Test 7: testsPassed=false WITHOUT failures array
+{
+  const tests = {
+    testsPassed: false,
+    testsWritten: 1,
+  }
+  const r = phase2Gate(tests, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
+  assert(
+    has(r, 'aborted') && r.aborted === 'Tests did not pass, verification skipped' &&
+    r.implement !== null && r.implement.costUsd === IMPL_COST &&
+    r.tests !== null && r.tests.costUsd === TESTS_COST &&
+    !has(r.tests, 'failures') &&
+    r.verify === null &&
+    r.setupCostUsd === SETUP_COST &&
+    r.totalCostUsd === SETUP_COST + IMPL_COST + TESTS_COST,
+    'Test 7: testsPassed=false without failures still aborts, no failures key'
+  )
+}
+
+// Test 8: testsPassed=true -- should pass the gate
+{
+  const tests = {
+    testsPassed: true,
+    testsWritten: 5,
+    failures: [],
+  }
+  const r = phase2Gate(tests, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
+  assert(
+    r.passed === true &&
+    r.testsCost === TESTS_COST &&
+    !has(r, 'error') &&
+    !has(r, 'aborted') &&
+    !has(r, 'implement') &&
+    !has(r, 'tests') &&
+    !has(r, 'verify'),
+    'Test 8: testsPassed=true passes gate to Phase 3'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n=== Total: ${passed} passed, ${failed} failed out of ${passed + failed} ===\n`)
+process.exit(failed > 0 ? 1 : 0)

--- a/.claude/workflows/go-implement/tests/test-phases.mjs
+++ b/.claude/workflows/go-implement/tests/test-phases.mjs
@@ -1,84 +1,67 @@
 // Test script for go-implement.js Phase 1 and Phase 2 gate logic.
 //
-// Extracts cost functions, logFeedback,
-// then simulates Phase 1 and Phase 2
-// gate logic with 8 test cases.
+// Simulates Phase 1 and Phase 2 gate decisions with 8 test cases.
+// Cost is now calculated before the null gate (tokens are spent even
+// if the agent fails), and collectFeedback is included in displaySummary.
 
 // ---------------------------------------------------------------------------
-// Extracted logFeedback
+// Mocks
 // ---------------------------------------------------------------------------
 const logs = []
 function log(msg) { logs.push(msg) }
 
-function logFeedback(phases) {
-  const all = Object.entries(phases)
-    .flatMap(([name, result]) => {
-      const items = (result && result.feedback) || []
-      return items.map(f => `[${name}] ${f}`)
+function collectFeedback(phases) {
+  const items = Object.entries(phases)
+    .flatMap(([phaseName, result]) => {
+      const feedback = (result && result.feedback) || []
+      return feedback.map(f => ({ phaseName, text: f }))
     })
-  if (all.length) {
+  if (items.length) {
     log('')
     log('Agent feedback on workflow instructions:')
-    all.forEach(f => log('  ' + f))
+    items.forEach(f => log('  [' + f.phaseName + '] ' + f.text))
   }
+  return items.length
+    ? '\n\n### Agent feedback\n\n' + items.map(f => '- **[' + f.phaseName + ']** ' + f.text).join('\n')
+    : ''
 }
 
 // ---------------------------------------------------------------------------
-// Simulate Phase 1 gate logic
+// Phase 1 gate logic
 // ---------------------------------------------------------------------------
-// Parameters:
-//   impl       - the agent result (null if failed)
-//   setupCost  - cost from setup phase
-//   implCost   - cost from impl phase (computed externally for testing)
-// Returns the same shape the workflow would return at that gate.
+// Cost is calculated before the null gate (the agent may have spent tokens).
 function phase1Gate(impl, setupCost, implCost) {
   if (!impl) {
     return {
       error: 'Implementation phase failed',
-      implement: null,
-      tests: null,
-      verify: null,
-      setupCostUsd: setupCost,
-      totalCostUsd: setupCost,
+      implement: null, tests: null, verify: null,
+      setupCostUsd: setupCost, totalCostUsd: setupCost,
     }
   }
-
 
   const filesModified = impl.filesModified || []
 
   if (!filesModified.length) {
     return {
       error: 'No files modified',
-      implement: { ...impl, costUsd: implCost },
-      tests: null,
-      verify: null,
-      setupCostUsd: setupCost,
-      totalCostUsd: setupCost + implCost,
+      implement: { ...impl, costUsd: implCost }, tests: null, verify: null,
+      setupCostUsd: setupCost, totalCostUsd: setupCost + implCost,
     }
   }
 
-  // Passed gate -- return a sentinel so tests can distinguish
   return { passed: true, implCost }
 }
 
 // ---------------------------------------------------------------------------
-// Simulate Phase 2 gate logic
+// Phase 2 gate logic
 // ---------------------------------------------------------------------------
-// Parameters:
-//   tests      - the agent result (null if failed)
-//   impl       - the impl result (spread into output)
-//   implCost   - cost from Phase 1
-//   testsCost  - cost from Phase 2 (computed externally)
-//   setupCost  - cost from setup phase
+// Cost is calculated before the null gate.
 function phase2Gate(tests, impl, implCost, testsCost, setupCost) {
   if (!tests) {
     return {
       error: 'Unit test phase failed',
-      implement: { ...impl, costUsd: implCost },
-      tests: null,
-      verify: null,
-      setupCostUsd: setupCost,
-      totalCostUsd: setupCost + implCost,
+      implement: { ...impl, costUsd: implCost }, tests: null, verify: null,
+      setupCostUsd: setupCost, totalCostUsd: setupCost + implCost + testsCost,
     }
   }
 
@@ -86,7 +69,6 @@ function phase2Gate(tests, impl, implCost, testsCost, setupCost) {
     if (tests.failures && tests.failures.length) {
       // would log failures here
     }
-    logFeedback({ implement: impl, tests })
     return {
       implement: { ...impl, costUsd: implCost },
       tests: { ...tests, costUsd: testsCost },
@@ -97,7 +79,6 @@ function phase2Gate(tests, impl, implCost, testsCost, setupCost) {
     }
   }
 
-  // Passed gate
   return { passed: true, testsCost }
 }
 
@@ -108,6 +89,7 @@ let passed = 0
 let failed = 0
 
 function assert(condition, label) {
+  logs.length = 0
   if (condition) {
     console.log(`[PASS] ${label}`)
     passed++
@@ -121,7 +103,6 @@ function has(obj, key) {
   return Object.prototype.hasOwnProperty.call(obj, key)
 }
 
-// Fixed costs for reproducibility
 const SETUP_COST = 0.05
 const IMPL_COST = 0.12
 const TESTS_COST = 0.08
@@ -138,47 +119,40 @@ console.log('\n=== Phase 1 Gate Tests ===\n')
     r.implement === null &&
     r.tests === null &&
     r.verify === null &&
-    has(r, 'setupCostUsd') && r.setupCostUsd === SETUP_COST &&
-    has(r, 'totalCostUsd') && r.totalCostUsd === SETUP_COST,
+    r.setupCostUsd === SETUP_COST &&
+    r.totalCostUsd === SETUP_COST,
     'Test 1: impl=null returns error with null phases, totalCostUsd=setupCost'
   )
 }
 
-// Test 2: filesModified=undefined (impl exists but no filesModified key)
+// Test 2: filesModified=undefined
 {
-  const impl = { summary: 'did stuff' }  // no filesModified property
+  const impl = { summary: 'did stuff' }
   const r = phase1Gate(impl, SETUP_COST, IMPL_COST)
   assert(
     r.error === 'No files modified' &&
     r.implement !== null &&
     has(r.implement, 'costUsd') && r.implement.costUsd === IMPL_COST &&
-    r.implement.summary === 'did stuff' &&
     r.tests === null &&
     r.verify === null &&
-    r.setupCostUsd === SETUP_COST &&
     r.totalCostUsd === SETUP_COST + IMPL_COST,
     'Test 2: filesModified=undefined triggers no-files gate, impl spread with costUsd'
   )
 }
 
-// Test 3: filesModified=[] (empty array)
+// Test 3: filesModified=[]
 {
   const impl = { filesModified: [], summary: 'nothing changed' }
   const r = phase1Gate(impl, SETUP_COST, IMPL_COST)
   assert(
     r.error === 'No files modified' &&
-    r.implement !== null &&
-    has(r.implement, 'costUsd') && r.implement.costUsd === IMPL_COST &&
     r.implement.filesModified.length === 0 &&
-    r.tests === null &&
-    r.verify === null &&
-    r.setupCostUsd === SETUP_COST &&
     r.totalCostUsd === SETUP_COST + IMPL_COST,
-    'Test 3: filesModified=[] triggers no-files gate with spread impl'
+    'Test 3: filesModified=[] triggers no-files gate'
   )
 }
 
-// Test 4: filesModified=["file.go"] with warnings -- should pass the gate
+// Test 4: filesModified=["file.go"] with warnings
 {
   const impl = {
     filesModified: ['file.go'],
@@ -188,11 +162,7 @@ console.log('\n=== Phase 1 Gate Tests ===\n')
   const r = phase1Gate(impl, SETUP_COST, IMPL_COST)
   assert(
     r.passed === true &&
-    r.implCost === IMPL_COST &&
-    !has(r, 'error') &&
-    !has(r, 'implement') &&
-    !has(r, 'tests') &&
-    !has(r, 'verify'),
+    !has(r, 'error'),
     'Test 4: filesModified=["file.go"] with warnings passes gate'
   )
 }
@@ -206,85 +176,63 @@ const implForP2 = {
   summary: 'added new query',
 }
 
-// Test 5: tests=null
+// Test 5: tests=null (cost still included)
 {
   const r = phase2Gate(null, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
   assert(
     r.error === 'Unit test phase failed' &&
-    r.implement !== null &&
-    has(r.implement, 'costUsd') && r.implement.costUsd === IMPL_COST &&
-    r.implement.summary === 'added new query' &&
+    r.implement.costUsd === IMPL_COST &&
     r.tests === null &&
     r.verify === null &&
-    has(r, 'setupCostUsd') && r.setupCostUsd === SETUP_COST &&
-    has(r, 'totalCostUsd') && r.totalCostUsd === SETUP_COST + IMPL_COST,
-    'Test 5: tests=null returns error, impl spread with costUsd, tests/verify null'
+    r.totalCostUsd === SETUP_COST + IMPL_COST + TESTS_COST,
+    'Test 5: tests=null includes testsCost in total (tokens spent even on failure)'
   )
 }
 
-// Test 6: testsPassed=false WITH failures array
+// Test 6: testsPassed=false with failures
 {
   const tests = {
     testsPassed: false,
     testsWritten: 3,
-    failures: ['TestFoo: expected 1 got 2', 'TestBar: nil pointer'],
+    failures: ['TestFoo: expected 1 got 2'],
   }
   const r = phase2Gate(tests, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
   assert(
     !has(r, 'error') &&
-    has(r, 'aborted') && r.aborted === 'Tests did not pass, verification skipped' &&
-    r.implement !== null && r.implement.costUsd === IMPL_COST &&
-    r.tests !== null && r.tests.costUsd === TESTS_COST &&
+    has(r, 'aborted') &&
+    r.aborted === 'Tests did not pass, verification skipped' &&
+    r.tests.costUsd === TESTS_COST &&
     r.tests.testsPassed === false &&
-    r.tests.failures.length === 2 &&
-    r.verify === null &&
-    r.setupCostUsd === SETUP_COST &&
     r.totalCostUsd === SETUP_COST + IMPL_COST + TESTS_COST,
-    'Test 6: testsPassed=false with failures returns aborted, both phases costed'
+    'Test 6: testsPassed=false returns aborted with test cost'
   )
 }
 
-// Test 7: testsPassed=false WITHOUT failures array
+// Test 7: testsPassed=false without failures key
 {
-  const tests = {
-    testsPassed: false,
-    testsWritten: 1,
-  }
+  const tests = { testsPassed: false, testsWritten: 1 }
   const r = phase2Gate(tests, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
   assert(
-    has(r, 'aborted') && r.aborted === 'Tests did not pass, verification skipped' &&
-    r.implement !== null && r.implement.costUsd === IMPL_COST &&
-    r.tests !== null && r.tests.costUsd === TESTS_COST &&
-    !has(r.tests, 'failures') &&
-    r.verify === null &&
-    r.setupCostUsd === SETUP_COST &&
-    r.totalCostUsd === SETUP_COST + IMPL_COST + TESTS_COST,
-    'Test 7: testsPassed=false without failures still aborts, no failures key'
+    has(r, 'aborted') &&
+    r.tests !== null &&
+    r.verify === null,
+    'Test 7: testsPassed=false without failures still aborts'
   )
 }
 
-// Test 8: testsPassed=true -- should pass the gate
+// Test 8: testsPassed=true
 {
-  const tests = {
-    testsPassed: true,
-    testsWritten: 5,
-    failures: [],
-  }
+  const tests = { testsPassed: true, testsWritten: 5 }
   const r = phase2Gate(tests, implForP2, IMPL_COST, TESTS_COST, SETUP_COST)
   assert(
     r.passed === true &&
-    r.testsCost === TESTS_COST &&
     !has(r, 'error') &&
-    !has(r, 'aborted') &&
-    !has(r, 'implement') &&
-    !has(r, 'tests') &&
-    !has(r, 'verify'),
+    !has(r, 'aborted'),
     'Test 8: testsPassed=true passes gate to Phase 3'
   )
 }
 
-// ---------------------------------------------------------------------------
-// Summary
-// ---------------------------------------------------------------------------
-console.log(`\n=== Total: ${passed} passed, ${failed} failed out of ${passed + failed} ===\n`)
-process.exit(failed > 0 ? 1 : 0)
+console.log('')
+console.log(`=== Total: ${passed} passed, ${failed} failed out of ${passed + failed} ===`)
+console.log('')
+if (failed > 0) process.exit(1)

--- a/.claude/workflows/go-implement/tests/test-verify-prompt.mjs
+++ b/.claude/workflows/go-implement/tests/test-verify-prompt.mjs
@@ -1,0 +1,388 @@
+// Test script for Phase 3 verify agent prompt construction
+// Extracted from go-implement.js 
+
+// ---------------------------------------------------------------------------
+// Extract the FEEDBACK_PROMPT (verbatim from go-implement.js )
+// ---------------------------------------------------------------------------
+const FEEDBACK_PROMPT = `## Workflow feedback
+
+Your structured output includes a \`feedback\` array of strings. Add one entry per issue you encountered with these instructions - not about the code. For example: an instruction that was unclear or ambiguous, a step that was missing, a prescribed approach that did not work, the Jira spec contradicting the design document or BDD scenarios (if provided), or anything else that would help improve these instructions. Leave it empty if everything worked as described.`
+
+// ---------------------------------------------------------------------------
+// Extract the template literal into a standalone function
+// (verbatim from go-implement.js )
+// ---------------------------------------------------------------------------
+function buildVerifyPrompt(specContext, tests, baseSha) {
+  return `You are an independent reviewer. Your job is to find problems, not to confirm everything is fine. Be skeptical. Default to flagging concerns rather than assuming correctness. The project conventions from AGENTS.md are already in your context.
+
+${specContext}
+
+## Context
+
+A previous agent reported: tests passed=${tests.testsPassed}, testsWritten=${tests.testsWritten}. Verify this independently, do not assume it is accurate. All changes are in the working tree, not committed.
+
+${tests.failures && tests.failures.length ? 'The following test failures were already identified before your review. If \`make before_commit\` fails on any of these, treat them as known issues rather than new findings:\n' + tests.failures.map(f => '- ' + f).join('\n') : ''}
+
+## Severity definitions
+
+- **critical**: bug or correctness issue that must be fixed before merge
+- **major**: significant concern (missing edge case, weak test, spec gap)
+- **minor**: style issue or minor improvement
+- **note**: observation, no action required
+
+## Instructions
+
+1. Run \`git diff ${baseSha}\` to see the full diff (these are uncommitted working tree changes, implementation + tests).
+2. Walk through each acceptance criteria from the specification, the design document (if provided) and BDD scenarios (if provided). Check whether all the criteria are met by the code AND covered by a test. Flag any unmet criteria.
+3. Look for missing edge cases, especially scenarios from the specification, design document, or BDD feature files that the code does not handle.
+4. Look for bugs: logic errors, off-by-one mistakes, nil pointer risks, race conditions, resource leaks, or security issues.
+5. Check test quality: do the test assertions check spec-defined expected values, or do they just mirror what the implementation returns? Flag assertions that would pass even if the code were broken (e.g., asserting the return value matches whatever the function happens to return, rather than what the spec says it should return). If the spec does not define exact expected values, note this limitation.
+6. Run \`make before_commit\` to check style, tests, license headers, and coverage. Report the output and whether it passed or failed (for beforeCommitPassed).
+7. If \`make before_commit\` fails, check whether the failing test or file appears in the diff (\`git diff ${baseSha}\`). If it does not, the failure is likely pre-existing. Also check whether the failure could be caused by a changed dependency (e.g., a modified interface that an existing test relies on). Note the distinction between new and pre-existing failures in your report.
+
+## Constraints
+
+- Do not fix any code. This is a read-only review.
+- Do not silently skip a failing check.
+- Do not create any git commits.
+
+## Before finishing, verify
+
+1. You checked every acceptance criteria against the Jira issue, the implementation and the respective tests, as well as the design doc (if provided) and BDD specs (if provided).
+2. You ran \`make before_commit\` and reported the full output.
+3. Every finding has a severity (critical, major, minor, or note).
+4. Your verdict is one of: pass, fail, or pass_with_notes.
+
+${FEEDBACK_PROMPT}`
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+let passed = 0
+let failed = 0
+
+function check(condition, detail) {
+  if (condition) {
+    console.log(`  [PASS] ${detail}`)
+    passed++
+  } else {
+    console.log(`  [FAIL] ${detail}`)
+    failed++
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: No failures (failures=[]) - no "already identified" text
+// ---------------------------------------------------------------------------
+console.log('\n--- Test 1: No failures (failures=[]) ---')
+{
+  const prompt = buildVerifyPrompt(
+    '## Spec\nDo the thing.',
+    { testsPassed: true, testsWritten: 3, failures: [] },
+    'abc1234'
+  )
+
+  check(
+    !prompt.includes('already identified'),
+    'Empty failures array does not produce "already identified" text'
+  )
+  check(
+    !prompt.includes('The following test failures'),
+    'Empty failures array does not produce the known-failures block'
+  )
+  check(
+    !prompt.includes('undefined'),
+    'No "undefined" leaks into text'
+  )
+  check(
+    !prompt.includes('null'),
+    'No "null" leaks into text'
+  )
+  // The empty conditional leaves just a blank line between context and severity
+  check(
+    prompt.includes('not committed.\n\n\n\n## Severity'),
+    'Blank line placeholder between context and severity sections'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Failures undefined - no crash, no "undefined" in output
+// ---------------------------------------------------------------------------
+console.log('\n--- Test 2: Failures undefined ---')
+{
+  const prompt = buildVerifyPrompt(
+    '## Spec\nDo the thing.',
+    { testsPassed: false, testsWritten: 0 },
+    'def5678'
+  )
+
+  check(
+    !prompt.includes('The following test failures'),
+    'Undefined failures does not produce the known-failures block'
+  )
+  check(
+    !prompt.includes('undefined'),
+    'No "undefined" leaks when failures is missing'
+  )
+  check(
+    prompt.includes('tests passed=false'),
+    'testsPassed=false is interpolated correctly'
+  )
+  check(
+    prompt.includes('testsWritten=0'),
+    'testsWritten=0 is interpolated correctly'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Two known failures - both as markdown bullets with real newlines
+// ---------------------------------------------------------------------------
+console.log('\n--- Test 3: Two known failures ---')
+{
+  const prompt = buildVerifyPrompt(
+    '## Spec\nMultiple failures.',
+    { testsPassed: false, testsWritten: 5, failures: ['TestFoo failed: exit 1', 'TestBar: nil pointer'] },
+    'aaa1111'
+  )
+
+  check(
+    prompt.includes('The following test failures were already identified'),
+    'Known-failures header present'
+  )
+  check(
+    prompt.includes('- TestFoo failed: exit 1'),
+    'First failure bullet rendered'
+  )
+  check(
+    prompt.includes('- TestBar: nil pointer'),
+    'Second failure bullet rendered'
+  )
+  // Verify actual newline between bullets, not literal backslash-n
+  const idx1 = prompt.indexOf('- TestFoo failed: exit 1')
+  const idx2 = prompt.indexOf('- TestBar: nil pointer')
+  check(
+    idx2 === idx1 + '- TestFoo failed: exit 1'.length + 1,
+    'Bullets separated by a real newline (\\n), not literal \\n'
+  )
+  check(
+    !prompt.includes('\\n'),
+    'No literal backslash-n in output'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Single failure
+// ---------------------------------------------------------------------------
+console.log('\n--- Test 4: Single failure ---')
+{
+  const prompt = buildVerifyPrompt(
+    '## Spec\nSingle fail.',
+    { testsPassed: false, testsWritten: 2, failures: ['TestAlpha panicked'] },
+    'bbb2222'
+  )
+
+  check(
+    prompt.includes('The following test failures were already identified'),
+    'Known-failures header present for single failure'
+  )
+  check(
+    prompt.includes('- TestAlpha panicked'),
+    'Single failure bullet rendered'
+  )
+  // Only one bullet, no extra join newlines
+  const lines = prompt.split('\n')
+  const bulletLines = lines.filter(l => l.startsWith('- TestAlpha'))
+  check(
+    bulletLines.length === 1,
+    'Exactly one bullet line for single failure'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: baseSha interpolation - SHA appears in git diff commands
+// ---------------------------------------------------------------------------
+console.log('\n--- Test 5: baseSha interpolation ---')
+{
+  const sha = 'deadbeef1234567890abcdef'
+  const prompt = buildVerifyPrompt(
+    '## Spec\nSha test.',
+    { testsPassed: true, testsWritten: 1, failures: [] },
+    sha
+  )
+
+  // baseSha appears in two places: instruction 1 and instruction 7
+  const gitDiffOccurrences = prompt.split(`git diff ${sha}`).length - 1
+  check(
+    gitDiffOccurrences === 2,
+    `baseSha appears exactly 2 times in git diff commands (found ${gitDiffOccurrences})`
+  )
+
+  // Verify it's inside backticks (inline code)
+  check(
+    prompt.includes(`\`git diff ${sha}\``),
+    'git diff command is wrapped in backticks (inline code)'
+  )
+
+  // Verify backticks are real backtick characters, not escaped
+  check(
+    !prompt.includes('\\`'),
+    'No escaped backticks in output'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Full prompt with all specContext sections
+//         Check headings, no uninterpolated ${}, beforeCommitPassed mentioned
+// ---------------------------------------------------------------------------
+console.log('\n--- Test 6: Full prompt with all specContext sections ---')
+{
+  const specContext = `## Issue Specification (CCXDEV-99999)
+
+Summary: Add new database table for tracking widget states
+
+### Acceptance Criteria
+
+1. Create migration adding \`widget_states\` table
+2. Add Go struct with JSON tags
+3. Write CRUD operations in storage.go
+
+## Design Document
+
+Read the design document at \`/path/to/design.md\` for architecture and implementation
+guidance.
+
+## BDD Scenarios
+
+These feature files describe expected user-facing behavior:
+- \`/path/to/widgets.feature\``
+
+  const tests = {
+    testsPassed: true,
+    testsWritten: 7,
+    failures: ['TestWidgetCleanup: context deadline exceeded'],
+  }
+  const sha = 'f00dcafe'
+
+  const prompt = buildVerifyPrompt(specContext, tests, sha)
+
+  // -- Headings present --
+  check(
+    prompt.includes('## Issue Specification (CCXDEV-99999)'),
+    'Issue specification heading present'
+  )
+  check(
+    prompt.includes('## Design Document'),
+    'Design document heading present'
+  )
+  check(
+    prompt.includes('## BDD Scenarios'),
+    'BDD scenarios heading present'
+  )
+  check(
+    prompt.includes('## Context'),
+    'Context heading present'
+  )
+  check(
+    prompt.includes('## Severity definitions'),
+    'Severity definitions heading present'
+  )
+  check(
+    prompt.includes('## Instructions'),
+    'Instructions heading present'
+  )
+  check(
+    prompt.includes('## Constraints'),
+    'Constraints heading present'
+  )
+  check(
+    prompt.includes('## Before finishing, verify'),
+    'Before finishing heading present'
+  )
+  check(
+    prompt.includes('## Workflow feedback'),
+    'Workflow feedback heading present'
+  )
+
+  // -- No uninterpolated ${} --
+  // eslint-disable-next-line no-template-curly-in-string
+  const unresolvedPattern = /\$\{[^}]+\}/
+  check(
+    !unresolvedPattern.test(prompt),
+    'No uninterpolated ${...} placeholders remain in the output'
+  )
+
+  // -- beforeCommitPassed is mentioned, not the old codeStylePassed --
+  check(
+    prompt.includes('beforeCommitPassed'),
+    'beforeCommitPassed is mentioned in the prompt'
+  )
+  check(
+    !prompt.includes('codeStylePassed'),
+    'Old codeStylePassed is NOT mentioned anywhere in the prompt'
+  )
+
+  // -- Content interpolation checks --
+  check(
+    prompt.includes('tests passed=true, testsWritten=7'),
+    'Test stats interpolated correctly'
+  )
+  check(
+    prompt.includes('- TestWidgetCleanup: context deadline exceeded'),
+    'Known failure bullet present'
+  )
+  check(
+    prompt.includes(`\`git diff ${sha}\``),
+    'baseSha interpolated in instructions'
+  )
+  check(
+    prompt.includes('`make before_commit`'),
+    'make before_commit reference present'
+  )
+
+  // -- Structural checks --
+  const headings = prompt.split('\n').filter(l => /^## /.test(l))
+  check(
+    headings.length >= 7,
+    `At least 7 ## headings found (got ${headings.length})`
+  )
+
+  // -- No leaks --
+  check(
+    !prompt.includes('[object Object]'),
+    'No [object Object] in output'
+  )
+
+  // -- All four severity levels --
+  check(
+    prompt.includes('- **critical**:') &&
+      prompt.includes('- **major**:') &&
+      prompt.includes('- **minor**:') &&
+      prompt.includes('- **note**:'),
+    'All four severity levels present with bold markdown'
+  )
+
+  // -- Prompt ends cleanly --
+  check(
+    prompt.trimEnd().endsWith('Leave it empty if everything worked as described.'),
+    'Prompt ends cleanly with final feedback instruction'
+  )
+
+  // -- Starts correctly --
+  check(
+    prompt.startsWith('You are an independent reviewer.'),
+    'Prompt starts with reviewer preamble'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('\n' + '='.repeat(50))
+console.log(`Total: ${passed + failed} tests | ${passed} passed | ${failed} failed`)
+if (failed > 0) {
+  console.log('SOME TESTS FAILED')
+  process.exit(1)
+} else {
+  console.log('ALL TESTS PASSED')
+}

--- a/.claude/workflows/go-implement/tests/test-verify-prompt.mjs
+++ b/.claude/workflows/go-implement/tests/test-verify-prompt.mjs
@@ -1,5 +1,5 @@
 // Test script for Phase 3 verify agent prompt construction
-// Extracted from go-implement.js 
+// Extracted from go-implement.js
 
 // ---------------------------------------------------------------------------
 // Extract the FEEDBACK_PROMPT (verbatim from go-implement.js )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 @AGENTS.md
 
-## Workflow policy
+## Claude workflow policy
 
 When a workflow fails (e.g., `/go-implement` failing because the sandbox is not enabled), report the error and tell the user how to fix it. Do not fall back to doing the work yourself.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,4 +4,4 @@
 
 When a workflow fails (e.g., `/go-implement` failing because the sandbox is not enabled), report the error and tell the user how to fix it. Do not fall back to doing the work yourself.
 
-When a workflow completes, always display the full `displaySummary` from the workflow result (including the summary table, verification report, and estimated costs). Then wait for the user's next instruction — do not autonomously fix issues, re-apply changes, or take any follow-up action.
+When a workflow completes, display the **entire** `displaySummary` from the workflow result **verbatim** — never truncate, summarize, or omit any section. This includes the summary table, the full verification report (every acceptance criterion, design alignment, BDD alignment, test quality, bug check, make before_commit result, test count verification, files modified, verdict), all verification deviations, all agent feedback on workflow instructions, and the estimated costs table. Copy the content as-is; do not paraphrase or shorten it. Then wait for the user's next instruction — do not autonomously fix issues, re-apply changes, or take any follow-up action.


### PR DESCRIPTION
# Description
### **Important note**
The reason the workflow script is one big noodle of a file is because of the current limitations of the Claude workflows, the main being that `import` is not yet supported by the workflow. Once importing is supported, we'll split the script into meaningful parts (prompts, helper functions, string builders,...)

### Changes in this PR
- adds `Phase 2: Unit tests` along with the `UNIT_TEST_SCHEMA` that the phase responds with.
- adds `Phase 3: Verify` + the `VERIFICATION_SCHEMA` 
- adds gates between phases to stop the workflow if the previous phase failed and/or the next phase has nothing to do
- adds the final summary and `return` statement, which the main Claude session always receives
  - add yet another instruction to `CLAUDE.md` to _actually_ display the given summary when a workflow finishes and not summarizing it itself
- adds generated point-in-time tests for my own sanity, checking whether the JS parts can handle different arguments and different outputs from previous phases

Fixes CCXDEV-16555

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Configuration update

## Testing steps
this full workflow was used to implement https://github.com/RedHatInsights/ccx-notification-service/pull/1255 and https://github.com/RedHatInsights/ccx-notification-service/pull/1259 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
