### PR TITLE
[CCXDEV-16562] Establish aggregator DB connection at startup

### DIFF
--- a/.claude/workflows/go-implement.js
+++ b/.claude/workflows/go-implement.js
@@ -60,16 +60,17 @@ export const meta = {
 //
 // Why the need for an INPUT_RATIO:
 // Claude Code agents read a lot of context (AGENTS.md, source files, diffs)
-// but produce relatively little output. The 50:1 ratio was calibrated from
-// /usage data across a few real issues (Opus 4 on Vertex AI). Cache reads
-// dominate input costs. If estimates drift from /usage actuals, re-calibrate
-// by comparing estimated vs actual costs.
+// but produce relatively little output. Cache reads dominate input volume
+// but cost only $0.50/MTok (vs $5/MTok uncached, $6.25/MTok cache write).
+// The ratio is calibrated so that (output * INPUT_RATIO * USD_PER_INPUT_MTOK)
+// approximates the real blended input cost. Re-calibrate by comparing
+// estimated vs actual costs from /usage.
 //
 // Pricing (as of 2026-07, Claude Opus 4 on Vertex AI):
 // $5/MTok input, $25/MTok output (same as the Anthropic API).
 const USD_PER_OUTPUT_MTOK = 25
 const USD_PER_INPUT_MTOK = 5
-const INPUT_RATIO = 50
+const INPUT_RATIO = 35
 
 // Estimate the dollar cost for a given number of output tokens.
 // Input tokens are not tracked by the runtime, so they are estimated
@@ -456,7 +457,6 @@ ${specContext}
 3. If you added new imports or dependencies, run \`go mod tidy\`.
 4. If you added or modified any interface, run \`make gen-mocks\` (see AGENTS.md for details).
 5. Run \`make style\` to check linting. Fix any issues it reports and re-run \`make style\` until it passes. If you cannot resolve an issue after 3 attempts, stop and describe the issue and the \`make style\` error output in warnings.
-6. Run \`make license\` to add license headers to any new \`.go\` files. This must be last because earlier steps (gen-mocks, style fixes) may create new files.
 
 ## Constraints
 
@@ -471,9 +471,8 @@ ${specContext}
 
 1. If you changed an interface, mocks are regenerated (you ran \`make gen-mocks\`).
 2. \`make style\` passes with no errors.
-3. \`make license\` was run after all other steps.
-4. Every acceptance criteria from the specification has a corresponding code change.
-5. No git commits were created. All changes are in the working tree only.
+3. Every acceptance criteria from the specification has a corresponding code change.
+4. No git commits were created. All changes are in the working tree only.
 
 ${FEEDBACK_PROMPT}`,
   { label: 'implement', schema: IMPLEMENT_SCHEMA }
@@ -583,10 +582,9 @@ ${specContext}
 2. \`make style\` passes with no errors.
 3. \`go test\` passes for all affected packages (or every failure is documented in the failures list with a description).
 4. \`make coverage\` passes, or explains why it didn't pass (uncoverable statements, non-existing mocks).
-5. \`make license\` was run after all other steps.
-6. Test assertions check spec-defined expected values, not values copied from the implementation output.
-7. No production code was modified.
-8. No git commits were created.
+5. Test assertions check spec-defined expected values, not values copied from the implementation output.
+6. No production code was modified.
+7. No git commits were created.
 
 ${FEEDBACK_PROMPT}`,
   { label: 'unit-tests', schema: UNIT_TEST_SCHEMA }

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -141,7 +141,7 @@ objects:
           command:
             - /bin/sh
             - -c
-            - ./ccx-notification-service --instant-reports --verbose
+            - ./ccx-notification-service --instant-reports --verbose --ignore-disabled-rules
       - name: to-service-log
         schedule: ${JOB_SCHEDULE__SERVICE_LOG}
         restartPolicy: Never
@@ -289,7 +289,7 @@ objects:
           command:
             - /bin/sh
             - -c
-            - ./ccx-notification-service --instant-reports --verbose
+            - ./ccx-notification-service --instant-reports --verbose --ignore-disabled-rules
 
     kafkaTopics:
       - topicName: ${OUTGOING_TOPIC}

--- a/differ/aggregator_db_test.go
+++ b/differ/aggregator_db_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright © 2025, 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RedHatInsights/ccx-notification-service/conf"
+	"github.com/RedHatInsights/ccx-notification-service/differ"
+	"github.com/RedHatInsights/ccx-notification-service/types"
+)
+
+// TestAggregatorStorageErrorMessage checks the error message of
+// AggregatorStorageError.
+func TestAggregatorStorageErrorMessage(t *testing.T) {
+	err := &differ.AggregatorStorageError{}
+	assert.Equal(t, "AggregatorStorageError", err.Error())
+}
+
+// TestConnectAndCloseAggregatorDBSuccess tests the happy path where the
+// aggregator DB connection is established and closed successfully. This
+// covers the acceptance criteria: "Aggregator DB connection is established
+// before any other startup work" and "Connection is closed after disabled
+// rules are fetched."
+func TestConnectAndCloseAggregatorDBSuccess(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	defer zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	config := conf.ConfigStruct{
+		AggregatorStorage: conf.StorageConfiguration{
+			Driver: "sqlite3",
+		},
+	}
+
+	d := differ.Differ{}
+	err := differ.ConnectAndCloseAggregatorDB(&d, &config)
+	assert.Nil(t, err)
+
+	// After successful connect-and-close, AggregatorStorage should be nil
+	// (connection was cleaned up).
+	assert.Nil(t, d.AggregatorStorage)
+
+	executionLog := buf.String()
+	assert.Contains(t, executionLog, differ.AggregatorDBConnectionMessage)
+	assert.Contains(t, executionLog, differ.AggregatorDBClosedMessage)
+}
+
+// TestConnectAndCloseAggregatorDBConnectionFailure tests that when the
+// aggregator DB connection fails, the method returns an AggregatorStorageError.
+// This covers: "If the aggregator DB is unreachable, the service exits with
+// an appropriate error."
+func TestConnectAndCloseAggregatorDBConnectionFailure(t *testing.T) {
+	config := conf.ConfigStruct{
+		AggregatorStorage: conf.StorageConfiguration{
+			Driver: "unsupported-driver",
+		},
+	}
+
+	d := differ.Differ{}
+	err := differ.ConnectAndCloseAggregatorDB(&d, &config)
+	assert.ErrorIs(t, err, &differ.AggregatorStorageError{})
+	assert.Nil(t, d.AggregatorStorage)
+}
+
+// TestConnectAndCloseAggregatorDBLogsConnectionMessage verifies that the
+// connection attempt log message is produced.
+func TestConnectAndCloseAggregatorDBLogsConnectionMessage(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	defer zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	config := conf.ConfigStruct{
+		AggregatorStorage: conf.StorageConfiguration{
+			Driver: "unsupported-driver",
+		},
+	}
+
+	d := differ.Differ{}
+	_ = differ.ConnectAndCloseAggregatorDB(&d, &config)
+
+	executionLog := buf.String()
+	assert.Contains(t, executionLog, differ.AggregatorDBConnectionMessage)
+}
+
+// TestConnectAndCloseAggregatorDBLogsOnConnectionFailure verifies the error
+// log message when the aggregator DB connection fails.
+func TestConnectAndCloseAggregatorDBLogsOnConnectionFailure(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.Logger = zerolog.New(buf).Level(zerolog.ErrorLevel)
+	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	defer zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	config := conf.ConfigStruct{
+		AggregatorStorage: conf.StorageConfiguration{
+			Driver: "unsupported-driver",
+		},
+	}
+
+	d := differ.Differ{}
+	_ = differ.ConnectAndCloseAggregatorDB(&d, &config)
+
+	executionLog := buf.String()
+	assert.Contains(t, executionLog, "Cannot connect to the aggregator database")
+}
+
+// TestConnectAndCloseAggregatorDBFailureDoesNotLogClose verifies that when
+// connection fails, the close log message is NOT produced. This demonstrates
+// the fail-fast behavior: the method returns immediately on connection error.
+func TestConnectAndCloseAggregatorDBFailureDoesNotLogClose(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	defer zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	config := conf.ConfigStruct{
+		AggregatorStorage: conf.StorageConfiguration{
+			Driver: "unsupported-driver",
+		},
+	}
+
+	d := differ.Differ{}
+	_ = differ.ConnectAndCloseAggregatorDB(&d, &config)
+
+	executionLog := buf.String()
+	assert.NotContains(t, executionLog, differ.AggregatorDBClosedMessage)
+}
+
+// TestRunIgnoreDisabledRulesSkipsAggregatorDB verifies that when
+// --ignore-disabled-rules is set, no aggregator DB connection attempt is made.
+// This is the acceptance criteria: "If --ignore-disabled-rules is set, no
+// connection attempt is made."
+// The aggregator storage is configured with an invalid driver so that any
+// connection attempt would fail. If the skip logic works, the service proceeds
+// past the aggregator DB step and fails later (content fetch), proving no
+// connection was attempted.
+// Uses ServiceLog path to avoid mock Kafka broker overhead.
+func TestRunIgnoreDisabledRulesSkipsAggregatorDB(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	defer zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	config := conf.ConfigStruct{
+		Storage: conf.StorageConfiguration{
+			Driver: "sqlite3",
+		},
+		ServiceLog: conf.ServiceLogConfiguration{
+			Enabled: true,
+		},
+		AggregatorStorage: conf.StorageConfiguration{
+			Driver: "invalid-driver-should-never-be-used",
+		},
+	}
+	cliFlags := types.CliFlags{
+		InstantReports:      true,
+		IgnoreDisabledRules: true,
+	}
+	retval := differ.Run(config, cliFlags)
+	// The service should skip the aggregator DB connection entirely and
+	// proceed to the next step (fetching content), which will fail because
+	// no content service is running. FetchContentError means we got past
+	// the aggregator DB step successfully.
+	assert.Equal(t, differ.ExitStatusFetchContentError, retval)
+
+	executionLog := buf.String()
+	assert.Contains(t, executionLog, differ.AggregatorDBSkippedMessage)
+	assert.NotContains(t, executionLog, differ.AggregatorDBConnectionMessage)
+}
+
+// TestRunAggregatorDBFailureExitCode verifies that Run returns
+// ExitStatusAggregatorStorageError when the aggregator DB is unreachable.
+// This tests the full integration path through Run -> start ->
+// connectAndCloseAggregatorDB -> selectError.
+// Uses ServiceLog path to avoid mock Kafka broker overhead.
+func TestRunAggregatorDBFailureExitCode(t *testing.T) {
+	config := conf.ConfigStruct{
+		Storage: conf.StorageConfiguration{
+			Driver: "sqlite3",
+		},
+		ServiceLog: conf.ServiceLogConfiguration{
+			Enabled: true,
+		},
+		AggregatorStorage: conf.StorageConfiguration{
+			Driver: "unsupported-driver",
+		},
+	}
+	cliFlags := types.CliFlags{
+		InstantReports: true,
+	}
+	retval := differ.Run(config, cliFlags)
+	assert.Equal(t, differ.ExitStatusAggregatorStorageError, retval)
+}
+
+// TestExitStatusAggregatorStorageErrorValue checks that
+// ExitStatusAggregatorStorageError has the expected value (one past
+// ExitStatusServiceLogError).
+func TestExitStatusAggregatorStorageErrorValue(t *testing.T) {
+	assert.Equal(t, differ.ExitStatusServiceLogError+1, differ.ExitStatusAggregatorStorageError)
+}
+
+// TestExportedAggregatorDBConstants checks that the exported message constants
+// have the expected values from the spec.
+func TestExportedAggregatorDBConstants(t *testing.T) {
+	assert.Equal(t, "Connecting to aggregator database to fetch disabled rules", differ.AggregatorDBConnectionMessage)
+	assert.Equal(t, "Aggregator database connection closed", differ.AggregatorDBClosedMessage)
+	assert.Equal(t, "Skipping aggregator DB connection (--ignore-disabled-rules is set)", differ.AggregatorDBSkippedMessage)
+}

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -72,6 +72,8 @@ const (
 	ExitStatusEventFilterError
 	// ExitStatusServiceLogError is raised when Service Log notifier cannot be initialized
 	ExitStatusServiceLogError
+	// ExitStatusAggregatorStorageError is raised when the aggregator DB connection fails
+	ExitStatusAggregatorStorageError
 )
 
 // Total risk values
@@ -92,34 +94,37 @@ const (
 
 // Messages
 const (
-	serviceName                 = "CCX Notification Service"
-	separator                   = "------------------------------------------------------------"
-	operationFailedMessage      = "Operation failed"
-	clusterEntryMessage         = "cluster entry"
-	organizationIDAttribute     = "org id"
-	AccountNumberAttribute      = "account number"
-	typeAttribute               = "type"
-	clusterAttribute            = "cluster"
-	ruleAttribute               = "rule"
-	likelihoodAttribute         = "likelihood"
-	impactAttribute             = "impact"
-	errorKeyAttribute           = "error key"
-	numberOfEventsAttribute     = "number of events"
-	clustersAttribute           = "clusters"
-	totalRiskAttribute          = "totalRisk"
-	errorStr                    = "Error:"
-	reportWithHighImpactMessage = "Report with impact higher than configured threshold detected"
-	invalidJSONContent          = "The provided content cannot be encoded as JSON."
-	metricsPushFailedMessage    = "Couldn't push prometheus metrics"
-	tagsNotSetMessage           = "Tags for tag filter not set"
-	evaluationErrorMessage      = "Evaluation error"
-	serviceLogSendErrorMessage  = "Sending entry to service log failed for this report"
-	renderReportsFailedMessage  = "Rendering reports failed for this cluster"
-	ReportNotFoundError         = "report for rule ID %v and error key %v has not been found"
-	destinationNotSet           = "No known event destination configured. Aborting."
-	onlyOneDestinationAllowed   = "Only one integration should be enabled (Kafka / Service log. Review your config."
-	configurationProblem        = "Configuration problem"
-	noEquivalentSeverityMessage = "No Service log severity defined for given total risk. Creating event with Info severity"
+	serviceName                   = "CCX Notification Service"
+	separator                     = "------------------------------------------------------------"
+	operationFailedMessage        = "Operation failed"
+	clusterEntryMessage           = "cluster entry"
+	organizationIDAttribute       = "org id"
+	AccountNumberAttribute        = "account number"
+	typeAttribute                 = "type"
+	clusterAttribute              = "cluster"
+	ruleAttribute                 = "rule"
+	likelihoodAttribute           = "likelihood"
+	impactAttribute               = "impact"
+	errorKeyAttribute             = "error key"
+	numberOfEventsAttribute       = "number of events"
+	clustersAttribute             = "clusters"
+	totalRiskAttribute            = "totalRisk"
+	errorStr                      = "Error:"
+	reportWithHighImpactMessage   = "Report with impact higher than configured threshold detected"
+	invalidJSONContent            = "The provided content cannot be encoded as JSON."
+	metricsPushFailedMessage      = "Couldn't push prometheus metrics"
+	tagsNotSetMessage             = "Tags for tag filter not set"
+	evaluationErrorMessage        = "Evaluation error"
+	serviceLogSendErrorMessage    = "Sending entry to service log failed for this report"
+	renderReportsFailedMessage    = "Rendering reports failed for this cluster"
+	ReportNotFoundError           = "report for rule ID %v and error key %v has not been found"
+	destinationNotSet             = "No known event destination configured. Aborting."
+	onlyOneDestinationAllowed     = "Only one integration should be enabled (Kafka / Service log. Review your config."
+	configurationProblem          = "Configuration problem"
+	noEquivalentSeverityMessage   = "No Service log severity defined for given total risk. Creating event with Info severity"
+	aggregatorDBConnectionMessage = "Connecting to aggregator database to fetch disabled rules"
+	aggregatorDBClosedMessage     = "Aggregator database connection closed"
+	aggregatorDBSkippedMessage    = "Skipping aggregator DB connection (--ignore-disabled-rules is set)"
 )
 
 // Constants for notification message top level fields
@@ -187,16 +192,18 @@ type NotificationURLs struct {
 
 // Differ is the struct that holds all the dependencies and configuration of this service
 type Differ struct {
-	Storage            Storage
-	Notifier           producer.Producer
-	NotificationType   types.EventType
-	Target             types.EventTarget
-	PreviouslyReported types.NotifiedRecordsPerCluster
-	CoolDown           string
-	Thresholds         EventThresholds
-	Filter             string
-	FilterByTag        bool
-	TagsSet            types.TagsSet
+	Storage             Storage
+	Notifier            producer.Producer
+	NotificationType    types.EventType
+	Target              types.EventTarget
+	PreviouslyReported  types.NotifiedRecordsPerCluster
+	CoolDown            string
+	Thresholds          EventThresholds
+	Filter              string
+	FilterByTag         bool
+	TagsSet             types.TagsSet
+	IgnoreDisabledRules bool
+	AggregatorStorage   Storage
 }
 
 // TODO: same way we have a Differ struct now, we should have a struct
@@ -861,6 +868,40 @@ func (d *Differ) RetrievePreviouslyReportedForEventTarget(cooldown string, targe
 	return nil
 }
 
+// connectAndCloseAggregatorDB establishes a short-lived read-only connection
+// to the aggregator database, executes any required startup queries (disabled
+// rules fetching will be added in CCXDEV-16564 and CCXDEV-16565), and closes
+// the connection immediately. The aggregator DB is not kept open during
+// per-cluster processing.
+func (d *Differ) connectAndCloseAggregatorDB(config *conf.ConfigStruct) error {
+	log.Info().Msg(aggregatorDBConnectionMessage)
+
+	aggregatorStorageConfig := conf.GetAggregatorStorageConfiguration(config)
+	aggregatorStorage, err := NewStorage(&aggregatorStorageConfig)
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot connect to the aggregator database")
+		return &AggregatorStorageError{}
+	}
+
+	d.AggregatorStorage = aggregatorStorage
+
+	// TODO: Fetch disabled rules here (CCXDEV-16564, CCXDEV-16565)
+	// Rename the function to match the new behavior.
+	// The queries will populate in-memory maps in Differ for:
+	// - cluster_rule_toggle (per-cluster disables)
+	// - rule_disable (org-wide acks)
+
+	err = closeStorage(aggregatorStorage)
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot close the aggregator database connection")
+		return &AggregatorStorageError{}
+	}
+
+	d.AggregatorStorage = nil
+	log.Info().Msg(aggregatorDBClosedMessage)
+	return nil
+}
+
 func (d *Differ) start(config *conf.ConfigStruct) error {
 	SetServiceStatus(StatusStarting)
 	defer SetServiceStatus(StatusInactive)
@@ -870,6 +911,20 @@ func (d *Differ) start(config *conf.ConfigStruct) error {
 
 	metricsConfiguration := conf.GetMetricsConfiguration(config)
 	registerMetrics(&metricsConfiguration)
+
+	// Establish and close the aggregator DB connection before any other
+	// startup work. This is a blocking operation: if the aggregator DB is
+	// unavailable the job fails fast without having consumed any other
+	// resources. Skipped entirely when --ignore-disabled-rules is set.
+	if d.IgnoreDisabledRules {
+		log.Info().Msg(aggregatorDBSkippedMessage)
+	} else {
+		err := d.connectAndCloseAggregatorDB(config)
+		if err != nil {
+			return err
+		}
+	}
+
 	log.Info().Msg(separator)
 	log.Info().Msg("Getting rule content and impacts from content service")
 
@@ -1080,6 +1135,8 @@ func Run(config conf.ConfigStruct, cliFlags types.CliFlags) int {
 		return selectError(err)
 	}
 
+	d.IgnoreDisabledRules = cliFlags.IgnoreDisabledRules
+
 	err = d.start(&config)
 	return selectError(err)
 }
@@ -1136,6 +1193,8 @@ func selectError(err error) int {
 		return ExitStatusConfiguration
 	case *StatusEventFilterError:
 		return ExitStatusEventFilterError
+	case *AggregatorStorageError:
+		return ExitStatusAggregatorStorageError
 	}
 
 	return ExitStatusOK

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -891,13 +891,16 @@ func (d *Differ) connectAndCloseAggregatorDB(config *conf.ConfigStruct) error {
 	// - cluster_rule_toggle (per-cluster disables)
 	// - rule_disable (org-wide acks)
 
+	// close storage and remove reference to the DB in Differ
 	err = closeStorage(aggregatorStorage)
+
+	d.AggregatorStorage = nil
+
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot close the aggregator database connection")
 		return &AggregatorStorageError{}
 	}
 
-	d.AggregatorStorage = nil
 	log.Info().Msg(aggregatorDBClosedMessage)
 	return nil
 }

--- a/differ/errors.go
+++ b/differ/errors.go
@@ -52,3 +52,10 @@ type StatusEventFilterError struct {
 func (e *StatusEventFilterError) Error() string {
 	return e.Msg
 }
+
+// AggregatorStorageError is related to any aggregator DB connection or query error
+type AggregatorStorageError struct{}
+
+func (e *AggregatorStorageError) Error() string {
+	return "AggregatorStorageError"
+}

--- a/differ/export_test.go
+++ b/differ/export_test.go
@@ -58,19 +58,24 @@ var (
 	DeleteOperationSpecified       = deleteOperationSpecified
 	CloseStorage                   = closeStorage
 	PrintNewReportsForCleanup      = printNewReportsForCleanup
+
+	ConnectAndCloseAggregatorDB = (*Differ).connectAndCloseAggregatorDB
 )
 
 const (
-	NotificationTypeInstant     = notificationTypeInstant
-	NotificationBundleName      = notificationBundleName
-	NotificationApplicationName = notificationApplicationName
-	NotificationPayloadRuleURL  = notificationPayloadRuleURL
-	NotificationStateSent       = notificationStateSent
-	NotificationStateSame       = notificationStateSame
-	NotificationStateLower      = notificationStateLower
-	NotificationStateError      = notificationStateError
-	ReportWithHighImpactMessage = reportWithHighImpactMessage
-	NoEquivalentSeverityMessage = noEquivalentSeverityMessage
+	NotificationTypeInstant       = notificationTypeInstant
+	NotificationBundleName        = notificationBundleName
+	NotificationApplicationName   = notificationApplicationName
+	NotificationPayloadRuleURL    = notificationPayloadRuleURL
+	NotificationStateSent         = notificationStateSent
+	NotificationStateSame         = notificationStateSame
+	NotificationStateLower        = notificationStateLower
+	NotificationStateError        = notificationStateError
+	ReportWithHighImpactMessage   = reportWithHighImpactMessage
+	NoEquivalentSeverityMessage   = noEquivalentSeverityMessage
+	AggregatorDBConnectionMessage = aggregatorDBConnectionMessage
+	AggregatorDBClosedMessage     = aggregatorDBClosedMessage
+	AggregatorDBSkippedMessage    = aggregatorDBSkippedMessage
 )
 
 func InClauseFromStringSlice(slice []string) string {


### PR DESCRIPTION
# Description
- implement a new short-lived database connection to the Aggregator database
  - no SQL queries or anything else yet, purely the connection and subsequent cleanup
- add UTs for the new DB connection
- check for `--ignore-disabled-rules` before attempting to initialize the DB
- add `--ignore-disabled-rules` to Clowdapps before we configure the new DB connection (coming in following PRs)
- tweak `go-implement` workflow slightly

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)
- Configuration update

## Testing steps
local setup

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
