### PR TITLE
[CCXDEV-16624] prevent PostgreSQL password to be printed in the logs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -248,8 +248,8 @@ func NewStorage(configuration *conf.StorageConfiguration) (*DBStorage, error) {
 	}
 
 	log.Info().Msgf(
-		"Making connection to data storage, driver=%s datasource=%s",
-		driverName, dataSource,
+		"Making connection to data storage, driver=%s, host=%s, database=%s",
+		driverName, configuration.PGHost, configuration.PGDBName,
 	)
 
 	connection, err := sql.Open(driverName, dataSource)


### PR DESCRIPTION
# Description
Currently the connection string for the PostgreSQL DB connections is printed in full. 

This PR removes the logging of the whole data source string and instead only prints the host and DB name for identification purposes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- Security fix

## Testing steps
locally checked the logs

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
