### PR TITLE
[CCXDEV-16565] Fetch org-wide acked rules from Aggregator's  `rule_disable` table

### DIFF
--- a/differ/aggregator_db_test.go
+++ b/differ/aggregator_db_test.go
@@ -51,10 +51,12 @@ func TestLoadDisabledRulesPopulatesMap(t *testing.T) {
 
 	storage := mocks.Storage{}
 	storage.On("ReadClusterRuleToggles").Return(expected, nil)
+	storage.On("ReadOrgRuleDisables").Return(make(types.OrgDisabledRules), nil)
 
 	d := differ.Differ{
 		AggregatorStorage:    &storage,
 		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
 	}
 	err := differ.LoadDisabledRules(&d)
 
@@ -68,20 +70,24 @@ func TestLoadDisabledRulesPopulatesMap(t *testing.T) {
 }
 
 // TestLoadDisabledRulesEmptyTable verifies that when the aggregator
-// table has no disabled rules, the map stays empty.
+// tables have no disabled rules, both maps stay empty.
 func TestLoadDisabledRulesEmptyTable(t *testing.T) {
 	storage := mocks.Storage{}
 	storage.On("ReadClusterRuleToggles").Return(make(types.ClusterDisabledRules), nil)
+	storage.On("ReadOrgRuleDisables").Return(make(types.OrgDisabledRules), nil)
 
 	d := differ.Differ{
 		AggregatorStorage:    &storage,
 		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
 	}
 	err := differ.LoadDisabledRules(&d)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, d.ClusterDisabledRules)
 	assert.Empty(t, d.ClusterDisabledRules)
+	assert.NotNil(t, d.OrgDisabledRules)
+	assert.Empty(t, d.OrgDisabledRules)
 	storage.AssertExpectations(t)
 }
 
@@ -116,15 +122,116 @@ func TestLoadDisabledRulesLogsCount(t *testing.T) {
 
 	storage := mocks.Storage{}
 	storage.On("ReadClusterRuleToggles").Return(expected, nil)
+	storage.On("ReadOrgRuleDisables").Return(make(types.OrgDisabledRules), nil)
 
 	d := differ.Differ{
 		AggregatorStorage:    &storage,
 		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
 	}
 	_ = differ.LoadDisabledRules(&d)
 
 	executionLog := buf.String()
 	assert.Contains(t, executionLog, "Loaded per-cluster disabled rules from cluster_rule_toggle")
+}
+
+// --- loadDisabledRules tests: org-wide disabled rules (CCXDEV-16565) ---
+
+// TestLoadDisabledRulesPopulatesOrgMap verifies the happy path: when
+// ReadOrgRuleDisables returns data, loadDisabledRules populates
+// OrgDisabledRules on the Differ struct.
+func TestLoadDisabledRulesPopulatesOrgMap(t *testing.T) {
+	expectedOrg := types.OrgDisabledRules{
+		{OrgID: "1", RuleID: "test_rule", ErrorKey: "TEST_RULE_CRITICAL_IMPACT"}:  {},
+		{OrgID: "2", RuleID: "test_rule", ErrorKey: "TEST_RULE_IMPORTANT_IMPACT"}: {},
+	}
+
+	storage := mocks.Storage{}
+	storage.On("ReadClusterRuleToggles").Return(make(types.ClusterDisabledRules), nil)
+	storage.On("ReadOrgRuleDisables").Return(expectedOrg, nil)
+
+	d := differ.Differ{
+		AggregatorStorage:    &storage,
+		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
+	}
+	err := differ.LoadDisabledRules(&d)
+
+	assert.NoError(t, err)
+	assert.Len(t, d.OrgDisabledRules, 2)
+	for key := range expectedOrg {
+		_, ok := d.OrgDisabledRules[key]
+		assert.True(t, ok, "expected key %v in OrgDisabledRules", key)
+	}
+	storage.AssertExpectations(t)
+}
+
+// TestLoadDisabledRulesOrgQueryError verifies that when ReadOrgRuleDisables
+// fails, loadDisabledRules returns an AggregatorStorageError.
+func TestLoadDisabledRulesOrgQueryError(t *testing.T) {
+	storage := mocks.Storage{}
+	storage.On("ReadClusterRuleToggles").Return(make(types.ClusterDisabledRules), nil)
+	storage.On("ReadOrgRuleDisables").Return(types.OrgDisabledRules(nil), fmt.Errorf("query failed"))
+
+	d := differ.Differ{
+		AggregatorStorage:    &storage,
+		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
+	}
+	err := differ.LoadDisabledRules(&d)
+
+	assert.ErrorIs(t, err, &differ.AggregatorStorageError{})
+	storage.AssertExpectations(t)
+}
+
+// TestLoadDisabledRulesOrgQueryErrorLogsMessage verifies that the error log
+// message is produced when ReadOrgRuleDisables fails.
+func TestLoadDisabledRulesOrgQueryErrorLogsMessage(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.Logger = zerolog.New(buf).Level(zerolog.ErrorLevel)
+	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	defer zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	storage := mocks.Storage{}
+	storage.On("ReadClusterRuleToggles").Return(make(types.ClusterDisabledRules), nil)
+	storage.On("ReadOrgRuleDisables").Return(types.OrgDisabledRules(nil), fmt.Errorf("query failed"))
+
+	d := differ.Differ{
+		AggregatorStorage:    &storage,
+		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
+	}
+	_ = differ.LoadDisabledRules(&d)
+
+	executionLog := buf.String()
+	assert.Contains(t, executionLog, "Cannot read org-wide rule disables from the aggregator database")
+}
+
+// TestLoadDisabledRulesLogsOrgCount verifies that the info log with the
+// org-wide disabled rules count is emitted on success.
+func TestLoadDisabledRulesLogsOrgCount(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	defer zerolog.SetGlobalLevel(zerolog.WarnLevel)
+
+	expectedOrg := types.OrgDisabledRules{
+		{OrgID: "1", RuleID: "test_rule", ErrorKey: "TEST_RULE_CRITICAL_IMPACT"}: {},
+	}
+
+	storage := mocks.Storage{}
+	storage.On("ReadClusterRuleToggles").Return(make(types.ClusterDisabledRules), nil)
+	storage.On("ReadOrgRuleDisables").Return(expectedOrg, nil)
+
+	d := differ.Differ{
+		AggregatorStorage:    &storage,
+		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
+	}
+	_ = differ.LoadDisabledRules(&d)
+
+	executionLog := buf.String()
+	assert.Contains(t, executionLog, "Loaded org-wide disabled rules from rule_disable")
 }
 
 // --- fetchDisabledRulesFromAggregatorDB tests (real DB, same pattern as Run) ---
@@ -313,4 +420,19 @@ func TestNewInitializesClusterDisabledRulesMap(t *testing.T) {
 
 	assert.NotNil(t, d.ClusterDisabledRules, "ClusterDisabledRules should be initialized by New()")
 	assert.Empty(t, d.ClusterDisabledRules, "ClusterDisabledRules should be empty after construction")
+}
+
+// TestNewInitializesOrgDisabledRulesMap checks that New() initializes
+// OrgDisabledRules as an empty (not nil) map.
+func TestNewInitializesOrgDisabledRulesMap(t *testing.T) {
+	config := conf.ConfigStruct{
+		ServiceLog: conf.ServiceLogConfiguration{
+			Enabled: true,
+		},
+	}
+	d, err := differ.New(&config, nil)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, d.OrgDisabledRules, "OrgDisabledRules should be initialized by New()")
+	assert.Empty(t, d.OrgDisabledRules, "OrgDisabledRules should be empty after construction")
 }

--- a/differ/differ.go
+++ b/differ/differ.go
@@ -205,6 +205,7 @@ type Differ struct {
 	IgnoreDisabledRules  bool
 	AggregatorStorage    Storage
 	ClusterDisabledRules types.ClusterDisabledRules
+	OrgDisabledRules     types.OrgDisabledRules
 }
 
 // TODO: same way we have a Differ struct now, we should have a struct
@@ -881,7 +882,13 @@ func (d *Differ) loadDisabledRules() error {
 	d.ClusterDisabledRules = clusterDisabled
 	log.Info().Int("disabled_rules", len(clusterDisabled)).Msg("Loaded per-cluster disabled rules from cluster_rule_toggle")
 
-	// TODO: Fetch org-wide disabled rules here (CCXDEV-16565)
+	orgDisabled, err := d.AggregatorStorage.ReadOrgRuleDisables()
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot read org-wide rule disables from the aggregator database")
+		return &AggregatorStorageError{}
+	}
+	d.OrgDisabledRules = orgDisabled
+	log.Info().Int("disabled_rules", len(orgDisabled)).Msg("Loaded org-wide disabled rules from rule_disable")
 
 	return nil
 }
@@ -1173,6 +1180,7 @@ func New(config *conf.ConfigStruct, storage Storage) (*Differ, error) {
 		PreviouslyReported:   make(types.NotifiedRecordsPerCluster),
 		Thresholds:           EventThresholds{},
 		ClusterDisabledRules: make(types.ClusterDisabledRules),
+		OrgDisabledRules:     make(types.OrgDisabledRules),
 	}
 	if conf.GetKafkaBrokerConfiguration(config).Enabled {
 		d.Target = types.NotificationBackendTarget

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -801,6 +801,10 @@ func (storage DBStorage) ReadOrgRuleDisables() (types.OrgDisabledRules, error) {
 		disabledRules[key] = struct{}{}
 	}
 
+	if err := rows.Err(); err != nil {
+		return disabledRules, err
+	}
+
 	return disabledRules, nil
 }
 

--- a/differ/storage.go
+++ b/differ/storage.go
@@ -113,6 +113,7 @@ type Storage interface {
 	PrintOldReportsForCleanup(maxAge string) error
 	CleanupOldReports(maxAge string) (int, error)
 	ReadClusterRuleToggles() (types.ClusterDisabledRules, error)
+	ReadOrgRuleDisables() (types.OrgDisabledRules, error)
 }
 
 // DBStorage is an implementation of Storage interface that use selected SQL like database
@@ -227,6 +228,15 @@ const (
 		SELECT cluster_id, rule_id, error_key
 		  FROM cluster_rule_toggle
 		 WHERE disabled = 1
+       `
+
+	// ReadOrgRuleDisablesQuery selects all org-wide disabled (acked) rules
+	// from the aggregator DB's rule_disable table. The presence of a row
+	// means the rule is disabled; re-enabling deletes the row, so all rows
+	// are fetched.
+	ReadOrgRuleDisablesQuery = `
+		SELECT org_id, rule_id, error_key
+		  FROM rule_disable
        `
 )
 
@@ -743,6 +753,48 @@ func (storage DBStorage) ReadClusterRuleToggles() (types.ClusterDisabledRules, e
 			ClusterID: clusterID,
 			RuleID:    ruleID,
 			ErrorKey:  errorKey,
+		}
+
+		// empty struct because we just need to check for the map key presence
+		disabledRules[key] = struct{}{}
+	}
+
+	return disabledRules, nil
+}
+
+// ReadOrgRuleDisables reads all org-wide disabled (acked) rules from the
+// rule_disable table in the aggregator database. Every row present in the
+// table represents a disabled rule. The result is a hash map keyed by
+// (org_id, rule_id, error_key) for O(1) lookups during per-rule processing.
+func (storage DBStorage) ReadOrgRuleDisables() (types.OrgDisabledRules, error) {
+	disabledRules := make(types.OrgDisabledRules)
+
+	rows, err := storage.connection.Query(ReadOrgRuleDisablesQuery)
+	if err != nil {
+		return disabledRules, err
+	}
+
+	defer func() {
+		err := rows.Close()
+		if err != nil {
+			log.Error().Err(err).Msg(unableToCloseDBRowsHandle)
+		}
+	}()
+
+	for rows.Next() {
+		var (
+			orgID    string
+			ruleID   types.RuleID
+			errorKey types.ErrorKey
+		)
+
+		if err := rows.Scan(&orgID, &ruleID, &errorKey); err != nil {
+			return disabledRules, err
+		}
+		key := types.OrgRuleKey{
+			OrgID:    orgID,
+			RuleID:   ruleID,
+			ErrorKey: errorKey,
 		}
 
 		// empty struct because we just need to check for the map key presence

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -2484,6 +2484,294 @@ func TestWriteNotificationRecordForClusterWrongDriver(t *testing.T) {
 	checkAllExpectations(t, mock)
 }
 
+// --- ReadOrgRuleDisables tests (CCXDEV-16565) ---
+
+// TestReadOrgRuleDisablesPopulatesMap checks that ReadOrgRuleDisables
+// returns a correctly populated map when the rule_disable table contains
+// rows. Every row in this table represents a disabled rule; the presence
+// of a row means the rule is disabled.
+// This is the acceptance criteria: "Unit test with a mock DB verifying
+// the map is populated correctly."
+func TestReadOrgRuleDisablesPopulatesMap(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"org_id", "rule_id", "error_key"})
+
+	// these rows represent org-wide disabled rules from the aggregator DB
+	rows.AddRow("1", "test_rule", "TEST_RULE_CRITICAL_IMPACT")
+	rows.AddRow("2", "test_rule", "TEST_RULE_IMPORTANT_IMPACT")
+
+	// expected query performed by tested function
+	expectedQuery := regexp.QuoteMeta(differ.ReadOrgRuleDisablesQuery)
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	disabledRules, err := storage.ReadOrgRuleDisables()
+
+	// tested method should NOT return an error
+	assert.NoError(t, err, "error was not expected while querying rule_disable table")
+
+	// exactly two disabled rules should be returned
+	assert.Len(t, disabledRules, 2, "Exactly 2 disabled rules should be returned")
+
+	// check that the expected keys are present in the map
+	key1 := types.OrgRuleKey{
+		OrgID:    "1",
+		RuleID:   "test_rule",
+		ErrorKey: "TEST_RULE_CRITICAL_IMPACT",
+	}
+	_, exists := disabledRules[key1]
+	assert.True(t, exists, "First disabled rule should be present in the map")
+
+	key2 := types.OrgRuleKey{
+		OrgID:    "2",
+		RuleID:   "test_rule",
+		ErrorKey: "TEST_RULE_IMPORTANT_IMPACT",
+	}
+	_, exists = disabledRules[key2]
+	assert.True(t, exists, "Second disabled rule should be present in the map")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// TestReadOrgRuleDisablesEmptyTable checks that ReadOrgRuleDisables
+// returns an empty (not nil) map when the rule_disable table has no rows.
+// This is the acceptance criteria: "Unit test verifying an empty table
+// results in an empty map."
+func TestReadOrgRuleDisablesEmptyTable(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query - empty result set
+	rows := sqlmock.NewRows([]string{"org_id", "rule_id", "error_key"})
+
+	// expected query performed by tested function
+	expectedQuery := regexp.QuoteMeta(differ.ReadOrgRuleDisablesQuery)
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	disabledRules, err := storage.ReadOrgRuleDisables()
+
+	// tested method should NOT return an error
+	assert.NoError(t, err, "error was not expected while querying empty rule_disable table")
+
+	// map should be empty but not nil
+	assert.NotNil(t, disabledRules, "Returned map should not be nil")
+	assert.Empty(t, disabledRules, "Map should be empty for an empty table")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// TestReadOrgRuleDisablesOnQueryError checks that ReadOrgRuleDisables
+// returns an error when the SQL query fails.
+func TestReadOrgRuleDisablesOnQueryError(t *testing.T) {
+	// error to be thrown
+	mockedError := errors.New("mocked error")
+
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// expected query performed by tested function
+	expectedQuery := regexp.QuoteMeta(differ.ReadOrgRuleDisablesQuery)
+
+	// let's raise an error!
+	mock.ExpectQuery(expectedQuery).WillReturnError(mockedError)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	disabledRules, err := storage.ReadOrgRuleDisables()
+
+	// tested method SHOULD return an error
+	assert.Error(t, err, "an error is expected while querying rule_disable table")
+
+	// map should still be initialized (not nil) even on error
+	assert.NotNil(t, disabledRules, "Returned map should not be nil even on error")
+	assert.Empty(t, disabledRules, "Map should be empty on query error")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// TestReadOrgRuleDisablesOnScanError checks that ReadOrgRuleDisables
+// returns an error when row scanning fails due to invalid data types.
+func TestReadOrgRuleDisablesOnScanError(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query with invalid data;
+	// also set a close error to exercise the deferred rows.Close() error branch
+	rows := sqlmock.NewRows([]string{"org_id", "rule_id", "error_key"})
+	rows.AddRow("valid_org", "test_rule", nil)
+	rows.CloseError(fmt.Errorf("close failed"))
+
+	// expected query performed by tested function
+	expectedQuery := regexp.QuoteMeta(differ.ReadOrgRuleDisablesQuery)
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	disabledRules, err := storage.ReadOrgRuleDisables()
+
+	// tested method SHOULD return the scan error (not the close error)
+	assert.Error(t, err, "an error is expected while scanning rule_disable rows")
+
+	// map should be empty on scan error
+	assert.Empty(t, disabledRules, "Map should be empty on scan error")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// TestReadOrgRuleDisablesSameOrgMultipleRules checks that multiple disabled
+// rules for the same organization are stored as separate entries in the map.
+// This aligns with the BDD scenario "Check that a rule ack affects all
+// clusters in an organization" which expects org-wide granularity.
+func TestReadOrgRuleDisablesSameOrgMultipleRules(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"org_id", "rule_id", "error_key"})
+
+	// same org, two different disabled rules
+	orgID := "1"
+	rows.AddRow(orgID, "test_rule", "TEST_RULE_CRITICAL_IMPACT")
+	rows.AddRow(orgID, "test_rule", "TEST_RULE_IMPORTANT_IMPACT")
+
+	// expected query performed by tested function
+	expectedQuery := regexp.QuoteMeta(differ.ReadOrgRuleDisablesQuery)
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	disabledRules, err := storage.ReadOrgRuleDisables()
+
+	// tested method should NOT return an error
+	assert.NoError(t, err, "error was not expected while querying rule_disable table")
+
+	// both rules should be present as separate entries
+	assert.Len(t, disabledRules, 2, "Two disabled rules for the same org should result in 2 map entries")
+
+	// verify both keys exist
+	key1 := types.OrgRuleKey{
+		OrgID:    orgID,
+		RuleID:   "test_rule",
+		ErrorKey: "TEST_RULE_CRITICAL_IMPACT",
+	}
+	_, exists := disabledRules[key1]
+	assert.True(t, exists, "Critical impact rule should be present")
+
+	key2 := types.OrgRuleKey{
+		OrgID:    orgID,
+		RuleID:   "test_rule",
+		ErrorKey: "TEST_RULE_IMPORTANT_IMPACT",
+	}
+	_, exists = disabledRules[key2]
+	assert.True(t, exists, "Important impact rule should be present")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// TestReadOrgRuleDisablesAckDoesNotAffectOtherOrgs checks that a rule ack
+// for one organization does not interfere with another organization's entry.
+// This aligns with the BDD scenario "Check that a rule ack for an
+// organization does not affect other organizations."
+func TestReadOrgRuleDisablesAckDoesNotAffectOtherOrgs(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"org_id", "rule_id", "error_key"})
+
+	// only org 1 has the rule disabled
+	rows.AddRow("1", "test_rule", "TEST_RULE_CRITICAL_IMPACT")
+
+	// expected query performed by tested function
+	expectedQuery := regexp.QuoteMeta(differ.ReadOrgRuleDisablesQuery)
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	disabledRules, err := storage.ReadOrgRuleDisables()
+
+	// tested method should NOT return an error
+	assert.NoError(t, err, "error was not expected while querying rule_disable table")
+
+	// only one entry should exist
+	assert.Len(t, disabledRules, 1, "Only the acked org's rule should be in the map")
+
+	// org 1's rule is present
+	key1 := types.OrgRuleKey{
+		OrgID:    "1",
+		RuleID:   "test_rule",
+		ErrorKey: "TEST_RULE_CRITICAL_IMPACT",
+	}
+	_, exists := disabledRules[key1]
+	assert.True(t, exists, "Org 1's rule should be present")
+
+	// org 2's same rule is NOT present (different org)
+	key2 := types.OrgRuleKey{
+		OrgID:    "2",
+		RuleID:   "test_rule",
+		ErrorKey: "TEST_RULE_CRITICAL_IMPACT",
+	}
+	_, exists = disabledRules[key2]
+	assert.False(t, exists, "Org 2's rule should not be present")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
+// --- ReadClusterRuleToggles tests (CCXDEV-16564) ---
+
 // TestReadClusterRuleTogglesPopulatesMap checks that
 // ReadClusterRuleToggles returns a correctly populated map when the
 // cluster_rule_toggle table contains rows with disabled = 1.

--- a/differ/storage_test.go
+++ b/differ/storage_test.go
@@ -2770,6 +2770,46 @@ func TestReadOrgRuleDisablesAckDoesNotAffectOtherOrgs(t *testing.T) {
 	checkAllExpectations(t, mock)
 }
 
+// TestReadOrgRuleDisablesOnRowIterationError checks that ReadOrgRuleDisables
+// returns an error when the row iterator fails mid-stream (rows.Err()).
+func TestReadOrgRuleDisablesOnRowIterationError(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock := mustCreateMockConnection(t)
+
+	// prepare mocked result for SQL query;
+	// two valid rows, but a row error on the second causes rows.Next()
+	// to return false and rows.Err() to report the failure
+	rows := sqlmock.NewRows([]string{"org_id", "rule_id", "error_key"})
+	rows.AddRow("1", "test_rule", "TEST_ERROR_KEY")
+	rows.AddRow("1", "another_rule", "ANOTHER_KEY")
+	rows.RowError(1, fmt.Errorf("connection reset"))
+
+	// expected query performed by tested function
+	expectedQuery := regexp.QuoteMeta(differ.ReadOrgRuleDisablesQuery)
+
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// prepare connection to mocked database
+	storage := differ.NewFromConnection(connection, 1)
+
+	// call the tested method
+	disabledRules, err := storage.ReadOrgRuleDisables()
+
+	// tested method SHOULD return the iteration error
+	assert.Error(t, err, "an error is expected on row iteration failure")
+	assert.Contains(t, err.Error(), "connection reset")
+
+	// the first row was read successfully, so the map contains it
+	assert.Len(t, disabledRules, 1, "Map should contain the one successfully read row")
+
+	// connection to mocked DB needs to be closed properly
+	checkConnectionClose(t, connection)
+
+	// check if all expectations were met
+	checkAllExpectations(t, mock)
+}
+
 // --- ReadClusterRuleToggles tests (CCXDEV-16564) ---
 
 // TestReadClusterRuleTogglesPopulatesMap checks that

--- a/tests/mocks/Storage.go
+++ b/tests/mocks/Storage.go
@@ -329,6 +329,36 @@ func (_m *Storage) ReadNotificationTypes() ([]types.NotificationType, error) {
 	return r0, r1
 }
 
+// ReadOrgRuleDisables provides a mock function with no fields
+func (_m *Storage) ReadOrgRuleDisables() (types.OrgDisabledRules, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReadOrgRuleDisables")
+	}
+
+	var r0 types.OrgDisabledRules
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (types.OrgDisabledRules, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() types.OrgDisabledRules); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.OrgDisabledRules)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ReadReportForCluster provides a mock function with given fields: orgID, clusterName
 func (_m *Storage) ReadReportForCluster(orgID types.OrgID, clusterName types.ClusterName) (types.ClusterReport, types.Timestamp, error) {
 	ret := _m.Called(orgID, clusterName)

--- a/types/types.go
+++ b/types/types.go
@@ -279,6 +279,20 @@ type ClusterRuleKey struct {
 // is an empty struct because only presence matters (O(1) lookup).
 type ClusterDisabledRules map[ClusterRuleKey]struct{}
 
+// OrgRuleKey is a composite key identifying a specific rule acked across all
+// clusters in an organization. It is used as the map key for org-wide disabled
+// rules loaded from the aggregator DB's rule_disable table. OrgID is a string
+// because the aggregator DB stores it as VARCHAR.
+type OrgRuleKey struct {
+	OrgID    string
+	RuleID   RuleID
+	ErrorKey ErrorKey
+}
+
+// OrgDisabledRules is a set of org-wide disabled (acked) rules. The map value
+// is an empty struct because only presence matters (O(1) lookup).
+type OrgDisabledRules map[OrgRuleKey]struct{}
+
 // NotifiedRecordsPerCluster maps a string representation of ClusterOrgKey to a NotificationRecord
 type NotifiedRecordsPerCluster map[ClusterOrgKey]NotificationRecord
 


### PR DESCRIPTION
# Description

- adds the ability to fetch org-wide acked (disabled) rules from the aggregator DB's `rule_disable` table at startup
- the results are stored in a new `OrgDisabledRules` map on the `Differ` struct, keyed by `(org_id, rule_id, error_key)` 
- when `--ignore-disabled-rules` is set, the aggregator DB fetch is skipped entirely and the map remains empty (not nil).

<changes> Changes

-  **`types/types.go`** — New `OrgRuleKey` struct and `OrgDisabledRules` map type, mirroring the existing `ClusterRuleKey`/`ClusterDisabledRules` pattern
-  **`differ/storage.go`** — `ReadOrgRuleDisables()` method on `DBStorage` with `SELECT org_id, rule_id, error_key FROM rule_disable`; added to the `Storage` interface. Includes `rows.Err()` check after iteration (improvement over the existing pattern)
-  **`differ/differ.go`** — Replaced the TODO in `loadDisabledRules()` with the actual call; initialized `OrgDisabledRules` in `New()`
-  **`tests/mocks/Storage.go`** — Regenerated via `make gen-mocks`
</changes>

Fixes CCXDEV-16565

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)
- Configuration update

## Testing steps
full local setup

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
